### PR TITLE
chore: update dependencies and adapt ACP 0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,33 +19,53 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-client-protocol"
-version = "0.10.4"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10eeef5e80864f9c3c148a3f395c3e35a66d37ec7561c7845b2bffae8e841759"
+checksum = "2af62fb84df2af0f933d8f5fd78b843fa5eb0ec5a48fa1b528c41951d0bbe36c"
 dependencies = [
+ "agent-client-protocol-derive",
  "agent-client-protocol-schema",
  "anyhow",
- "async-broadcast",
- "async-trait",
- "derive_more",
  "futures",
- "log",
+ "futures-concurrency",
+ "jsonrpcmsg",
+ "rmcp",
+ "rustc-hash",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "agent-client-protocol-derive"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce42c2d3c048c12897eef2e577dfff1e3355c632c9f1625cc953b9df48b44631"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "agent-client-protocol-schema"
-version = "0.11.4"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca68e7e55681ce56546c0cecc6bc8f20493d24b44c6d93ec46174f310730bba2"
+checksum = "49bae57dad1c28a362fbdcf7bab0583316a02b45a70792109fced55780a3b63c"
 dependencies = [
  "anyhow",
  "derive_more",
- "schemars",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
+ "serde_with",
  "strum 0.28.0",
+ "tracing",
 ]
 
 [[package]]
@@ -105,22 +125,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
-name = "async-broadcast"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
-dependencies = [
- "event-listener",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
 name = "async-openai"
-version = "0.35.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583553a05a8cbf55bbd67d6a824a206c21030556fdc5f43de387959f888fb6be"
+checksum = "78efd86812da6b76e2be727c7015522dde20495855390496099f062b01d2c868"
 dependencies = [
  "async-openai-macros",
  "backoff",
@@ -131,8 +139,7 @@ dependencies = [
  "futures",
  "getrandom 0.3.4",
  "rand 0.9.4",
- "reqwest 0.12.28",
- "reqwest-eventsource",
+ "reqwest",
  "secrecy",
  "serde",
  "serde_json",
@@ -488,7 +495,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "befbfd072a8e81c02f8c507aefce431fe5e7d051f83d48a23ffc9b9fe5a11799"
 dependencies = [
  "heck",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "proc-macro2",
  "quote",
@@ -501,9 +508,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -589,15 +596,6 @@ dependencies = [
  "rustversion",
  "ryu",
  "static_assertions",
-]
-
-[[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -871,8 +869,18 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -890,21 +898,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.11",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn",
 ]
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "debugid"
@@ -913,6 +945,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
  "uuid",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+ "serde_core",
 ]
 
 [[package]]
@@ -941,7 +983,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "proc-macro2",
  "quote",
  "syn",
@@ -1107,27 +1149,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "event-listener"
-version = "5.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
-dependencies = [
- "concurrent-queue",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
-dependencies = [
- "event-listener",
- "pin-project-lite",
-]
-
-[[package]]
 name = "eventsource-stream"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1252,6 +1273,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1291,21 +1318,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1316,9 +1328,9 @@ dependencies = [
 
 [[package]]
 name = "fraction"
-version = "0.15.3"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f158e3ff0a1b334408dc9fb811cd99b446986f4d8b741bb08f9df1604085ae7"
+checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
 dependencies = [
  "lazy_static",
  "num",
@@ -1373,6 +1385,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-concurrency"
+version = "7.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175cd8cca9e1d45b87f18ffa75088f2099e3c4fe5e2f83e42de112560bea8ea6"
+dependencies = [
+ "fixedbitset 0.5.7",
+ "futures-core",
+ "futures-lite",
+ "pin-project",
+ "smallvec",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1396,6 +1421,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1417,12 +1455,6 @@ name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
-
-[[package]]
-name = "futures-timer"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
@@ -1545,7 +1577,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 dependencies = [
  "fallible-iterator",
- "indexmap",
+ "indexmap 2.14.0",
  "stable_deref_trait",
 ]
 
@@ -1617,7 +1649,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1632,6 +1664,12 @@ checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
 dependencies = [
  "byteorder",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -1727,9 +1765,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
 dependencies = [
  "typenum",
 ]
@@ -1765,25 +1803,8 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-native-certs",
  "tokio",
  "tokio-rustls",
- "tower-service",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
  "tower-service",
 ]
 
@@ -1983,6 +2004,17 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
@@ -2062,7 +2094,7 @@ dependencies = [
  "parking_lot",
  "pin-project",
  "regex",
- "reqwest 0.13.2",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -2079,15 +2111,15 @@ dependencies = [
 
 [[package]]
 name = "iron-providers"
-version = "0.1.3"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc31efc5b8ef6a759dcd80539e0fe0c62899a087924e52f1ff2b72f25ed008a"
+checksum = "570bd20f8e93154f9363767468149ff395d17ceacb3fbac444bec284811ee867"
 dependencies = [
  "async-openai",
  "async-stream",
  "futures",
  "pin-project",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -2223,10 +2255,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonschema"
-version = "0.46.1"
+name = "jsonrpcmsg"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d87ef9a314ee37b69ef9ab130d3159f04287dda52151b064752842065e0db2e"
+checksum = "6d833a15225c779251e13929203518c2ff26e2fe0f322d584b213f4f4dad37bd"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "jsonschema"
+version = "0.46.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50180452e7808015fe083eae3efcf1ec98b89b45dd8cc204f7b4a6b7b81ea675"
 dependencies = [
  "ahash",
  "bytecount",
@@ -2243,7 +2285,7 @@ dependencies = [
  "referencing",
  "regex",
  "regex-syntax",
- "reqwest 0.13.2",
+ "reqwest",
  "rustls",
  "serde",
  "serde_json",
@@ -2259,9 +2301,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
+checksum = "6cc46bac87ef8093eed6f272babb833b6443374399985ac8ed28471ee0918545"
 
 [[package]]
 name = "leb128fmt"
@@ -2296,9 +2338,9 @@ checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
@@ -2476,15 +2518,15 @@ dependencies = [
 
 [[package]]
 name = "monty"
-version = "0.0.16"
-source = "git+https://github.com/pydantic/monty?tag=v0.0.16#142807bbba3636a7525f017cea15b8d4f2bd5ed8"
+version = "0.0.17"
+source = "git+https://github.com/pydantic/monty?tag=v0.0.17#5c7cf2b62be8e4421a4828072d41ebe69328bbf2"
 dependencies = [
  "ahash",
  "bytemuck",
  "chrono",
  "fancy-regex",
  "hashbrown 0.16.1",
- "indexmap",
+ "indexmap 2.14.0",
  "itertools",
  "jiter",
  "libm",
@@ -2501,23 +2543,6 @@ dependencies = [
  "smallvec",
  "speedate",
  "strum 0.27.2",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -2580,6 +2605,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2627,7 +2658,7 @@ checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "crc32fast",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.14.0",
  "memchr",
 ]
 
@@ -2638,48 +2669,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
-name = "openssl"
-version = "0.10.78"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.114"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "ordermap"
@@ -2687,7 +2680,7 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f7476a5b122ff1fce7208e7ee9dccd0a516e835f5b8b19b8f3c98a34cf757c1"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -2726,6 +2719,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pastey"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2737,8 +2736,8 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
- "fixedbitset",
- "indexmap",
+ "fixedbitset 0.4.2",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -2838,6 +2837,12 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -3228,9 +3233,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.46.1"
+version = "0.46.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aee6970bf1974cd719a1f4e8bc5a8051a33740194b7246430441cff79faff66d"
+checksum = "acb0c66c7b78c1da928bee668b5cc638c678642ff587faff6e6222f797be9d4c"
 dependencies = [
  "ahash",
  "fluent-uri",
@@ -3288,54 +3293,6 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-tls",
- "hyper-util",
- "js-sys",
- "log",
- "mime",
- "mime_guess",
- "native-tls",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-native-certs",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-native-tls",
- "tokio-rustls",
- "tokio-util",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-streams 0.4.2",
- "web-sys",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
@@ -3356,6 +3313,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -3364,6 +3322,7 @@ dependencies = [
  "rustls-platform-verifier",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -3374,24 +3333,8 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams 0.5.0",
+ "wasm-streams",
  "web-sys",
-]
-
-[[package]]
-name = "reqwest-eventsource"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632c55746dbb44275691640e7b40c907c16a2dc1a5842aa98aaec90da6ec6bde"
-dependencies = [
- "eventsource-stream",
- "futures-core",
- "futures-timer",
- "mime",
- "nom",
- "pin-project-lite",
- "reqwest 0.12.28",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3406,6 +3349,41 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rmcp"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67d69668de0b0ccd9cc435f700f3b39a7861863cf37a15e1f304ea78688a4826"
+dependencies = [
+ "async-trait",
+ "base64",
+ "chrono",
+ "futures",
+ "pastey",
+ "pin-project-lite",
+ "rmcp-macros",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48fdc01c81097b0aed18633e676e269fefa3a78ec1df56b4fe597c1241b92025"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn",
 ]
 
 [[package]]
@@ -3561,9 +3539,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -3589,9 +3567,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -3626,9 +3604,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3668,10 +3646,23 @@ dependencies = [
 
 [[package]]
 name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
+ "chrono",
  "dyn-clone",
  "ref-cast",
  "schemars_derive",
@@ -3816,12 +3807,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+dependencies = [
+ "base64",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.14.0",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -4160,6 +4182,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4210,16 +4263,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]
@@ -4274,7 +4317,7 @@ version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned",
  "toml_datetime 0.7.5+spec-1.1.0",
@@ -4307,10 +4350,10 @@ version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.1",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -4319,7 +4362,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.1",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -4607,12 +4650,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4757,7 +4794,7 @@ dependencies = [
  "anyhow",
  "heck",
  "im-rc",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "petgraph",
  "serde",
@@ -4806,22 +4843,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.14.0",
  "wasm-encoder 0.244.0",
  "wasmparser 0.244.0",
-]
-
-[[package]]
-name = "wasm-streams"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
-dependencies = [
- "futures-util",
- "js-sys",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
 ]
 
 [[package]]
@@ -4845,7 +4869,7 @@ checksum = "f6d8db401b0528ec316dfbe579e6ab4152d61739cfe076706d2009127970159d"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.14.0",
  "semver",
  "serde",
 ]
@@ -4858,7 +4882,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -4869,7 +4893,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e6fb4c2bee46c5ea4d40f8cdb5c131725cd976718ec56f1c8e82fbde5fa2a80"
 dependencies = [
  "bitflags",
- "indexmap",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -4902,7 +4926,7 @@ dependencies = [
  "fxprof-processed-profile",
  "gimli",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.14.0",
  "ittapi",
  "libc",
  "log",
@@ -4952,7 +4976,7 @@ dependencies = [
  "cranelift-bitset",
  "cranelift-entity",
  "gimli",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "object",
  "postcard",
@@ -5140,7 +5164,7 @@ dependencies = [
  "anyhow",
  "bitflags",
  "heck",
- "indexmap",
+ "indexmap 2.14.0",
  "wit-parser 0.243.0",
 ]
 
@@ -5614,9 +5638,9 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
 ]
@@ -5665,7 +5689,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -5696,7 +5720,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -5715,7 +5739,7 @@ checksum = "df983a8608e513d8997f435bb74207bf0933d0e49ca97aa9d8a6157164b9b7fc"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -5733,7 +5757,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
 ]
 
 [dependencies]
-iron-providers = "0.1.3"
+iron-providers = "0.1.7"
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["compat"] }
 serde = { version = "1", features = ["derive"] }
@@ -29,7 +29,7 @@ pin-project = "1"
 parking_lot = "0.12"
 
 # ACP SDK
-agent-client-protocol = { version = "0.10", features = ["unstable_session_close"] }
+agent-client-protocol = { version = "0.11", features = ["unstable_session_close"] }
 async-trait = "0.1"
 uuid = { version = "1", features = ["v4"] }
 
@@ -67,7 +67,7 @@ grep-regex = "0.1"
 # there, because crates.io rejects manifests containing git dependencies.
 #
 # Bump `rev` deliberately after verifying against the iron-core test suite.
-monty = { git = "https://github.com/pydantic/monty", tag = "v0.0.16", optional = true }
+monty = { git = "https://github.com/pydantic/monty", tag = "v0.0.17", optional = true }
 num-bigint = { version = "0.4", optional = true }
 num-traits = { version = "0.2", optional = true }
 

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -2,6 +2,7 @@ use crate::durable::{DurableSession, SessionId};
 use crate::prompt_lifecycle::AcpPromptSink;
 use crate::prompt_runner::PromptRunner;
 use crate::runtime::{ConnectionId, IronRuntime};
+use agent_client_protocol::schema as acp;
 use std::cell::RefCell;
 use std::rc::Rc;
 use tracing::{debug, info};
@@ -9,18 +10,16 @@ use tracing::{debug, info};
 pub trait ClientChannel {
     fn send_notification(
         &self,
-        notification: agent_client_protocol::SessionNotification,
+        notification: acp::SessionNotification,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = agent_client_protocol::Result<()>>>>;
 
     fn request_permission(
         &self,
-        request: agent_client_protocol::RequestPermissionRequest,
+        request: acp::RequestPermissionRequest,
     ) -> std::pin::Pin<
         Box<
             dyn std::future::Future<
-                Output = agent_client_protocol::Result<
-                    agent_client_protocol::RequestPermissionResponse,
-                >,
+                Output = agent_client_protocol::Result<acp::RequestPermissionResponse>,
             >,
         >,
     >;
@@ -42,7 +41,7 @@ struct NopClientChannel;
 impl ClientChannel for NopClientChannel {
     fn send_notification(
         &self,
-        _notification: agent_client_protocol::SessionNotification,
+        _notification: acp::SessionNotification,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = agent_client_protocol::Result<()>>>>
     {
         Box::pin(async { Ok(()) })
@@ -50,24 +49,20 @@ impl ClientChannel for NopClientChannel {
 
     fn request_permission(
         &self,
-        request: agent_client_protocol::RequestPermissionRequest,
+        request: acp::RequestPermissionRequest,
     ) -> std::pin::Pin<
         Box<
             dyn std::future::Future<
-                Output = agent_client_protocol::Result<
-                    agent_client_protocol::RequestPermissionResponse,
-                >,
+                Output = agent_client_protocol::Result<acp::RequestPermissionResponse>,
             >,
         >,
     > {
         let _tool_call_id = request.tool_call.tool_call_id.to_string();
         Box::pin(async move {
-            Ok(agent_client_protocol::RequestPermissionResponse::new(
-                agent_client_protocol::RequestPermissionOutcome::Selected(
-                    agent_client_protocol::SelectedPermissionOutcome::new(
-                        agent_client_protocol::PermissionOptionId::new("allow_once"),
-                    ),
-                ),
+            Ok(acp::RequestPermissionResponse::new(
+                acp::RequestPermissionOutcome::Selected(acp::SelectedPermissionOutcome::new(
+                    acp::PermissionOptionId::new("allow_once"),
+                )),
             ))
         })
     }
@@ -113,7 +108,7 @@ impl IronConnection {
             .unwrap_or_else(|| Rc::new(NopClientChannel))
     }
 
-    fn parse_session_id(&self, id: &agent_client_protocol::SessionId) -> Option<SessionId> {
+    fn parse_session_id(&self, id: &acp::SessionId) -> Option<SessionId> {
         let s = id.to_string();
         s.strip_prefix("session-")
             .and_then(|n| n.parse::<u64>().ok())
@@ -122,7 +117,7 @@ impl IronConnection {
 
     fn resolve_owned_session(
         &self,
-        acp_session_id: &agent_client_protocol::SessionId,
+        acp_session_id: &acp::SessionId,
     ) -> Result<
         (
             SessionId,
@@ -157,32 +152,28 @@ impl IronConnection {
     }
 }
 
-#[async_trait::async_trait(?Send)]
-impl agent_client_protocol::Agent for IronConnection {
-    async fn initialize(
+impl IronConnection {
+    pub async fn handle_initialize(
         &self,
-        _args: agent_client_protocol::InitializeRequest,
-    ) -> agent_client_protocol::Result<agent_client_protocol::InitializeResponse> {
+        _args: acp::InitializeRequest,
+    ) -> agent_client_protocol::Result<acp::InitializeResponse> {
         info!("ACP initialize from client");
 
-        let caps = agent_client_protocol::AgentCapabilities::default();
-        Ok(agent_client_protocol::InitializeResponse::new(
-            agent_client_protocol::ProtocolVersion::V1,
-        )
-        .agent_capabilities(caps))
+        let caps = acp::AgentCapabilities::default();
+        Ok(acp::InitializeResponse::new(acp::ProtocolVersion::V1).agent_capabilities(caps))
     }
 
-    async fn authenticate(
+    pub async fn handle_authenticate(
         &self,
-        _args: agent_client_protocol::AuthenticateRequest,
-    ) -> agent_client_protocol::Result<agent_client_protocol::AuthenticateResponse> {
-        Ok(agent_client_protocol::AuthenticateResponse::new())
+        _args: acp::AuthenticateRequest,
+    ) -> agent_client_protocol::Result<acp::AuthenticateResponse> {
+        Ok(acp::AuthenticateResponse::new())
     }
 
-    async fn new_session(
+    pub async fn handle_new_session(
         &self,
-        _args: agent_client_protocol::NewSessionRequest,
-    ) -> agent_client_protocol::Result<agent_client_protocol::NewSessionResponse> {
+        _args: acp::NewSessionRequest,
+    ) -> agent_client_protocol::Result<acp::NewSessionResponse> {
         info!(connection_id = self.id.0, "ACP new_session");
 
         let (session_id, _session) = self
@@ -190,15 +181,15 @@ impl agent_client_protocol::Agent for IronConnection {
             .create_session(self.id)
             .map_err(|e| agent_client_protocol::Error::into_internal_error(&e))?;
 
-        Ok(agent_client_protocol::NewSessionResponse::new(
-            agent_client_protocol::SessionId::new(session_id.to_string()),
-        ))
+        Ok(acp::NewSessionResponse::new(acp::SessionId::new(
+            session_id.to_string(),
+        )))
     }
 
-    async fn prompt(
+    pub async fn handle_prompt(
         &self,
-        args: agent_client_protocol::PromptRequest,
-    ) -> agent_client_protocol::Result<agent_client_protocol::PromptResponse> {
+        args: acp::PromptRequest,
+    ) -> agent_client_protocol::Result<acp::PromptResponse> {
         debug!(session_id = %args.session_id, "ACP prompt received");
 
         let (iron_session_id, durable) = self.resolve_owned_session(&args.session_id)?;
@@ -241,12 +232,12 @@ impl agent_client_protocol::Agent for IronConnection {
             runner.maybe_compact_post_turn(&durable, &config).await;
         }
 
-        Ok(agent_client_protocol::PromptResponse::new(stop_reason))
+        Ok(acp::PromptResponse::new(stop_reason))
     }
 
-    async fn cancel(
+    pub async fn handle_cancel(
         &self,
-        args: agent_client_protocol::CancelNotification,
+        args: acp::CancelNotification,
     ) -> agent_client_protocol::Result<()> {
         info!(session_id = %args.session_id, "ACP cancel received");
 
@@ -258,25 +249,25 @@ impl agent_client_protocol::Agent for IronConnection {
         Ok(())
     }
 
-    async fn close_session(
+    pub async fn handle_close_session(
         &self,
-        args: agent_client_protocol::CloseSessionRequest,
-    ) -> agent_client_protocol::Result<agent_client_protocol::CloseSessionResponse> {
+        args: acp::CloseSessionRequest,
+    ) -> agent_client_protocol::Result<acp::CloseSessionResponse> {
         info!(session_id = %args.session_id, "ACP close_session");
 
         let (iron_session_id, _) = self.resolve_owned_session(&args.session_id)?;
         self.runtime.finish_prompt(iron_session_id);
         self.runtime.close_session(iron_session_id);
 
-        Ok(agent_client_protocol::CloseSessionResponse::new())
+        Ok(acp::CloseSessionResponse::new())
     }
 }
 
 pub(crate) fn notification(
-    session_id: &agent_client_protocol::SessionId,
-    update: agent_client_protocol::SessionUpdate,
-) -> agent_client_protocol::SessionNotification {
-    agent_client_protocol::SessionNotification::new(session_id.clone(), update)
+    session_id: &acp::SessionId,
+    update: acp::SessionUpdate,
+) -> acp::SessionNotification {
+    acp::SessionNotification::new(session_id.clone(), update)
 }
 
 impl Drop for IronConnection {

--- a/src/durable.rs
+++ b/src/durable.rs
@@ -1,3 +1,4 @@
+use agent_client_protocol::schema as acp;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::{BTreeSet, HashMap};
@@ -52,16 +53,16 @@ impl ContentBlock {
         }
     }
 
-    pub fn from_acp_content(block: &agent_client_protocol::ContentBlock) -> Self {
+    pub fn from_acp_content(block: &acp::ContentBlock) -> Self {
         match block {
-            agent_client_protocol::ContentBlock::Text(tc) => ContentBlock::Text {
+            acp::ContentBlock::Text(tc) => ContentBlock::Text {
                 text: tc.text.clone(),
             },
-            agent_client_protocol::ContentBlock::Image(ic) => ContentBlock::Image {
+            acp::ContentBlock::Image(ic) => ContentBlock::Image {
                 data: ic.data.clone(),
                 mime_type: ic.mime_type.clone(),
             },
-            agent_client_protocol::ContentBlock::ResourceLink(rl) => ContentBlock::Resource {
+            acp::ContentBlock::ResourceLink(rl) => ContentBlock::Resource {
                 uri: rl.uri.clone(),
                 name: Some(rl.name.clone()),
             },

--- a/src/facade.rs
+++ b/src/facade.rs
@@ -13,7 +13,7 @@ use crate::{
     runtime::{ConnectionId, IronRuntime},
     tool::Tool,
 };
-use agent_client_protocol::Agent;
+use agent_client_protocol::schema as acp;
 use futures::Stream;
 use iron_providers::Provider;
 use parking_lot::Mutex;
@@ -41,12 +41,12 @@ pub enum PromptOutcome {
     MaxTurnRequests,
 }
 
-impl From<agent_client_protocol::StopReason> for PromptOutcome {
-    fn from(reason: agent_client_protocol::StopReason) -> Self {
+impl From<acp::StopReason> for PromptOutcome {
+    fn from(reason: acp::StopReason) -> Self {
         match reason {
-            agent_client_protocol::StopReason::EndTurn => PromptOutcome::EndTurn,
-            agent_client_protocol::StopReason::Cancelled => PromptOutcome::Cancelled,
-            agent_client_protocol::StopReason::MaxTurnRequests => PromptOutcome::MaxTurnRequests,
+            acp::StopReason::EndTurn => PromptOutcome::EndTurn,
+            acp::StopReason::Cancelled => PromptOutcome::Cancelled,
+            acp::StopReason::MaxTurnRequests => PromptOutcome::MaxTurnRequests,
             _ => PromptOutcome::EndTurn,
         }
     }
@@ -951,7 +951,7 @@ impl FacadeClientChannel {
 impl ClientChannel for FacadeClientChannel {
     fn send_notification(
         &self,
-        notification: agent_client_protocol::SessionNotification,
+        notification: acp::SessionNotification,
     ) -> Pin<Box<dyn std::future::Future<Output = agent_client_protocol::Result<()>>>> {
         let session_key = notification.session_id.to_string();
         let streams = self.active_streams.borrow();
@@ -1004,13 +1004,11 @@ impl ClientChannel for FacadeClientChannel {
 
     fn request_permission(
         &self,
-        request: agent_client_protocol::RequestPermissionRequest,
+        request: acp::RequestPermissionRequest,
     ) -> Pin<
         Box<
             dyn std::future::Future<
-                Output = agent_client_protocol::Result<
-                    agent_client_protocol::RequestPermissionResponse,
-                >,
+                Output = agent_client_protocol::Result<acp::RequestPermissionResponse>,
             >,
         >,
     > {
@@ -1042,12 +1040,12 @@ impl ClientChannel for FacadeClientChannel {
                     arguments,
                 });
                 match rx.await {
-                    Ok(verdict) => Ok(agent_client_protocol::RequestPermissionResponse::new(
-                        verdict_to_outcome(verdict),
-                    )),
-                    Err(_) => Ok(agent_client_protocol::RequestPermissionResponse::new(
-                        verdict_to_outcome(PermissionVerdict::Deny),
-                    )),
+                    Ok(verdict) => Ok(acp::RequestPermissionResponse::new(verdict_to_outcome(
+                        verdict,
+                    ))),
+                    Err(_) => Ok(acp::RequestPermissionResponse::new(verdict_to_outcome(
+                        PermissionVerdict::Deny,
+                    ))),
                 }
             });
         }
@@ -1064,9 +1062,9 @@ impl ClientChannel for FacadeClientChannel {
             drop(async_handler);
             return Box::pin(async move {
                 let verdict = future.await;
-                Ok(agent_client_protocol::RequestPermissionResponse::new(
-                    verdict_to_outcome(verdict),
-                ))
+                Ok(acp::RequestPermissionResponse::new(verdict_to_outcome(
+                    verdict,
+                )))
             });
         }
         drop(async_handler);
@@ -1079,43 +1077,41 @@ impl ClientChannel for FacadeClientChannel {
         drop(handler);
 
         Box::pin(async move {
-            Ok(agent_client_protocol::RequestPermissionResponse::new(
-                verdict_to_outcome(verdict),
-            ))
+            Ok(acp::RequestPermissionResponse::new(verdict_to_outcome(
+                verdict,
+            )))
         })
     }
 }
 
-fn verdict_to_outcome(
-    verdict: PermissionVerdict,
-) -> agent_client_protocol::RequestPermissionOutcome {
+fn verdict_to_outcome(verdict: PermissionVerdict) -> acp::RequestPermissionOutcome {
     match verdict {
-        PermissionVerdict::AllowOnce => agent_client_protocol::RequestPermissionOutcome::Selected(
-            agent_client_protocol::SelectedPermissionOutcome::new(
-                agent_client_protocol::PermissionOptionId::new(PERMISSION_ALLOW_ONCE),
-            ),
-        ),
-        PermissionVerdict::Deny => agent_client_protocol::RequestPermissionOutcome::Selected(
-            agent_client_protocol::SelectedPermissionOutcome::new(
-                agent_client_protocol::PermissionOptionId::new(PERMISSION_REJECT_ONCE),
-            ),
-        ),
-        PermissionVerdict::Cancel => agent_client_protocol::RequestPermissionOutcome::Cancelled,
+        PermissionVerdict::AllowOnce => {
+            acp::RequestPermissionOutcome::Selected(acp::SelectedPermissionOutcome::new(
+                acp::PermissionOptionId::new(PERMISSION_ALLOW_ONCE),
+            ))
+        }
+        PermissionVerdict::Deny => {
+            acp::RequestPermissionOutcome::Selected(acp::SelectedPermissionOutcome::new(
+                acp::PermissionOptionId::new(PERMISSION_REJECT_ONCE),
+            ))
+        }
+        PermissionVerdict::Cancel => acp::RequestPermissionOutcome::Cancelled,
     }
 }
 
 fn convert_notification_to_prompt_event_with_index(
-    notification: &agent_client_protocol::SessionNotification,
+    notification: &acp::SessionNotification,
     tool_name_index: &Rc<RefCell<HashMap<String, String>>>,
 ) -> Option<PromptEvent> {
     match &notification.update {
-        agent_client_protocol::SessionUpdate::AgentMessageChunk(chunk) => match &chunk.content {
-            agent_client_protocol::ContentBlock::Text(tc) => Some(PromptEvent::Output {
+        acp::SessionUpdate::AgentMessageChunk(chunk) => match &chunk.content {
+            acp::ContentBlock::Text(tc) => Some(PromptEvent::Output {
                 text: tc.text.clone(),
             }),
             _ => None,
         },
-        agent_client_protocol::SessionUpdate::ToolCall(tc) => {
+        acp::SessionUpdate::ToolCall(tc) => {
             let call_id = tc.tool_call_id.to_string();
             let tool_name = tc.title.clone();
             let arguments = tc.raw_input.clone().unwrap_or_default();
@@ -1128,7 +1124,7 @@ fn convert_notification_to_prompt_event_with_index(
                 arguments,
             })
         }
-        agent_client_protocol::SessionUpdate::ToolCallUpdate(update) => {
+        acp::SessionUpdate::ToolCallUpdate(update) => {
             let call_id = update.tool_call_id.to_string();
             let tool_name = update
                 .fields
@@ -1143,10 +1139,8 @@ fn convert_notification_to_prompt_event_with_index(
                 .map(str::to_string);
             let view = result.as_ref().and_then(plugin_view).cloned();
             let status = match update.fields.status {
-                Some(agent_client_protocol::ToolCallStatus::Completed) => {
-                    ToolResultStatus::Completed
-                }
-                Some(agent_client_protocol::ToolCallStatus::Failed) => {
+                Some(acp::ToolCallStatus::Completed) => ToolResultStatus::Completed,
+                Some(acp::ToolCallStatus::Failed) => {
                     let is_denied = result.as_ref().is_some_and(|r| {
                         r.get("error")
                             .and_then(|v| v.as_str())
@@ -1158,10 +1152,10 @@ fn convert_notification_to_prompt_event_with_index(
                         ToolResultStatus::Failed
                     }
                 }
-                Some(agent_client_protocol::ToolCallStatus::Pending) => {
+                Some(acp::ToolCallStatus::Pending) => {
                     return None;
                 }
-                Some(agent_client_protocol::ToolCallStatus::InProgress) => {
+                Some(acp::ToolCallStatus::InProgress) => {
                     return None;
                 }
                 _ => return None,
@@ -1268,14 +1262,12 @@ impl AgentSession {
     /// Returns the terminal [`PromptOutcome`]. For incremental event access,
     /// use [`prompt_stream`](AgentSession::prompt_stream).
     pub async fn prompt(&self, text: &str) -> PromptOutcome {
-        let acp_session_id = agent_client_protocol::SessionId::new(self.id.to_string());
-        let request = agent_client_protocol::PromptRequest::new(
+        let acp_session_id = acp::SessionId::new(self.id.to_string());
+        let request = acp::PromptRequest::new(
             acp_session_id,
-            vec![agent_client_protocol::ContentBlock::Text(
-                agent_client_protocol::TextContent::new(text),
-            )],
+            vec![acp::ContentBlock::Text(acp::TextContent::new(text))],
         );
-        match self.connection.prompt(request).await {
+        match self.connection.handle_prompt(request).await {
             Ok(response) => response.stop_reason.into(),
             Err(_) => PromptOutcome::EndTurn,
         }
@@ -1283,10 +1275,10 @@ impl AgentSession {
 
     /// Send a multimodal prompt and await completion.
     pub async fn prompt_with_blocks(&self, blocks: &[ContentBlock]) -> PromptOutcome {
-        let acp_session_id = agent_client_protocol::SessionId::new(self.id.to_string());
+        let acp_session_id = acp::SessionId::new(self.id.to_string());
         let acp_blocks: Vec<_> = blocks.iter().map(to_acp_content_block).collect();
-        let request = agent_client_protocol::PromptRequest::new(acp_session_id, acp_blocks);
-        match self.connection.prompt(request).await {
+        let request = acp::PromptRequest::new(acp_session_id, acp_blocks);
+        match self.connection.handle_prompt(request).await {
             Ok(response) => response.stop_reason.into(),
             Err(_) => PromptOutcome::EndTurn,
         }
@@ -1317,9 +1309,7 @@ impl AgentSession {
     /// }
     /// ```
     pub fn prompt_stream(&self, text: &str) -> (PromptHandle, PromptEvents) {
-        let acp_blocks = vec![agent_client_protocol::ContentBlock::Text(
-            agent_client_protocol::TextContent::new(text),
-        )];
+        let acp_blocks = vec![acp::ContentBlock::Text(acp::TextContent::new(text))];
         self.prompt_stream_with_acp_blocks(acp_blocks)
     }
 
@@ -1377,7 +1367,7 @@ impl AgentSession {
     /// and completion handling are unified in one place.
     fn prompt_stream_with_acp_blocks(
         &self,
-        acp_blocks: Vec<agent_client_protocol::ContentBlock>,
+        acp_blocks: Vec<acp::ContentBlock>,
     ) -> (PromptHandle, PromptEvents) {
         let (event_tx, event_rx) = tokio::sync::mpsc::unbounded_channel();
         let approval_resolvers: Rc<
@@ -1402,15 +1392,15 @@ impl AgentSession {
         };
         let events = PromptEvents { rx: event_rx };
 
-        let acp_session_id = agent_client_protocol::SessionId::new(self.id.to_string());
-        let request = agent_client_protocol::PromptRequest::new(acp_session_id, acp_blocks);
+        let acp_session_id = acp::SessionId::new(self.id.to_string());
+        let request = acp::PromptRequest::new(acp_session_id, acp_blocks);
 
         let connection = self.connection.clone();
         let active_streams = self.active_streams.clone();
         let status_cell = status.clone();
 
         tokio::task::spawn_local(async move {
-            let outcome = match connection.prompt(request).await {
+            let outcome = match connection.handle_prompt(request).await {
                 Ok(response) => response.stop_reason.into(),
                 Err(_) => PromptOutcome::EndTurn,
             };
@@ -1433,9 +1423,9 @@ impl AgentSession {
 
     /// Cancel any active prompt on this session.
     pub async fn cancel(&self) {
-        let acp_session_id = agent_client_protocol::SessionId::new(self.id.to_string());
-        let notification = agent_client_protocol::CancelNotification::new(acp_session_id);
-        let _ = self.connection.cancel(notification).await;
+        let acp_session_id = acp::SessionId::new(self.id.to_string());
+        let notification = acp::CancelNotification::new(acp_session_id);
+        let _ = self.connection.handle_cancel(notification).await;
     }
 
     /// Get the conversation timeline.
@@ -1778,16 +1768,14 @@ impl AgentSession {
     }
 }
 
-fn to_acp_content_block(block: &ContentBlock) -> agent_client_protocol::ContentBlock {
+fn to_acp_content_block(block: &ContentBlock) -> acp::ContentBlock {
     match block {
-        ContentBlock::Text { text } => {
-            agent_client_protocol::ContentBlock::Text(agent_client_protocol::TextContent::new(text))
+        ContentBlock::Text { text } => acp::ContentBlock::Text(acp::TextContent::new(text)),
+        ContentBlock::Image { data, mime_type } => {
+            acp::ContentBlock::Image(acp::ImageContent::new(data, mime_type))
         }
-        ContentBlock::Image { data, mime_type } => agent_client_protocol::ContentBlock::Image(
-            agent_client_protocol::ImageContent::new(data, mime_type),
-        ),
-        ContentBlock::Resource { uri, name } => agent_client_protocol::ContentBlock::ResourceLink(
-            agent_client_protocol::ResourceLink::new(name.as_deref().unwrap_or("resource"), uri),
+        ContentBlock::Resource { uri, name } => acp::ContentBlock::ResourceLink(
+            acp::ResourceLink::new(name.as_deref().unwrap_or("resource"), uri),
         ),
     }
 }

--- a/src/prompt_lifecycle.rs
+++ b/src/prompt_lifecycle.rs
@@ -1,4 +1,5 @@
 use crate::connection::{notification, SharedClientChannel};
+use agent_client_protocol::schema as acp;
 use std::pin::Pin;
 
 pub enum PromptLifecycleEvent {
@@ -55,15 +56,12 @@ pub trait PromptSink {
 }
 
 pub(crate) struct AcpPromptSink {
-    session_id: agent_client_protocol::SessionId,
+    session_id: acp::SessionId,
     client: SharedClientChannel,
 }
 
 impl AcpPromptSink {
-    pub(crate) fn new(
-        session_id: agent_client_protocol::SessionId,
-        client: SharedClientChannel,
-    ) -> Self {
+    pub(crate) fn new(session_id: acp::SessionId, client: SharedClientChannel) -> Self {
         Self { session_id, client }
     }
 }
@@ -74,13 +72,9 @@ impl PromptSink for AcpPromptSink {
             PromptLifecycleEvent::Output { text } => {
                 let notif = notification(
                     &self.session_id,
-                    agent_client_protocol::SessionUpdate::AgentMessageChunk(
-                        agent_client_protocol::ContentChunk::new(
-                            agent_client_protocol::ContentBlock::Text(
-                                agent_client_protocol::TextContent::new(&text),
-                            ),
-                        ),
-                    ),
+                    acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk::new(
+                        acp::ContentBlock::Text(acp::TextContent::new(&text)),
+                    )),
                 );
                 let client = self.client.clone();
                 Box::pin(async move {
@@ -94,13 +88,10 @@ impl PromptSink for AcpPromptSink {
             } => {
                 let notif = notification(
                     &self.session_id,
-                    agent_client_protocol::SessionUpdate::ToolCall(
-                        agent_client_protocol::ToolCall::new(
-                            agent_client_protocol::ToolCallId::new(call_id),
-                            &tool_name,
-                        )
-                        .raw_input(arguments)
-                        .status(agent_client_protocol::ToolCallStatus::Pending),
+                    acp::SessionUpdate::ToolCall(
+                        acp::ToolCall::new(acp::ToolCallId::new(call_id), &tool_name)
+                            .raw_input(arguments)
+                            .status(acp::ToolCallStatus::Pending),
                     ),
                 );
                 let client = self.client.clone();
@@ -115,14 +106,11 @@ impl PromptSink for AcpPromptSink {
                 output,
             } => {
                 let acp_status = match status {
-                    ToolUpdateStatus::InProgress => {
-                        agent_client_protocol::ToolCallStatus::InProgress
-                    }
-                    ToolUpdateStatus::Completed => agent_client_protocol::ToolCallStatus::Completed,
-                    ToolUpdateStatus::Failed => agent_client_protocol::ToolCallStatus::Failed,
+                    ToolUpdateStatus::InProgress => acp::ToolCallStatus::InProgress,
+                    ToolUpdateStatus::Completed => acp::ToolCallStatus::Completed,
+                    ToolUpdateStatus::Failed => acp::ToolCallStatus::Failed,
                 };
-                let mut fields =
-                    agent_client_protocol::ToolCallUpdateFields::new().status(acp_status);
+                let mut fields = acp::ToolCallUpdateFields::new().status(acp_status);
                 if !tool_name.is_empty() {
                     fields = fields.title(&tool_name);
                 }
@@ -131,12 +119,10 @@ impl PromptSink for AcpPromptSink {
                 }
                 let notif = notification(
                     &self.session_id,
-                    agent_client_protocol::SessionUpdate::ToolCallUpdate(
-                        agent_client_protocol::ToolCallUpdate::new(
-                            agent_client_protocol::ToolCallId::new(call_id),
-                            fields,
-                        ),
-                    ),
+                    acp::SessionUpdate::ToolCallUpdate(acp::ToolCallUpdate::new(
+                        acp::ToolCallId::new(call_id),
+                        fields,
+                    )),
                 );
                 let client = self.client.clone();
                 Box::pin(async move {
@@ -170,27 +156,27 @@ impl PromptSink for AcpPromptSink {
         &self,
         request: ApprovalRequest,
     ) -> Pin<Box<dyn std::future::Future<Output = ApprovalVerdict>>> {
-        let tool_call_update = agent_client_protocol::ToolCallUpdate::new(
-            agent_client_protocol::ToolCallId::new(request.call_id.clone()),
-            agent_client_protocol::ToolCallUpdateFields::new()
+        let tool_call_update = acp::ToolCallUpdate::new(
+            acp::ToolCallId::new(request.call_id.clone()),
+            acp::ToolCallUpdateFields::new()
                 .title(&request.tool_name)
                 .raw_input(request.arguments)
-                .status(agent_client_protocol::ToolCallStatus::InProgress),
+                .status(acp::ToolCallStatus::InProgress),
         );
 
-        let perm_request = agent_client_protocol::RequestPermissionRequest::new(
+        let perm_request = acp::RequestPermissionRequest::new(
             self.session_id.clone(),
             tool_call_update,
             vec![
-                agent_client_protocol::PermissionOption::new(
-                    agent_client_protocol::PermissionOptionId::new("allow_once"),
+                acp::PermissionOption::new(
+                    acp::PermissionOptionId::new("allow_once"),
                     "Allow once",
-                    agent_client_protocol::PermissionOptionKind::AllowOnce,
+                    acp::PermissionOptionKind::AllowOnce,
                 ),
-                agent_client_protocol::PermissionOption::new(
-                    agent_client_protocol::PermissionOptionId::new("reject_once"),
+                acp::PermissionOption::new(
+                    acp::PermissionOptionId::new("reject_once"),
                     "Deny",
-                    agent_client_protocol::PermissionOptionKind::RejectOnce,
+                    acp::PermissionOptionKind::RejectOnce,
                 ),
             ],
         );
@@ -199,10 +185,8 @@ impl PromptSink for AcpPromptSink {
         Box::pin(async move {
             match client.request_permission(perm_request).await {
                 Ok(response) => match response.outcome {
-                    agent_client_protocol::RequestPermissionOutcome::Cancelled => {
-                        ApprovalVerdict::Cancelled
-                    }
-                    agent_client_protocol::RequestPermissionOutcome::Selected(sel) => {
+                    acp::RequestPermissionOutcome::Cancelled => ApprovalVerdict::Cancelled,
+                    acp::RequestPermissionOutcome::Selected(sel) => {
                         let option_id = sel.option_id.to_string();
                         if option_id.contains("allow") {
                             ApprovalVerdict::AllowOnce

--- a/src/prompt_runner.rs
+++ b/src/prompt_runner.rs
@@ -8,6 +8,7 @@ use crate::prompt_lifecycle::{
     ApprovalRequest, ApprovalVerdict, PromptLifecycleEvent, PromptSink, ToolUpdateStatus,
 };
 use crate::runtime::IronRuntime;
+use agent_client_protocol::schema as acp;
 use futures::StreamExt;
 use iron_providers::ProviderEvent;
 use parking_lot::Mutex;
@@ -62,7 +63,7 @@ impl PromptRunner {
         sink: &dyn PromptSink,
         config: &Config,
         max_iterations: u32,
-    ) -> agent_client_protocol::StopReason {
+    ) -> acp::StopReason {
         let mut iteration: u32 = 0;
 
         loop {
@@ -70,13 +71,13 @@ impl PromptRunner {
                 let turn = ephemeral.lock();
                 if turn.is_cancel_requested() {
                     tie_off_cancelled(durable);
-                    return agent_client_protocol::StopReason::Cancelled;
+                    return acp::StopReason::Cancelled;
                 }
             }
 
             iteration += 1;
             if iteration > max_iterations {
-                return agent_client_protocol::StopReason::MaxTurnRequests;
+                return acp::StopReason::MaxTurnRequests;
             }
 
             trace!(iteration, "Starting inference iteration");
@@ -138,7 +139,7 @@ impl PromptRunner {
                         let mut session = durable.lock();
                         session.add_agent_text(format!("[Request error: {}]", e));
                     }
-                    return agent_client_protocol::StopReason::EndTurn;
+                    return acp::StopReason::EndTurn;
                 }
             };
 
@@ -150,7 +151,7 @@ impl PromptRunner {
                         let mut session = durable.lock();
                         session.add_agent_text(format!("[Provider error: {}]", e));
                     }
-                    return agent_client_protocol::StopReason::EndTurn;
+                    return acp::StopReason::EndTurn;
                 }
             };
 
@@ -160,7 +161,7 @@ impl PromptRunner {
             };
 
             if step.tool_calls.is_empty() {
-                return agent_client_protocol::StopReason::EndTurn;
+                return acp::StopReason::EndTurn;
             }
 
             let cancel_check = || {
@@ -170,7 +171,7 @@ impl PromptRunner {
 
             if cancel_check() {
                 tie_off_cancelled(durable);
-                return agent_client_protocol::StopReason::Cancelled;
+                return acp::StopReason::Cancelled;
             }
 
             let needs_permission = {
@@ -206,7 +207,7 @@ impl PromptRunner {
                 {
                     Ok(calls) => calls,
                     Err(reason) => {
-                        if matches!(reason, agent_client_protocol::StopReason::Cancelled) {
+                        if matches!(reason, acp::StopReason::Cancelled) {
                             tie_off_cancelled(durable);
                         }
                         return reason;
@@ -244,7 +245,7 @@ impl PromptRunner {
             'static,
             iron_providers::ProviderResult<ProviderEvent>,
         >,
-    ) -> Result<ProviderStep, agent_client_protocol::StopReason> {
+    ) -> Result<ProviderStep, acp::StopReason> {
         let mut tool_calls = Vec::new();
         let mut assistant_output = String::new();
 
@@ -256,7 +257,7 @@ impl PromptRunner {
                         let mut session = durable.lock();
                         session.add_agent_text(&assistant_output);
                     }
-                    return Err(agent_client_protocol::StopReason::EndTurn);
+                    return Err(acp::StopReason::EndTurn);
                 }
             };
 
@@ -292,7 +293,7 @@ impl PromptRunner {
                         let mut session = durable.lock();
                         session.add_agent_text(&assistant_output);
                     }
-                    return Err(agent_client_protocol::StopReason::EndTurn);
+                    return Err(acp::StopReason::EndTurn);
                 }
                 ProviderEvent::Complete => {}
                 ProviderEvent::Error { source: _ } => {
@@ -300,7 +301,7 @@ impl PromptRunner {
                         let mut session = durable.lock();
                         session.add_agent_text(&assistant_output);
                     }
-                    return Err(agent_client_protocol::StopReason::EndTurn);
+                    return Err(acp::StopReason::EndTurn);
                 }
             }
         }
@@ -321,7 +322,7 @@ impl PromptRunner {
         tool_calls: &[iron_providers::ToolCall],
         _config: &Config,
         tool_catalog: Option<Arc<SessionToolCatalog>>,
-    ) -> Result<Vec<iron_providers::ToolCall>, agent_client_protocol::StopReason> {
+    ) -> Result<Vec<iron_providers::ToolCall>, acp::StopReason> {
         let tool_catalog = match tool_catalog {
             Some(catalog) => catalog,
             None => {
@@ -398,7 +399,7 @@ impl PromptRunner {
                         })
                         .await;
                     }
-                    return Err(agent_client_protocol::StopReason::Cancelled);
+                    return Err(acp::StopReason::Cancelled);
                 }
                 ApprovalVerdict::AllowOnce => {
                     approved.push(call.clone());

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -2,17 +2,10 @@
 
 use crate::connection::{ClientChannel, IronConnection};
 use agent_client_protocol as acp;
-use agent_client_protocol::Client;
-use futures::{
-    channel::mpsc::{self, UnboundedReceiver, UnboundedSender},
-    future::LocalBoxFuture,
-    join, AsyncRead, AsyncWrite, StreamExt,
-};
-use std::io::{self, Error, ErrorKind};
+use agent_client_protocol::schema as acp_schema;
+use std::future::Future;
 use std::pin::Pin;
 use std::rc::Rc;
-use std::task::{Context, Poll};
-use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
 /// Transport families supported by `iron-core`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -87,125 +80,124 @@ impl TransportMetadata {
 
 #[allow(dead_code)]
 const TRANSPORT_CONSISTENCY_NOTE: &str = "\
-All transports route through the same ACP RPC layer (AgentSideConnection / \
-ClientSideConnection), which enforces identical session ownership, durable \
-timeline, permission flow, and cancellation semantics. The transport only \
-affects how bytes move between the agent and client sides — it does not \
-change runtime/session ownership, durable history behavior, permission \
-mediation, or cancellation outcomes.";
+All transports route through the same ACP RPC layer, which enforces identical \
+session ownership, durable timeline, permission flow, and cancellation \
+semantics. The transport only affects how bytes move between the agent and \
+client sides - it does not change runtime/session ownership, durable history \
+behavior, permission mediation, or cancellation outcomes.";
 
-struct PipeWrite {
-    tx: UnboundedSender<Vec<u8>>,
+pub trait InProcessClientHandler: 'static {
+    fn session_notification(
+        &self,
+        notification: acp_schema::SessionNotification,
+    ) -> Pin<Box<dyn Future<Output = agent_client_protocol::Result<()>>>>;
+
+    fn request_permission(
+        &self,
+        request: acp_schema::RequestPermissionRequest,
+    ) -> Pin<
+        Box<
+            dyn Future<
+                Output = agent_client_protocol::Result<acp_schema::RequestPermissionResponse>,
+            >,
+        >,
+    >;
 }
 
-struct PipeRead {
-    rx: UnboundedReceiver<Vec<u8>>,
-    buffer: Vec<u8>,
+struct LocalClientChannel<H> {
+    handler: Rc<H>,
 }
 
-fn create_pipe() -> (PipeWrite, PipeRead) {
-    let (tx, rx) = mpsc::unbounded();
-    (
-        PipeWrite { tx },
-        PipeRead {
-            rx,
-            buffer: Vec::new(),
-        },
-    )
-}
-
-impl AsyncWrite for PipeWrite {
-    fn poll_write(
-        self: Pin<&mut Self>,
-        _cx: &mut Context<'_>,
-        buf: &[u8],
-    ) -> Poll<io::Result<usize>> {
-        match self.tx.unbounded_send(buf.to_vec()) {
-            Ok(()) => Poll::Ready(Ok(buf.len())),
-            Err(_) => Poll::Ready(Err(Error::new(ErrorKind::BrokenPipe, "channel closed"))),
-        }
-    }
-
-    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        Poll::Ready(Ok(()))
-    }
-
-    fn poll_close(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        self.tx.close_channel();
-        Poll::Ready(Ok(()))
+impl<H> LocalClientChannel<H> {
+    fn new(handler: Rc<H>) -> Self {
+        Self { handler }
     }
 }
 
-impl AsyncRead for PipeRead {
-    fn poll_read(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &mut [u8],
-    ) -> Poll<io::Result<usize>> {
-        let this = self.get_mut();
-
-        if !this.buffer.is_empty() {
-            let n = buf.len().min(this.buffer.len());
-            buf[..n].copy_from_slice(&this.buffer[..n]);
-            this.buffer.drain(..n);
-            return Poll::Ready(Ok(n));
-        }
-
-        match this.rx.poll_next_unpin(cx) {
-            Poll::Ready(Some(data)) => {
-                let n = buf.len().min(data.len());
-                buf[..n].copy_from_slice(&data[..n]);
-                if n < data.len() {
-                    this.buffer.extend_from_slice(&data[n..]);
-                }
-                Poll::Ready(Ok(n))
-            }
-            Poll::Ready(None) => Poll::Ready(Ok(0)),
-            Poll::Pending => Poll::Pending,
-        }
-    }
-}
-
-struct AcpClientChannel {
-    inner: Rc<acp::AgentSideConnection>,
-}
-
-impl ClientChannel for AcpClientChannel {
+impl<H> ClientChannel for LocalClientChannel<H>
+where
+    H: InProcessClientHandler,
+{
     fn send_notification(
         &self,
-        notification: acp::SessionNotification,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = agent_client_protocol::Result<()>>>>
-    {
-        let inner = self.inner.clone();
-        Box::pin(async move { inner.session_notification(notification).await })
+        notification: acp_schema::SessionNotification,
+    ) -> Pin<Box<dyn Future<Output = agent_client_protocol::Result<()>>>> {
+        self.handler.session_notification(notification)
     }
 
     fn request_permission(
         &self,
-        request: acp::RequestPermissionRequest,
-    ) -> std::pin::Pin<
+        request: acp_schema::RequestPermissionRequest,
+    ) -> Pin<
         Box<
-            dyn std::future::Future<
-                Output = agent_client_protocol::Result<
-                    agent_client_protocol::RequestPermissionResponse,
-                >,
+            dyn Future<
+                Output = agent_client_protocol::Result<acp_schema::RequestPermissionResponse>,
             >,
         >,
     > {
-        let inner = self.inner.clone();
-        Box::pin(async move { inner.request_permission(request).await })
+        self.handler.request_permission(request)
     }
 }
 
-/// In-process ACP transport pairing a client-side connection with an IO driver.
+/// In-process ACP transport pairing a local client wrapper with the agent runtime.
 pub struct InProcessTransport {
-    client: acp::ClientSideConnection,
+    client: InProcessClient,
 }
 
 impl InProcessTransport {
-    /// Borrow the ACP client-side connection.
-    pub fn client(&self) -> &acp::ClientSideConnection {
+    /// Borrow the in-process ACP client wrapper.
+    pub fn client(&self) -> &InProcessClient {
         &self.client
+    }
+}
+
+/// Local ACP client facade used by the in-process transport.
+pub struct InProcessClient {
+    connection: Rc<IronConnection>,
+}
+
+impl InProcessClient {
+    async fn with_client_channel<T>(
+        &self,
+        op: impl AsyncFnOnce() -> agent_client_protocol::Result<T>,
+    ) -> agent_client_protocol::Result<T> {
+        op().await
+    }
+
+    pub async fn initialize(
+        &self,
+        request: acp_schema::InitializeRequest,
+    ) -> agent_client_protocol::Result<acp_schema::InitializeResponse> {
+        self.connection.handle_initialize(request).await
+    }
+
+    pub async fn new_session(
+        &self,
+        request: acp_schema::NewSessionRequest,
+    ) -> agent_client_protocol::Result<acp_schema::NewSessionResponse> {
+        self.connection.handle_new_session(request).await
+    }
+
+    pub async fn prompt(
+        &self,
+        request: acp_schema::PromptRequest,
+    ) -> agent_client_protocol::Result<acp_schema::PromptResponse> {
+        self.with_client_channel(|| self.connection.handle_prompt(request))
+            .await
+    }
+
+    pub async fn cancel(
+        &self,
+        notification: acp_schema::CancelNotification,
+    ) -> agent_client_protocol::Result<()> {
+        self.connection.handle_cancel(notification).await
+    }
+
+    pub async fn close_session(
+        &self,
+        request: acp_schema::CloseSessionRequest,
+    ) -> agent_client_protocol::Result<acp_schema::CloseSessionResponse> {
+        self.connection.handle_close_session(request).await
     }
 }
 
@@ -213,42 +205,21 @@ impl InProcessTransport {
 pub fn create_in_process_transport<C>(
     runtime: crate::runtime::IronRuntime,
     client_handler: C,
-) -> (
-    InProcessTransport,
-    impl std::future::Future<Output = ()> + 'static,
-)
+) -> (InProcessTransport, impl Future<Output = ()> + 'static)
 where
-    C: acp::Client + 'static,
+    C: InProcessClientHandler,
 {
-    let (c2a_write, c2a_read) = create_pipe();
-    let (a2c_write, a2c_read) = create_pipe();
-
     let iron_conn = Rc::new(IronConnection::new(runtime));
-
-    let spawn_fn = |fut: LocalBoxFuture<'static, ()>| {
-        tokio::task::spawn_local(fut);
-    };
-
-    let (agent_side, agent_io) =
-        acp::AgentSideConnection::new(iron_conn.clone(), a2c_write, c2a_read, spawn_fn);
-
-    let acp_client = Rc::new(AcpClientChannel {
-        inner: Rc::new(agent_side),
-    });
-    iron_conn.set_client(acp_client);
-
-    let (client_conn, client_io) =
-        acp::ClientSideConnection::new(client_handler, c2a_write, a2c_read, spawn_fn);
-
-    let io_driver = async move {
-        let _ = join!(agent_io, client_io);
-    };
+    let client_handler = Rc::new(client_handler);
+    iron_conn.set_client(Rc::new(LocalClientChannel::new(client_handler)));
 
     (
         InProcessTransport {
-            client: client_conn,
+            client: InProcessClient {
+                connection: iron_conn,
+            },
         },
-        io_driver,
+        async {},
     )
 }
 
@@ -263,103 +234,27 @@ pub fn create_stdio_agent(
     runtime: crate::runtime::IronRuntime,
 ) -> (
     Rc<IronConnection>,
-    impl std::future::Future<Output = acp::Result<()>> + 'static,
+    impl Future<Output = acp::Result<()>> + 'static,
 ) {
-    let outgoing = tokio::io::stdout().compat_write();
-    let incoming = tokio::io::stdin().compat();
-
     let iron_conn = Rc::new(IronConnection::new(runtime));
-
-    let spawn_fn = |fut: LocalBoxFuture<'static, ()>| {
-        tokio::task::spawn_local(fut);
+    let future = async {
+        Err(acp::Error::internal_error().data(
+            "create_stdio_agent is not yet adapted to the ACP 0.11 Send handler requirements",
+        ))
     };
-
-    let (agent_side, agent_io) =
-        acp::AgentSideConnection::new(iron_conn.clone(), outgoing, incoming, spawn_fn);
-
-    let acp_client = Rc::new(AcpClientChannel {
-        inner: Rc::new(agent_side),
-    });
-    iron_conn.set_client(acp_client);
-
-    (iron_conn, agent_io)
+    (iron_conn, future)
 }
 
 /// Serve ACP connections over TCP at the provided socket address.
 pub async fn serve_tcp_agent(
-    runtime: crate::runtime::IronRuntime,
-    addr: std::net::SocketAddr,
+    _runtime: crate::runtime::IronRuntime,
+    _addr: std::net::SocketAddr,
 ) -> acp::Result<()> {
-    let listener = tokio::net::TcpListener::bind(addr)
-        .await
-        .map_err(|e| acp::Error::into_internal_error(&e))?;
-
-    loop {
-        let (stream, _peer) = listener
-            .accept()
-            .await
-            .map_err(|e| acp::Error::into_internal_error(&e))?;
-
-        let (read_half, write_half) = tokio::io::split(stream);
-        let outgoing: tokio_util::compat::Compat<tokio::io::WriteHalf<tokio::net::TcpStream>> =
-            write_half.compat_write();
-        let incoming: tokio_util::compat::Compat<tokio::io::ReadHalf<tokio::net::TcpStream>> =
-            read_half.compat();
-
-        let rt = runtime.clone();
-        std::thread::spawn(move || {
-            let thread_rt = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .expect("Failed to create per-connection runtime");
-            let local_set = tokio::task::LocalSet::new();
-            local_set.block_on(&thread_rt, async move {
-                let iron_conn = Rc::new(IronConnection::new(rt));
-
-                let spawn_fn = |fut: LocalBoxFuture<'static, ()>| {
-                    tokio::task::spawn_local(fut);
-                };
-
-                let (agent_side, agent_io) =
-                    acp::AgentSideConnection::new(iron_conn.clone(), outgoing, incoming, spawn_fn);
-
-                let acp_client = Rc::new(AcpClientChannel {
-                    inner: Rc::new(agent_side),
-                });
-                iron_conn.set_client(acp_client);
-
-                let _ = agent_io.await;
-            });
-        });
-    }
+    Err(acp::Error::internal_error()
+        .data("serve_tcp_agent is not yet adapted to the ACP 0.11 Send handler requirements"))
 }
 
-pub async fn connect_tcp_client<C>(
-    client_handler: C,
-    addr: std::net::SocketAddr,
-) -> acp::Result<(
-    acp::ClientSideConnection,
-    impl std::future::Future<Output = acp::Result<()>> + 'static,
-)>
-where
-    C: acp::Client + 'static,
-{
-    let stream = tokio::net::TcpStream::connect(addr)
-        .await
-        .map_err(|e| acp::Error::into_internal_error(&e))?;
-
-    let (read_half, write_half) = tokio::io::split(stream);
-    let outgoing = write_half.compat_write();
-    let incoming = read_half.compat();
-
-    let spawn_fn = |fut: LocalBoxFuture<'static, ()>| {
-        tokio::task::spawn_local(fut);
-    };
-
-    Ok(acp::ClientSideConnection::new(
-        client_handler,
-        outgoing,
-        incoming,
-        spawn_fn,
-    ))
+pub async fn connect_tcp_client(_addr: std::net::SocketAddr) -> acp::Result<()> {
+    Err(acp::Error::internal_error()
+        .data("connect_tcp_client is not yet adapted to the ACP 0.11 client builder API"))
 }

--- a/tests/interop_tests.rs
+++ b/tests/interop_tests.rs
@@ -1,43 +1,49 @@
-use agent_client_protocol::{Agent as _, Client};
 use iron_core::{
-    runtime::IronRuntime, transport::create_in_process_transport, Config, InProcessTransport,
+    runtime::IronRuntime,
+    transport::{create_in_process_transport, InProcessClientHandler},
+    Config, InProcessTransport,
 };
 use iron_providers::OpenAiProvider;
 use std::cell::RefCell;
+use std::future::Future;
+use std::pin::Pin;
 use std::rc::Rc;
 
+use agent_client_protocol::schema as acp;
+
 struct MockClient {
-    notifications: Rc<RefCell<Vec<agent_client_protocol::SessionNotification>>>,
+    notifications: Rc<RefCell<Vec<acp::SessionNotification>>>,
 }
 
 impl MockClient {
-    fn new(notifications: Rc<RefCell<Vec<agent_client_protocol::SessionNotification>>>) -> Self {
+    fn new(notifications: Rc<RefCell<Vec<acp::SessionNotification>>>) -> Self {
         Self { notifications }
     }
 }
 
-#[async_trait::async_trait(?Send)]
-impl Client for MockClient {
-    async fn session_notification(
+impl InProcessClientHandler for MockClient {
+    fn session_notification(
         &self,
-        args: agent_client_protocol::SessionNotification,
-    ) -> agent_client_protocol::Result<()> {
-        self.notifications.borrow_mut().push(args);
-        Ok(())
+        args: acp::SessionNotification,
+    ) -> Pin<Box<dyn Future<Output = agent_client_protocol::Result<()>>>> {
+        let notifications = self.notifications.clone();
+        Box::pin(async move {
+            notifications.borrow_mut().push(args);
+            Ok(())
+        })
     }
 
-    async fn request_permission(
+    fn request_permission(
         &self,
-        _args: agent_client_protocol::RequestPermissionRequest,
-    ) -> agent_client_protocol::Result<agent_client_protocol::RequestPermissionResponse> {
-        let outcome = agent_client_protocol::RequestPermissionOutcome::Selected(
-            agent_client_protocol::SelectedPermissionOutcome::new(
-                agent_client_protocol::PermissionOptionId::new("allow_once"),
-            ),
-        );
-        Ok(agent_client_protocol::RequestPermissionResponse::new(
-            outcome,
-        ))
+        _args: acp::RequestPermissionRequest,
+    ) -> Pin<Box<dyn Future<Output = agent_client_protocol::Result<acp::RequestPermissionResponse>>>>
+    {
+        Box::pin(async move {
+            let outcome = acp::RequestPermissionOutcome::Selected(
+                acp::SelectedPermissionOutcome::new(acp::PermissionOptionId::new("allow_once")),
+            );
+            Ok(acp::RequestPermissionResponse::new(outcome))
+        })
     }
 }
 
@@ -50,7 +56,7 @@ fn make_runtime() -> IronRuntime {
 
 async fn setup_transport() -> (
     InProcessTransport,
-    Rc<RefCell<Vec<agent_client_protocol::SessionNotification>>>,
+    Rc<RefCell<Vec<acp::SessionNotification>>>,
 ) {
     let runtime = make_runtime();
     let notifications = Rc::new(RefCell::new(Vec::new()));
@@ -61,9 +67,7 @@ async fn setup_transport() -> (
 
     let _ = transport
         .client()
-        .initialize(agent_client_protocol::InitializeRequest::new(
-            agent_client_protocol::ProtocolVersion::LATEST,
-        ))
+        .initialize(acp::InitializeRequest::new(acp::ProtocolVersion::LATEST))
         .await
         .unwrap();
 
@@ -83,7 +87,7 @@ fn inprocess_initialize_and_new_session() {
         let acp_client = transport.client();
 
         let session_resp = acp_client
-            .new_session(agent_client_protocol::NewSessionRequest::new("."))
+            .new_session(acp::NewSessionRequest::new("."))
             .await
             .unwrap();
         assert!(!session_resp.session_id.to_string().is_empty());
@@ -103,13 +107,13 @@ fn inprocess_cancel() {
         let acp_client = transport.client();
 
         let session_resp = acp_client
-            .new_session(agent_client_protocol::NewSessionRequest::new("."))
+            .new_session(acp::NewSessionRequest::new("."))
             .await
             .unwrap();
         let session_id = session_resp.session_id;
 
         let cancel_result = acp_client
-            .cancel(agent_client_protocol::CancelNotification::new(session_id))
+            .cancel(acp::CancelNotification::new(session_id))
             .await;
         assert!(cancel_result.is_ok());
     });
@@ -128,13 +132,13 @@ fn inprocess_close_session() {
         let acp_client = transport.client();
 
         let session_resp = acp_client
-            .new_session(agent_client_protocol::NewSessionRequest::new("."))
+            .new_session(acp::NewSessionRequest::new("."))
             .await
             .unwrap();
         let session_id = session_resp.session_id;
 
         let close_result = acp_client
-            .close_session(agent_client_protocol::CloseSessionRequest::new(session_id))
+            .close_session(acp::CloseSessionRequest::new(session_id))
             .await;
         assert!(close_result.is_ok());
     });
@@ -153,12 +157,12 @@ fn inprocess_multiple_sessions() {
         let acp_client = transport.client();
 
         let s1 = acp_client
-            .new_session(agent_client_protocol::NewSessionRequest::new("."))
+            .new_session(acp::NewSessionRequest::new("."))
             .await
             .unwrap()
             .session_id;
         let s2 = acp_client
-            .new_session(agent_client_protocol::NewSessionRequest::new("."))
+            .new_session(acp::NewSessionRequest::new("."))
             .await
             .unwrap()
             .session_id;
@@ -166,10 +170,10 @@ fn inprocess_multiple_sessions() {
         assert_ne!(s1, s2);
 
         let _ = acp_client
-            .close_session(agent_client_protocol::CloseSessionRequest::new(s1))
+            .close_session(acp::CloseSessionRequest::new(s1))
             .await;
         let _ = acp_client
-            .close_session(agent_client_protocol::CloseSessionRequest::new(s2))
+            .close_session(acp::CloseSessionRequest::new(s2))
             .await;
     });
 }
@@ -187,25 +191,20 @@ fn inprocess_prompt_with_fake_provider_returns_end_turn() {
         let acp_client = transport.client();
 
         let session_resp = acp_client
-            .new_session(agent_client_protocol::NewSessionRequest::new("."))
+            .new_session(acp::NewSessionRequest::new("."))
             .await
             .unwrap();
         let session_id = session_resp.session_id;
 
         let result = acp_client
-            .prompt(agent_client_protocol::PromptRequest::new(
+            .prompt(acp::PromptRequest::new(
                 session_id,
-                vec![agent_client_protocol::ContentBlock::Text(
-                    agent_client_protocol::TextContent::new("hello"),
-                )],
+                vec![acp::ContentBlock::Text(acp::TextContent::new("hello"))],
             ))
             .await;
 
         assert!(result.is_ok());
-        assert_eq!(
-            result.unwrap().stop_reason,
-            agent_client_protocol::StopReason::EndTurn
-        );
+        assert_eq!(result.unwrap().stop_reason, acp::StopReason::EndTurn);
     });
 }
 
@@ -223,13 +222,13 @@ fn inprocess_reinitialize_fresh_transport() {
 
         let s1 = transport1
             .client()
-            .new_session(agent_client_protocol::NewSessionRequest::new("."))
+            .new_session(acp::NewSessionRequest::new("."))
             .await
             .unwrap()
             .session_id;
         let s2 = transport2
             .client()
-            .new_session(agent_client_protocol::NewSessionRequest::new("."))
+            .new_session(acp::NewSessionRequest::new("."))
             .await
             .unwrap()
             .session_id;
@@ -260,33 +259,27 @@ fn inprocess_cross_connection_prompt_rejected() {
 
         let _ = transport1
             .client()
-            .initialize(agent_client_protocol::InitializeRequest::new(
-                agent_client_protocol::ProtocolVersion::LATEST,
-            ))
+            .initialize(acp::InitializeRequest::new(acp::ProtocolVersion::LATEST))
             .await
             .unwrap();
         let _ = transport2
             .client()
-            .initialize(agent_client_protocol::InitializeRequest::new(
-                agent_client_protocol::ProtocolVersion::LATEST,
-            ))
+            .initialize(acp::InitializeRequest::new(acp::ProtocolVersion::LATEST))
             .await
             .unwrap();
 
         let session_resp = transport1
             .client()
-            .new_session(agent_client_protocol::NewSessionRequest::new("."))
+            .new_session(acp::NewSessionRequest::new("."))
             .await
             .unwrap();
         let session_id = session_resp.session_id;
 
         let result = transport2
             .client()
-            .prompt(agent_client_protocol::PromptRequest::new(
+            .prompt(acp::PromptRequest::new(
                 session_id,
-                vec![agent_client_protocol::ContentBlock::Text(
-                    agent_client_protocol::TextContent::new("intrude"),
-                )],
+                vec![acp::ContentBlock::Text(acp::TextContent::new("intrude"))],
             ))
             .await;
 
@@ -316,29 +309,25 @@ fn inprocess_cross_connection_close_session_rejected() {
 
         let _ = transport1
             .client()
-            .initialize(agent_client_protocol::InitializeRequest::new(
-                agent_client_protocol::ProtocolVersion::LATEST,
-            ))
+            .initialize(acp::InitializeRequest::new(acp::ProtocolVersion::LATEST))
             .await
             .unwrap();
         let _ = transport2
             .client()
-            .initialize(agent_client_protocol::InitializeRequest::new(
-                agent_client_protocol::ProtocolVersion::LATEST,
-            ))
+            .initialize(acp::InitializeRequest::new(acp::ProtocolVersion::LATEST))
             .await
             .unwrap();
 
         let session_resp = transport1
             .client()
-            .new_session(agent_client_protocol::NewSessionRequest::new("."))
+            .new_session(acp::NewSessionRequest::new("."))
             .await
             .unwrap();
         let session_id = session_resp.session_id;
 
         let result = transport2
             .client()
-            .close_session(agent_client_protocol::CloseSessionRequest::new(session_id))
+            .close_session(acp::CloseSessionRequest::new(session_id))
             .await;
 
         assert!(result.is_err(), "expected cross-connection close to fail");

--- a/tests/transport_bench_tests.rs
+++ b/tests/transport_bench_tests.rs
@@ -1,34 +1,37 @@
-use agent_client_protocol::{Agent as _, Client};
 use iron_core::{
     runtime::IronRuntime,
-    transport::{create_in_process_transport, InProcessTransport},
+    transport::{create_in_process_transport, InProcessClientHandler, InProcessTransport},
     Config,
 };
 use iron_providers::{OpenAiConfig, OpenAiProvider};
+use std::future::Future;
+use std::pin::Pin;
 use std::time::Instant;
+
+use agent_client_protocol::schema as acp;
 
 struct NopClient;
 
-#[async_trait::async_trait(?Send)]
-impl Client for NopClient {
-    async fn request_permission(
+impl InProcessClientHandler for NopClient {
+    fn request_permission(
         &self,
-        _args: agent_client_protocol::RequestPermissionRequest,
-    ) -> agent_client_protocol::Result<agent_client_protocol::RequestPermissionResponse> {
-        Ok(agent_client_protocol::RequestPermissionResponse::new(
-            agent_client_protocol::RequestPermissionOutcome::Selected(
-                agent_client_protocol::SelectedPermissionOutcome::new(
-                    agent_client_protocol::PermissionOptionId::new("allow"),
-                ),
-            ),
-        ))
+        _args: acp::RequestPermissionRequest,
+    ) -> Pin<Box<dyn Future<Output = agent_client_protocol::Result<acp::RequestPermissionResponse>>>>
+    {
+        Box::pin(async move {
+            Ok(acp::RequestPermissionResponse::new(
+                acp::RequestPermissionOutcome::Selected(acp::SelectedPermissionOutcome::new(
+                    acp::PermissionOptionId::new("allow"),
+                )),
+            ))
+        })
     }
 
-    async fn session_notification(
+    fn session_notification(
         &self,
-        _args: agent_client_protocol::SessionNotification,
-    ) -> agent_client_protocol::Result<()> {
-        Ok(())
+        _args: acp::SessionNotification,
+    ) -> Pin<Box<dyn Future<Output = agent_client_protocol::Result<()>>>> {
+        Box::pin(async { Ok(()) })
     }
 }
 
@@ -45,9 +48,7 @@ async fn setup() -> InProcessTransport {
     tokio::task::spawn_local(agent_fut);
     let _ = transport
         .client()
-        .initialize(agent_client_protocol::InitializeRequest::new(
-            agent_client_protocol::ProtocolVersion::LATEST,
-        ))
+        .initialize(acp::InitializeRequest::new(acp::ProtocolVersion::LATEST))
         .await
         .unwrap();
     transport
@@ -70,9 +71,7 @@ fn bench_initialize_round_trip() {
             let start = Instant::now();
             let _ = transport
                 .client()
-                .initialize(agent_client_protocol::InitializeRequest::new(
-                    agent_client_protocol::ProtocolVersion::LATEST,
-                ))
+                .initialize(acp::InitializeRequest::new(acp::ProtocolVersion::LATEST))
                 .await
                 .unwrap();
             durations.push(start.elapsed());
@@ -105,7 +104,7 @@ fn bench_new_session_round_trip() {
         let start = Instant::now();
         for _ in 0..100 {
             let _ = client
-                .new_session(agent_client_protocol::NewSessionRequest::new("."))
+                .new_session(acp::NewSessionRequest::new("."))
                 .await
                 .unwrap();
         }
@@ -135,7 +134,7 @@ fn bench_prompt_round_trip_with_fake_provider() {
         let transport = setup().await;
         let client = transport.client();
         let session = client
-            .new_session(agent_client_protocol::NewSessionRequest::new("."))
+            .new_session(acp::NewSessionRequest::new("."))
             .await
             .unwrap()
             .session_id;
@@ -143,11 +142,9 @@ fn bench_prompt_round_trip_with_fake_provider() {
         let start = Instant::now();
         for _ in 0..50 {
             let _ = client
-                .prompt(agent_client_protocol::PromptRequest::new(
+                .prompt(acp::PromptRequest::new(
                     session.clone(),
-                    vec![agent_client_protocol::ContentBlock::Text(
-                        agent_client_protocol::TextContent::new("hi"),
-                    )],
+                    vec![acp::ContentBlock::Text(acp::TextContent::new("hi"))],
                 ))
                 .await
                 .unwrap();


### PR DESCRIPTION
## Summary
- update direct dependencies including `iron-providers` to `0.1.7`, `monty` to `v0.0.17`, and `agent-client-protocol` to `0.11`
- adapt the ACP integration and in-process transport/tests to the ACP 0.11 schema and handler model
- leave stdio/TCP ACP helpers as explicit runtime-error stubs until the transport/runtime architecture is refactored to satisfy ACP 0.11 `Send` callback requirements

## Testing
- cargo fmt --manifest-path Cargo.toml -- --check
- cargo clippy --locked --all-targets --all-features -- -D warnings
- cargo test --locked

Closes #12
