### PR TITLE
Implement dynamic system prompt templating

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,9 +126,9 @@ checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
 name = "async-openai"
-version = "0.36.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78efd86812da6b76e2be727c7015522dde20495855390496099f062b01d2c868"
+checksum = "dafa6acfa9d5138539abe815de90b0a4b7127420e6846c71bb23cf68660641ba"
 dependencies = [
  "async-openai-macros",
  "backoff",
@@ -517,12 +517,6 @@ dependencies = [
  "libc",
  "shlex",
 ]
-
-[[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -1237,6 +1231,17 @@ name = "fancy-regex"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
 dependencies = [
  "bit-set",
  "regex-automata",
@@ -1964,9 +1969,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -2111,9 +2116,9 @@ dependencies = [
 
 [[package]]
 name = "iron-providers"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "570bd20f8e93154f9363767468149ff395d17ceacb3fbac444bec284811ee867"
+checksum = "51edc31e3e112a6509915bbdfc547443fa81e13b5d5aec03382d7f9c1286f101"
 dependencies = [
  "async-openai",
  "async-stream",
@@ -2190,27 +2195,32 @@ dependencies = [
 
 [[package]]
 name = "jni"
-version = "0.21.1"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cesu8",
  "cfg-if",
  "combine",
- "jni-sys 0.3.1",
+ "jni-macros",
+ "jni-sys",
  "log",
- "thiserror 1.0.69",
+ "simd_cesu8",
+ "thiserror 2.0.18",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-link",
 ]
 
 [[package]]
-name = "jni-sys"
-version = "0.3.1"
+name = "jni-macros"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
 dependencies = [
- "jni-sys 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
 ]
 
 [[package]]
@@ -2244,9 +2254,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2266,15 +2276,15 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.46.2"
+version = "0.46.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50180452e7808015fe083eae3efcf1ec98b89b45dd8cc204f7b4a6b7b81ea675"
+checksum = "cbe92a2f8b00686061eab5cdcfd6f382c27f2084456e7be90ae9f0fe4a30552a"
 dependencies = [
  "ahash",
  "bytecount",
  "data-encoding",
  "email_address",
- "fancy-regex",
+ "fancy-regex 0.18.0",
  "fraction",
  "getrandom 0.3.4",
  "idna",
@@ -2524,7 +2534,7 @@ dependencies = [
  "ahash",
  "bytemuck",
  "chrono",
- "fancy-regex",
+ "fancy-regex 0.17.0",
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
  "itertools",
@@ -3233,9 +3243,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.46.2"
+version = "0.46.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acb0c66c7b78c1da928bee668b5cc638c678642ff587faff6e6222f797be9d4c"
+checksum = "e125f10bdcd507598c702daada18c47fe5bfba4d7a9545b015b5d432f7168ca3"
 dependencies = [
  "ahash",
  "fluent-uri",
@@ -3293,9 +3303,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
  "base64",
  "bytes",
@@ -3539,9 +3549,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.39"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -3577,9 +3587,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
@@ -3902,6 +3912,22 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
@@ -4732,9 +4758,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4745,9 +4771,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4755,9 +4781,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4765,9 +4791,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4778,9 +4804,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
 ]
@@ -4828,12 +4854,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.247.0"
+version = "0.248.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b6733b8b91d010a6ac5b0fb237dc46a19650bc4c67db66857e2e787d437204"
+checksum = "ac92cf547bc18d27ecc521015c08c353b4f18b84ab388bb6d1b6b682c620d9b6"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.247.0",
+ "wasmparser 0.248.0",
 ]
 
 [[package]]
@@ -4888,9 +4914,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.247.0"
+version = "0.248.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e6fb4c2bee46c5ea4d40f8cdb5c131725cd976718ec56f1c8e82fbde5fa2a80"
+checksum = "aa4439c5eee9df71ee0c6efb37f63b1fcb1fec38f85f5142c54e7ed05d33091a"
 dependencies = [
  "bitflags",
  "indexmap 2.14.0",
@@ -5179,31 +5205,31 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "247.0.0"
+version = "248.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "579d2d47eb33b0cdf9b14723cb115f1e1b7d6e77aac6f0816e5b7c7aeaa418ff"
+checksum = "acc54622ed5a5cddafcdf152043f9d4aed54d4a653d686b7dfe874809fca99d7"
 dependencies = [
  "bumpalo",
  "leb128fmt",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.247.0",
+ "wasm-encoder 0.248.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.247.0"
+version = "1.248.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3f4091c56437e86f2b57fa2fac72c4f528957a605b3f44f7c0b3b19a17ac5ee"
+checksum = "d75cd9e510603909748e6ebab89f27cd04472c1d9d85a3c88a7a6fc51a1a7934"
 dependencies = [
- "wast 247.0.0",
+ "wast 248.0.0",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5401,15 +5427,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -5442,21 +5459,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -5494,12 +5496,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -5512,12 +5508,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -5527,12 +5517,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5560,12 +5544,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -5575,12 +5553,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5596,12 +5568,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -5611,12 +5577,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
 ]
 
 [dependencies]
-iron-providers = "0.1.7"
+iron-providers = "0.1.8"
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["compat"] }
 serde = { version = "1", features = ["derive"] }

--- a/openspec/changes/dynamic-system-prompt-templating/.openspec.yaml
+++ b/openspec/changes/dynamic-system-prompt-templating/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-29

--- a/openspec/changes/dynamic-system-prompt-templating/design.md
+++ b/openspec/changes/dynamic-system-prompt-templating/design.md
@@ -1,0 +1,125 @@
+## Context
+
+`iron-core` already composes multiple prompt layers, including baseline prompt text, repository instructions, session instructions, active skills, and runtime context. That composition is effective, but it treats prompt assembly mostly as ordered concatenation. Issue `#14` requires a stronger model: each section must have a fixed owner, a fixed place in the final system prompt, and clear rules for when the full prompt should be rebuilt.
+
+The main architectural constraint is prompt caching. We should not rebuild the system prompt every turn. Instead, we need an explicit invalidation model so prompt rebuilds happen only when relevant inputs change.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Produce one final system prompt from a fixed nine-section order.
+- Make section ownership explicit and enforceable in code.
+- Allow provider-specific and client-specific content only in their designated sections.
+- Rebuild the system prompt only when explicit invalidation events occur.
+- Preserve the ability to extend invalidation triggers later without redesigning the prompt API.
+
+**Non-Goals:**
+- Exposing a public generic template DSL or arbitrary section override API.
+- Recomputing the system prompt on every turn.
+- Allowing providers or clients to replace core policy sections.
+- Solving future model-specific prompt shortening or adaptive compression in this change.
+
+## Decisions
+
+### Represent the system prompt as fixed ordered sections with typed ownership
+Model the prompt as a fixed set of section slots rather than as free-form blocks. Each section has:
+- a stable position in the final prompt
+- an owning authority
+- a rebuild temperature / invalidation policy
+
+This is preferable to a generic `update(section, content)` interface because ownership rules remain encoded in the type surface instead of being left to convention.
+
+### Keep the template engine internal
+`iron-core` may compile a template into the binary with `include_str!` and render it with Tera or a similar engine, but callers should not manipulate raw template blocks directly.
+
+This is preferable to exposing template names publicly because core safety and policy sections must remain non-overridable.
+
+### Separate ownership from invalidation temperature
+Ownership answers who may supply content. Temperature answers when prompt content may change.
+
+For example:
+- `Tool Philosophy` is core-owned but warm because it depends on actual tool availability.
+- `Editing Guidelines` may accept client content but should usually be cold after startup.
+
+This is preferable to a single mutable/not-mutable flag because it captures the real constraints of the issue.
+
+### Use explicit invalidation hooks rather than per-turn recomposition
+The prompt manager should cache the rendered system prompt and invalidate it only when tracked inputs change. Initial invalidation support should cover:
+- working directory changes affecting `Static Context`
+- provider/model changes affecting `Provider-Specific Guidance`
+- tool availability changes affecting `Tool Philosophy`
+- explicit client configuration changes affecting `Editing Guidelines` or `Client Injection`
+
+This is preferable to unconditional rebuilds because it preserves prompt caching while still allowing future dynamic behavior.
+
+### Treat client editing guidance and client injection as distinct external slots
+`Editing Guidelines` should be modeled as client-supplied editing guidance with core fallback defaults.
+
+`Client Injection` should be modeled as optional client-provided markdown fragments, likely as an ordered list with optional labels/titles, while keeping `iron-core` mostly unopinionated about fragment contents.
+
+This is preferable to combining the two because they serve different semantic roles and update frequencies.
+
+## Proposed Structure
+
+Introduce an internal prompt state model along these lines:
+
+- `SystemPromptSections`
+  - core literal sections
+  - core derived sections
+  - provider fragment section
+  - client editing guidance section
+  - client injection section
+- `SystemPromptInputs`
+  - client name
+  - runtime context snapshot
+  - tool availability snapshot
+  - provider guidance fragment
+  - client editing guidance override
+  - client injection fragments
+- `SystemPromptCache`
+  - last rendered prompt
+  - invalidation flags / input fingerprinting
+
+The existing prompt assembly pipeline can then evolve from plain concatenation into a section renderer that emits the final single system prompt in fixed order.
+
+## Section Ownership Model
+
+### Core-owned cold sections
+- Identity
+- Core Guidelines
+- Safety & Destructive Actions
+- Communication & Formatting
+
+These are literal sections or mostly literal sections owned entirely by `iron-core`.
+
+### Core-owned warm sections
+- Static Context
+- Tool Philosophy
+
+These are derived by `iron-core` from runtime state and tool state.
+
+### External fragment sections
+- Editing Guidelines: client-supplied guidance with core fallback
+- Provider-Specific Guidance: provider-owned trusted fragment
+- Client Injection: client-owned optional markdown fragment list
+
+## Risks / Trade-offs
+
+- [The API surface may become more complex than today’s prompt concatenation] → Keep the public API narrow and typed; complexity should stay mostly internal.
+- [Working directory may not be the only runtime context field that eventually needs invalidation] → Build the invalidation mechanism generically, even if only CWD is wired first.
+- [Client injection can become a dumping ground] → Keep the slot intentionally narrow and clearly separated from core policy sections.
+- [Template rendering can obscure where content came from] → Preserve section-level tests and section-specific builders so failures remain diagnosable.
+
+## Migration Plan
+
+- Introduce section and input structs alongside the current composition path.
+- Move existing baseline/runtime/provider composition into the new section renderer without changing external behavior first.
+- Add explicit invalidation support, initially for working directory changes.
+- Add client/provider input APIs for editing guidance and client injection.
+- Update prompt composition tests to assert section order, ownership boundaries, and cache-sensitive rebuild behavior.
+
+## Open Questions
+
+- Should `Client Injection` require titles for fragments, or should plain ordered markdown fragments be first-class?
+- Should runtime date/time be captured once per rendered prompt or once per session to avoid cache churn from clock movement?
+- Should repository instructions remain a separate pre-section input, or should they be folded into one of the core sections in a follow-up change?

--- a/openspec/changes/dynamic-system-prompt-templating/proposal.md
+++ b/openspec/changes/dynamic-system-prompt-templating/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+`iron-core` currently assembles provider instructions through a fixed composition pipeline, but it does not model section ownership, mutability, or prompt rebuild triggers explicitly. Issue `#14` needs more than string interpolation: it needs a single system prompt with fixed section ordering, core-owned policy boundaries, narrow provider/client extension slots, and explicit invalidation hooks so prompt caching is preserved.
+
+Without that structure, a generic block-override template system would make core policy too easy to replace, blur ownership between `iron-core`, `iron-providers`, and embedding clients, and encourage unnecessary full prompt rebuilds on every turn.
+
+## What Changes
+
+- Introduce a section-owned system prompt model with a fixed nine-section order.
+- Add explicit authority boundaries for core-owned, provider-owned, and client-owned prompt sections.
+- Add internal template rendering for the final system prompt without exposing a public generic block override surface.
+- Add explicit prompt invalidation hooks, initially supporting static-context rebuilds on working directory changes and provider-guidance/tool-philosophy rebuilds when relevant inputs change.
+- Add typed client/provider inputs for editing guidance, provider-specific guidance, and client injection fragments.
+- Add tests that verify section ordering, ownership enforcement, and rebuild behavior.
+
+## Capabilities
+
+### New Capabilities
+- `dynamic-system-prompt-templating`: Compose the system prompt from fixed sections with explicit ownership and invalidation rules.
+
+### Modified Capabilities
+- `dependency-version-guidance`: no direct behavior change, but provider instructions will now be inserted through the provider-owned prompt section rather than ad hoc composition.
+
+## Impact
+
+- Affected code: `src/prompt/*`, `src/request_builder.rs`, session/runtime prompt state management, and prompt composition tests.
+- Affected systems: provider instruction assembly, runtime-context injection, provider/model guidance injection, and client prompt customization APIs.
+- API/protocol impact: new internal section/state abstractions and likely new facade/runtime setters for client editing guidance and client injection content.

--- a/openspec/changes/dynamic-system-prompt-templating/specs/dynamic-system-prompt-templating/spec.md
+++ b/openspec/changes/dynamic-system-prompt-templating/specs/dynamic-system-prompt-templating/spec.md
@@ -1,0 +1,81 @@
+## ADDED Requirements
+
+### Requirement: The runtime SHALL compose the system prompt from a fixed ordered section model
+`iron-core` SHALL render the system prompt from a fixed ordered set of sections rather than from arbitrary caller-defined template blocks.
+
+#### Scenario: System prompt uses the canonical section order
+- **WHEN** a provider request is built
+- **THEN** the final system prompt is rendered in this order:
+  1. Identity
+  2. Static Context
+  3. Core Guidelines
+  4. Tool Philosophy
+  5. Editing Guidelines
+  6. Safety & Destructive Actions
+  7. Provider-Specific Guidance
+  8. Communication & Formatting
+  9. Client Injection
+
+### Requirement: Core-owned prompt policy sections SHALL NOT be externally overridable
+Core-owned policy sections SHALL remain under `iron-core` control even when providers or clients supply prompt-related inputs.
+
+#### Scenario: Provider cannot replace core safety guidance
+- **WHEN** a provider supplies provider-specific guidance
+- **THEN** that content appears only in `Provider-Specific Guidance`
+- **AND** `Safety & Destructive Actions` remains unchanged
+
+#### Scenario: Client cannot replace core guidelines
+- **WHEN** a client supplies editing guidance or client injection content
+- **THEN** `Core Guidelines` and `Communication & Formatting` remain unchanged
+
+### Requirement: Static context SHALL rebuild only on explicit invalidation events
+`iron-core` SHALL cache the rendered system prompt and rebuild it only when tracked inputs affecting rendered content change.
+
+#### Scenario: Working directory change invalidates static context
+- **WHEN** the runtime working directory changes for a session
+- **THEN** the cached system prompt is invalidated
+- **AND** the next provider request renders an updated `Static Context` section
+
+#### Scenario: Stable runtime state reuses cached prompt
+- **WHEN** no tracked prompt inputs have changed since the last render
+- **THEN** the runtime reuses the cached system prompt
+- **AND** it does not rebuild the prompt for that request
+
+### Requirement: Tool philosophy SHALL be core-owned and derived from available tools
+`Tool Philosophy` SHALL be rendered by `iron-core` from actual tool/runtime availability rather than supplied by external callers.
+
+#### Scenario: Tool availability change updates tool philosophy
+- **WHEN** the available tool set changes for a session or runtime
+- **THEN** the next rendered system prompt reflects the updated tool guidance
+- **AND** no provider-supplied fragment can replace that section
+
+### Requirement: Editing guidance SHALL support client override with core fallback
+`Editing Guidelines` SHALL support client-supplied editing guidance while preserving a core default when no client guidance is supplied.
+
+#### Scenario: Client editing guidance overrides default content
+- **WHEN** a client supplies editing guidance for the session
+- **THEN** the `Editing Guidelines` section renders that client-supplied guidance
+
+#### Scenario: Missing client editing guidance falls back to core defaults
+- **WHEN** a client does not supply editing guidance
+- **THEN** the `Editing Guidelines` section renders the core default guidance
+
+### Requirement: Provider-specific guidance SHALL be isolated to its designated section
+Provider/model-specific system prompting from `iron-providers` SHALL appear only in the provider-owned section.
+
+#### Scenario: Provider fragment is inserted in provider section only
+- **WHEN** `iron-providers` supplies a provider/model guidance fragment
+- **THEN** that fragment appears in `Provider-Specific Guidance`
+- **AND** no other section ordering or ownership changes
+
+### Requirement: Client injection SHALL support ordered trusted markdown fragments
+`iron-core` SHALL provide a client-owned injection slot for additional system prompting without redefining core-owned sections.
+
+#### Scenario: Client injection fragments render in order
+- **WHEN** a client supplies multiple injection fragments
+- **THEN** the `Client Injection` section renders them in caller-specified order
+
+#### Scenario: Empty client injection omits extra content
+- **WHEN** a client supplies no injection content
+- **THEN** the `Client Injection` section is empty or omitted according to the renderer policy
+- **AND** the rest of the section order remains stable

--- a/openspec/changes/dynamic-system-prompt-templating/tasks.md
+++ b/openspec/changes/dynamic-system-prompt-templating/tasks.md
@@ -1,0 +1,42 @@
+## 1. Prompt section model
+
+- [x] 1.1 Define the fixed nine-section prompt model and section ordering in `iron-core`
+- [x] 1.2 Add explicit section ownership metadata for core, provider, and client supplied sections
+- [x] 1.3 Add typed inputs for provider guidance, client editing guidance, and client injection content
+- [x] 1.4 Add internal defaults for core-owned sections and editing-guidance fallback content
+
+## 2. Rendering and caching
+
+- [x] 2.1 Add an internal compiled system prompt template and renderer
+- [x] 2.2 Introduce a cached prompt state object that tracks rendered output and invalidation state
+- [x] 2.3 Rebuild the full system prompt only when tracked inputs change
+- [x] 2.4 Wire explicit invalidation for working directory changes affecting `Static Context`
+- [x] 2.5 Wire invalidation for provider/model changes affecting `Provider-Specific Guidance`
+- [x] 2.6 Wire invalidation for tool availability changes affecting `Tool Philosophy`
+
+## 3. Integration with existing prompt composition
+
+- [x] 3.1 Refactor current prompt assembly to emit the fixed section order rather than ad hoc concatenation
+- [x] 3.2 Preserve repository instructions, active skills, and runtime context semantics within the new section model
+- [x] 3.3 Ensure core-owned cold sections cannot be overridden by provider or client inputs
+- [x] 3.4 Ensure `Provider-Specific Guidance` only accepts trusted provider-owned content
+- [x] 3.5 Ensure `Editing Guidelines` uses client-supplied content when present and core fallback otherwise
+- [x] 3.6 Ensure `Client Injection` accepts optional markdown fragments without affecting core section ownership
+
+## 4. Runtime and facade surfaces
+
+- [x] 4.1 Add runtime/session APIs for setting client editing guidance at startup
+- [x] 4.2 Add runtime/session APIs for setting client injection content
+- [x] 4.3 Add provider integration hooks for provider/model-specific guidance fragments
+- [x] 4.4 Add explicit prompt invalidation hooks for future runtime state changes beyond working directory changes
+
+## 5. Verification
+
+- [x] 5.1 Add tests verifying the final prompt uses the fixed nine-section order
+- [x] 5.2 Add tests verifying core-owned sections cannot be externally overridden
+- [x] 5.3 Add tests verifying provider guidance only appears in its dedicated section
+- [x] 5.4 Add tests verifying client editing guidance overrides core fallback correctly
+- [x] 5.5 Add tests verifying client injection fragments render in order
+- [x] 5.6 Add tests verifying prompt rebuild happens on working directory change and is skipped otherwise
+- [x] 5.7 Add tests verifying tool availability changes update `Tool Philosophy`
+- [x] 5.8 Run prompt composition, request builder, and regression test suites

--- a/src/config.rs
+++ b/src/config.rs
@@ -41,6 +41,10 @@ pub struct Config {
     pub context_window_policy: ContextWindowPolicy,
     /// Model identifier passed to the provider on each inference request.
     pub model: String,
+    /// Provider name (e.g. "openai", "anthropic") used to look up provider-specific
+    /// system prompt fragments from `iron-providers`. When set, the fragment is
+    /// resolved automatically and overrides `prompt_composition.provider_guidance`.
+    pub provider_name: Option<String>,
     /// Default generation settings applied to every inference request.
     pub default_generation: GenerationConfig,
     /// Default tool policy applied when requests include tools.
@@ -71,6 +75,7 @@ impl Default for Config {
             default_approval_strategy: ApprovalStrategy::PerTool,
             context_window_policy: ContextWindowPolicy::default(),
             model: "gpt-4o".to_string(),
+            provider_name: None,
             default_generation: GenerationConfig::default(),
             default_tool_policy: ToolPolicy::Auto,
             context_management: ContextManagementConfig::default(),
@@ -111,6 +116,13 @@ impl Config {
     /// Set the default model identifier used for inference.
     pub fn with_model<S: Into<String>>(mut self, model: S) -> Self {
         self.model = model.into();
+        self
+    }
+
+    /// Set the provider name used to resolve provider-specific system prompt
+    /// fragments from `iron-providers` (e.g. "openai", "anthropic").
+    pub fn with_provider_name<S: Into<String>>(mut self, name: S) -> Self {
+        self.provider_name = Some(name.into());
         self
     }
 

--- a/src/prompt/assembly.rs
+++ b/src/prompt/assembly.rs
@@ -48,7 +48,11 @@ impl PromptAssembler {
         parts.join("\n\n")
     }
 
-    fn render_repo_instructions(payload: &RepoInstructionPayload) -> String {
+    pub fn render_repo_instructions(payload: &RepoInstructionPayload) -> String {
+        if payload.sources.is_empty() && payload.additional_files.is_empty() {
+            return String::new();
+        }
+
         let mut section = String::from("<repository_instructions>");
         section.push('\n');
 

--- a/src/prompt/config.rs
+++ b/src/prompt/config.rs
@@ -63,6 +63,9 @@ pub struct PromptCompositionConfig {
     pub additional_files: Vec<PathBuf>,
     pub additional_inline: Vec<String>,
     pub protected_resources: Vec<String>,
+    pub provider_guidance: Option<String>,
+    pub client_editing_guidance: Option<String>,
+    pub client_injections: Vec<ClientPromptFragment>,
 }
 
 impl Default for PromptCompositionConfig {
@@ -77,6 +80,9 @@ impl Default for PromptCompositionConfig {
                 ".env".to_string(),
                 ".envrc".to_string(),
             ],
+            provider_guidance: None,
+            client_editing_guidance: None,
+            client_injections: Vec::new(),
         }
     }
 }
@@ -104,6 +110,43 @@ impl PromptCompositionConfig {
     pub fn with_protected_resources(mut self, resources: Vec<String>) -> Self {
         self.protected_resources = resources;
         self
+    }
+
+    pub fn with_provider_guidance<S: Into<String>>(mut self, guidance: S) -> Self {
+        self.provider_guidance = Some(guidance.into());
+        self
+    }
+
+    pub fn with_client_editing_guidance<S: Into<String>>(mut self, guidance: S) -> Self {
+        self.client_editing_guidance = Some(guidance.into());
+        self
+    }
+
+    pub fn with_client_injections(mut self, fragments: Vec<ClientPromptFragment>) -> Self {
+        self.client_injections = fragments;
+        self
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ClientPromptFragment {
+    pub title: Option<String>,
+    pub markdown: String,
+}
+
+impl ClientPromptFragment {
+    pub fn new<S: Into<String>>(markdown: S) -> Self {
+        Self {
+            title: None,
+            markdown: markdown.into(),
+        }
+    }
+
+    pub fn titled<T: Into<String>, M: Into<String>>(title: T, markdown: M) -> Self {
+        Self {
+            title: Some(title.into()),
+            markdown: markdown.into(),
+        }
     }
 }
 

--- a/src/prompt/mod.rs
+++ b/src/prompt/mod.rs
@@ -3,12 +3,18 @@ pub mod baseline;
 pub mod config;
 pub mod repo_loader;
 pub mod runtime_context;
+pub mod system;
 
 pub use assembly::PromptAssembler;
 pub use baseline::BASELINE_PROMPT;
 pub use config::{
-    AdditionalInstructionFile, PromptCompositionConfig, RepoInstructionConfig,
-    RepoInstructionFamily, RepoInstructionPayload, RepoInstructionSource,
+    AdditionalInstructionFile, ClientPromptFragment, PromptCompositionConfig,
+    RepoInstructionConfig, RepoInstructionFamily, RepoInstructionPayload, RepoInstructionSource,
 };
 pub use repo_loader::RepoInstructionLoader;
 pub use runtime_context::RuntimeContextRenderer;
+pub use system::{
+    PromptSection, PromptSectionMetadata, PromptSectionOwner, PromptSectionTemperature,
+    SystemPromptCache, SystemPromptFingerprint, SystemPromptInputs, SystemPromptRenderer,
+    PROMPT_SECTION_ORDER,
+};

--- a/src/prompt/system.rs
+++ b/src/prompt/system.rs
@@ -1,0 +1,315 @@
+use crate::prompt::{ClientPromptFragment, RepoInstructionPayload};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PromptSection {
+    Identity,
+    StaticContext,
+    CoreGuidelines,
+    ToolPhilosophy,
+    EditingGuidelines,
+    Safety,
+    ProviderSpecificGuidance,
+    CommunicationFormatting,
+    ClientInjection,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PromptSectionOwner {
+    Core,
+    Provider,
+    Client,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PromptSectionTemperature {
+    Cold,
+    Warm,
+    Hot,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PromptSectionMetadata {
+    pub section: PromptSection,
+    pub title: &'static str,
+    pub owner: PromptSectionOwner,
+    pub temperature: PromptSectionTemperature,
+}
+
+pub const PROMPT_SECTION_ORDER: [PromptSection; 9] = [
+    PromptSection::Identity,
+    PromptSection::StaticContext,
+    PromptSection::CoreGuidelines,
+    PromptSection::ToolPhilosophy,
+    PromptSection::EditingGuidelines,
+    PromptSection::Safety,
+    PromptSection::ProviderSpecificGuidance,
+    PromptSection::CommunicationFormatting,
+    PromptSection::ClientInjection,
+];
+
+impl PromptSection {
+    pub fn metadata(self) -> PromptSectionMetadata {
+        match self {
+            PromptSection::Identity => PromptSectionMetadata {
+                section: self,
+                title: "Identity",
+                owner: PromptSectionOwner::Core,
+                temperature: PromptSectionTemperature::Cold,
+            },
+            PromptSection::StaticContext => PromptSectionMetadata {
+                section: self,
+                title: "Static Context",
+                owner: PromptSectionOwner::Core,
+                temperature: PromptSectionTemperature::Warm,
+            },
+            PromptSection::CoreGuidelines => PromptSectionMetadata {
+                section: self,
+                title: "Core Guidelines",
+                owner: PromptSectionOwner::Core,
+                temperature: PromptSectionTemperature::Cold,
+            },
+            PromptSection::ToolPhilosophy => PromptSectionMetadata {
+                section: self,
+                title: "Tool Philosophy",
+                owner: PromptSectionOwner::Core,
+                temperature: PromptSectionTemperature::Hot,
+            },
+            PromptSection::EditingGuidelines => PromptSectionMetadata {
+                section: self,
+                title: "Editing Guidelines",
+                owner: PromptSectionOwner::Client,
+                temperature: PromptSectionTemperature::Warm,
+            },
+            PromptSection::Safety => PromptSectionMetadata {
+                section: self,
+                title: "Safety & Destructive Actions",
+                owner: PromptSectionOwner::Core,
+                temperature: PromptSectionTemperature::Cold,
+            },
+            PromptSection::ProviderSpecificGuidance => PromptSectionMetadata {
+                section: self,
+                title: "Provider-Specific Guidance",
+                owner: PromptSectionOwner::Provider,
+                temperature: PromptSectionTemperature::Warm,
+            },
+            PromptSection::CommunicationFormatting => PromptSectionMetadata {
+                section: self,
+                title: "Communication & Formatting",
+                owner: PromptSectionOwner::Core,
+                temperature: PromptSectionTemperature::Cold,
+            },
+            PromptSection::ClientInjection => PromptSectionMetadata {
+                section: self,
+                title: "Client Injection",
+                owner: PromptSectionOwner::Client,
+                temperature: PromptSectionTemperature::Warm,
+            },
+        }
+    }
+}
+
+pub struct SystemPromptInputs<'a> {
+    pub baseline: &'a str,
+    pub runtime_context: &'a str,
+    pub repo_payload: &'a RepoInstructionPayload,
+    pub additional_inline: &'a [String],
+    pub session_instructions: Option<&'a str>,
+    pub skill_instructions: Option<&'a str>,
+    pub provider_guidance: Option<&'a str>,
+    pub client_editing_guidance: Option<&'a str>,
+    pub client_injections: &'a [ClientPromptFragment],
+    pub python_exec_available: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SystemPromptFingerprint(String);
+
+impl SystemPromptFingerprint {
+    pub fn from_inputs(inputs: &SystemPromptInputs<'_>) -> Self {
+        let mut value = String::new();
+        push_part(&mut value, inputs.baseline);
+        push_part(&mut value, inputs.runtime_context);
+        push_part(&mut value, &format!("{:?}", inputs.repo_payload));
+        push_part(&mut value, &format!("{:?}", inputs.additional_inline));
+        push_part(&mut value, inputs.session_instructions.unwrap_or_default());
+        push_part(&mut value, inputs.skill_instructions.unwrap_or_default());
+        push_part(&mut value, inputs.provider_guidance.unwrap_or_default());
+        push_part(
+            &mut value,
+            inputs.client_editing_guidance.unwrap_or_default(),
+        );
+        push_part(&mut value, &format!("{:?}", inputs.client_injections));
+        push_part(
+            &mut value,
+            if inputs.python_exec_available {
+                "1"
+            } else {
+                "0"
+            },
+        );
+        Self(value)
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct SystemPromptCache {
+    rendered: Option<String>,
+    fingerprint: Option<SystemPromptFingerprint>,
+}
+
+impl SystemPromptCache {
+    pub fn render(&mut self, inputs: &SystemPromptInputs<'_>) -> &str {
+        let fingerprint = SystemPromptFingerprint::from_inputs(inputs);
+        if self.fingerprint.as_ref() != Some(&fingerprint) {
+            self.rendered = Some(SystemPromptRenderer::render(inputs));
+            self.fingerprint = Some(fingerprint);
+        }
+
+        self.rendered.as_deref().unwrap_or_default()
+    }
+
+    pub fn invalidate_working_directory(&mut self) {
+        self.invalidate();
+    }
+
+    pub fn invalidate_provider_guidance(&mut self) {
+        self.invalidate();
+    }
+
+    pub fn invalidate_tool_availability(&mut self) {
+        self.invalidate();
+    }
+
+    pub fn invalidate(&mut self) {
+        self.rendered = None;
+        self.fingerprint = None;
+    }
+}
+
+pub struct SystemPromptRenderer;
+
+impl SystemPromptRenderer {
+    pub fn render(inputs: &SystemPromptInputs<'_>) -> String {
+        PROMPT_SECTION_ORDER
+            .iter()
+            .enumerate()
+            .map(|(idx, section)| Self::render_section(idx + 1, *section, inputs))
+            .collect::<Vec<_>>()
+            .join("\n\n")
+    }
+
+    fn render_section(
+        index: usize,
+        section: PromptSection,
+        inputs: &SystemPromptInputs<'_>,
+    ) -> String {
+        let meta = section.metadata();
+        let mut rendered = format!("## {}. {}\n", index, meta.title);
+        let body = match section {
+            PromptSection::Identity => render_identity(),
+            PromptSection::StaticContext => inputs.runtime_context.to_string(),
+            PromptSection::CoreGuidelines => render_core_guidelines(inputs.baseline),
+            PromptSection::ToolPhilosophy => render_tool_philosophy(inputs.python_exec_available),
+            PromptSection::EditingGuidelines => inputs
+                .client_editing_guidance
+                .filter(|s| !s.trim().is_empty())
+                .map(str::to_string)
+                .unwrap_or_else(render_default_editing_guidelines),
+            PromptSection::Safety => render_safety(),
+            PromptSection::ProviderSpecificGuidance => inputs
+                .provider_guidance
+                .filter(|s| !s.trim().is_empty())
+                .unwrap_or("No provider-specific guidance supplied.")
+                .to_string(),
+            PromptSection::CommunicationFormatting => render_communication_formatting(),
+            PromptSection::ClientInjection => render_client_injection(inputs),
+        };
+        rendered.push_str(body.trim());
+        rendered
+    }
+}
+
+fn render_identity() -> String {
+    "You are an AI coding agent powered by iron-core. Follow the core-owned instructions in this prompt and preserve the authority boundaries between core, provider, and client sections.".to_string()
+}
+
+fn render_core_guidelines(baseline: &str) -> String {
+    if baseline.trim().is_empty() {
+        "Work efficiently, verify changes where practical, and keep reasoning grounded in the available repository context.".to_string()
+    } else {
+        baseline.to_string()
+    }
+}
+
+fn render_tool_philosophy(python_exec_available: bool) -> String {
+    let mut text = String::from(
+        "Use tools deliberately. Prefer direct file/search tools for repository inspection and terminal commands for build, test, and package-manager operations.",
+    );
+    if python_exec_available {
+        text.push_str("\n\n`python_exec` is available for deterministic computation and safe orchestration of independent tool calls; use the exposed tools namespace rather than direct host filesystem or network access.");
+    } else {
+        text.push_str("\n\n`python_exec` is not currently available in the visible tool catalog.");
+    }
+    text
+}
+
+fn render_default_editing_guidelines() -> String {
+    "Make the smallest correct change, preserve existing style, and avoid modifying unrelated user work.".to_string()
+}
+
+fn render_safety() -> String {
+    "Do not perform destructive or irreversible actions unless explicitly requested. Never read or modify protected resources, credentials, or secrets unless the user has specifically authorized that exact action.".to_string()
+}
+
+fn render_communication_formatting() -> String {
+    "Communicate concisely. Report what changed, how it was verified, and any remaining risks or blockers.".to_string()
+}
+
+fn render_client_injection(inputs: &SystemPromptInputs<'_>) -> String {
+    let mut parts = Vec::new();
+    let repo = crate::prompt::PromptAssembler::render_repo_instructions(inputs.repo_payload);
+    if !repo.is_empty() {
+        parts.push(repo);
+    }
+
+    parts.extend(
+        inputs
+            .additional_inline
+            .iter()
+            .filter(|s| !s.is_empty())
+            .cloned(),
+    );
+
+    if let Some(instructions) = inputs.session_instructions.filter(|s| !s.is_empty()) {
+        parts.push(instructions.to_string());
+    }
+
+    if let Some(skills) = inputs.skill_instructions.filter(|s| !s.is_empty()) {
+        parts.push(skills.to_string());
+    }
+
+    for fragment in inputs.client_injections {
+        if fragment.markdown.trim().is_empty() {
+            continue;
+        }
+        let mut rendered = String::new();
+        if let Some(title) = fragment.title.as_ref().filter(|s| !s.trim().is_empty()) {
+            rendered.push_str(&format!("### {}\n", title));
+        }
+        rendered.push_str(&fragment.markdown);
+        parts.push(rendered);
+    }
+
+    if parts.is_empty() {
+        "No client injection supplied.".to_string()
+    } else {
+        parts.join("\n\n")
+    }
+}
+
+fn push_part(target: &mut String, value: &str) {
+    target.push_str(&value.len().to_string());
+    target.push(':');
+    target.push_str(value);
+    target.push('|');
+}

--- a/src/request_builder.rs
+++ b/src/request_builder.rs
@@ -4,7 +4,7 @@ use crate::{
     error::RuntimeError,
     tool::ToolRegistry,
 };
-use iron_providers::{InferenceRequest, Message, ToolPolicy};
+use iron_providers::{InferenceRequest, Message, ProviderRegistry, ToolPolicy};
 
 pub struct EffectiveToolRequestContext<'a> {
     pub compacted_context: Option<&'a CompactedContext>,
@@ -205,14 +205,36 @@ fn build_composed_instructions(
         python_exec_available,
     );
 
-    crate::prompt::PromptAssembler::assemble(
+    let provider_guidance = resolve_provider_guidance(config);
+
+    crate::prompt::SystemPromptRenderer::render(&crate::prompt::SystemPromptInputs {
         baseline,
-        &repo_payload,
-        &config.prompt_composition.additional_inline,
+        runtime_context: &runtime_context,
+        repo_payload: &repo_payload,
+        additional_inline: &config.prompt_composition.additional_inline,
         session_instructions,
         skill_instructions,
-        &runtime_context,
-    )
+        provider_guidance: provider_guidance.as_deref(),
+        client_editing_guidance: config.prompt_composition.client_editing_guidance.as_deref(),
+        client_injections: &config.prompt_composition.client_injections,
+        python_exec_available,
+    })
+}
+
+/// Resolve provider-specific guidance from `iron-providers` when a provider name
+/// is configured, falling back to the manually set `provider_guidance` in
+/// `PromptCompositionConfig`.
+fn resolve_provider_guidance(config: &Config) -> Option<String> {
+    if let Some(ref name) = config.provider_name {
+        let registry = ProviderRegistry::default();
+        match registry.system_prompt_fragment(name) {
+            Ok(fragment) => return Some(fragment.to_string()),
+            Err(_) => {
+                // Unknown provider name — fall through to manual guidance
+            }
+        }
+    }
+    config.prompt_composition.provider_guidance.clone()
 }
 
 fn apply_context_window_policy(

--- a/tests/prompt_composition_tests.rs
+++ b/tests/prompt_composition_tests.rs
@@ -2,12 +2,42 @@ use iron_core::{
     config::Config,
     prompt::config::PromptCompositionConfig,
     prompt::{
-        AdditionalInstructionFile, PromptAssembler, RepoInstructionConfig, RepoInstructionFamily,
-        RepoInstructionLoader, RepoInstructionPayload, RepoInstructionSource,
-        RuntimeContextRenderer,
+        AdditionalInstructionFile, ClientPromptFragment, PromptAssembler, PromptSectionOwner,
+        RepoInstructionConfig, RepoInstructionFamily, RepoInstructionLoader,
+        RepoInstructionPayload, RepoInstructionSource, RuntimeContextRenderer, SystemPromptCache,
+        SystemPromptInputs, SystemPromptRenderer, PROMPT_SECTION_ORDER,
     },
 };
+use iron_providers::Message;
 use std::path::PathBuf;
+
+fn section_position(prompt: &str, title: &str) -> usize {
+    prompt
+        .find(title)
+        .unwrap_or_else(|| panic!("missing section title: {title}"))
+}
+
+fn render_system_prompt<'a>(
+    payload: &'a RepoInstructionPayload,
+    runtime_context: &'a str,
+    provider_guidance: Option<&'a str>,
+    client_editing_guidance: Option<&'a str>,
+    client_injections: &'a [ClientPromptFragment],
+    python_exec_available: bool,
+) -> String {
+    SystemPromptRenderer::render(&SystemPromptInputs {
+        baseline: "BASELINE",
+        runtime_context,
+        repo_payload: payload,
+        additional_inline: &[],
+        session_instructions: None,
+        skill_instructions: None,
+        provider_guidance,
+        client_editing_guidance,
+        client_injections,
+        python_exec_available,
+    })
+}
 
 fn make_source(filename: &str, content: &str) -> RepoInstructionSource {
     RepoInstructionSource {
@@ -25,77 +55,117 @@ fn make_additional(path: &str, content: &str) -> AdditionalInstructionFile {
 }
 
 #[test]
-fn prompt_layer_ordering_baseline_first() {
+fn prompt_section_ordering_is_fixed() {
     let payload = RepoInstructionPayload::default();
-    let result =
-        PromptAssembler::assemble("BASELINE", &payload, &[], Some("SESSION"), None, "RUNTIME");
-    let baseline_pos = result.find("BASELINE").unwrap();
-    let session_pos = result.find("SESSION").unwrap();
-    let runtime_pos = result.find("RUNTIME").unwrap();
-    assert!(baseline_pos < session_pos);
-    assert!(session_pos < runtime_pos);
+    let result = render_system_prompt(&payload, "RUNTIME", None, None, &[], false);
+
+    let mut last = 0;
+    for (idx, section) in PROMPT_SECTION_ORDER.iter().enumerate() {
+        let title = format!("## {}. {}", idx + 1, section.metadata().title);
+        let pos = section_position(&result, &title);
+        assert!(pos >= last, "section out of order: {title}");
+        last = pos;
+    }
 }
 
 #[test]
-fn prompt_layer_ordering_repo_between_baseline_and_session() {
+fn prompt_section_metadata_declares_expected_owners() {
+    assert_eq!(PROMPT_SECTION_ORDER.len(), 9);
+    assert_eq!(
+        PROMPT_SECTION_ORDER[0].metadata().owner,
+        PromptSectionOwner::Core
+    );
+    assert_eq!(
+        PROMPT_SECTION_ORDER[6].metadata().owner,
+        PromptSectionOwner::Provider
+    );
+    assert_eq!(
+        PROMPT_SECTION_ORDER[8].metadata().owner,
+        PromptSectionOwner::Client
+    );
+}
+
+#[test]
+fn prompt_preserves_repo_and_session_content_inside_client_injection() {
     let payload = RepoInstructionPayload {
         sources: vec![make_source("AGENTS.md", "repo content")],
         additional_files: vec![],
     };
-    let result =
-        PromptAssembler::assemble("BASELINE", &payload, &[], Some("SESSION"), None, "RUNTIME");
-    let baseline_pos = result.find("BASELINE").unwrap();
-    let repo_pos = result.find("repo content").unwrap();
-    let session_pos = result.find("SESSION").unwrap();
-    let runtime_pos = result.find("RUNTIME").unwrap();
-    assert!(baseline_pos < repo_pos);
-    assert!(repo_pos < session_pos);
-    assert!(session_pos < runtime_pos);
-}
+    let result = SystemPromptRenderer::render(&SystemPromptInputs {
+        baseline: "BASELINE",
+        runtime_context: "RUNTIME",
+        repo_payload: &payload,
+        additional_inline: &["INLINE".to_string()],
+        session_instructions: Some("SESSION"),
+        skill_instructions: Some("SKILLS"),
+        provider_guidance: None,
+        client_editing_guidance: None,
+        client_injections: &[],
+        python_exec_available: false,
+    });
 
-#[test]
-fn prompt_layer_ordering_inline_between_repo_and_session() {
-    let payload = RepoInstructionPayload::default();
-    let result = PromptAssembler::assemble(
-        "BASELINE",
-        &payload,
-        &["INLINE".to_string()],
-        Some("SESSION"),
-        None,
-        "RUNTIME",
-    );
-    let baseline_pos = result.find("BASELINE").unwrap();
+    let client_pos = section_position(&result, "## 9. Client Injection");
+    let repo_pos = result.find("repo content").unwrap();
     let inline_pos = result.find("INLINE").unwrap();
     let session_pos = result.find("SESSION").unwrap();
-    assert!(baseline_pos < inline_pos);
+    let skill_pos = result.find("SKILLS").unwrap();
+    assert!(client_pos < repo_pos);
+    assert!(repo_pos < inline_pos);
     assert!(inline_pos < session_pos);
-}
-
-#[test]
-fn prompt_layer_ordering_skills_between_session_and_runtime() {
-    let payload = RepoInstructionPayload::default();
-    let result = PromptAssembler::assemble(
-        "BASELINE",
-        &payload,
-        &[],
-        Some("SESSION"),
-        Some("<skill_content name=\"review\">\nUse the review checklist\n</skill_content>"),
-        "RUNTIME",
-    );
-    let session_pos = result.find("SESSION").unwrap();
-    let skill_pos = result.find("<skill_content name=\"review\">").unwrap();
-    let runtime_pos = result.find("RUNTIME").unwrap();
     assert!(session_pos < skill_pos);
-    assert!(skill_pos < runtime_pos);
 }
 
 #[test]
-fn absent_layers_omitted() {
+fn provider_guidance_only_appears_in_provider_section() {
     let payload = RepoInstructionPayload::default();
-    let result = PromptAssembler::assemble("BASELINE", &payload, &[], None, None, "");
-    assert!(result.contains("BASELINE"));
-    assert!(!result.contains("<repository_instructions>"));
-    assert!(!result.contains("<runtime_context>"));
+    let result = render_system_prompt(
+        &payload,
+        "RUNTIME",
+        Some("provider fragment"),
+        None,
+        &[],
+        false,
+    );
+    let provider_pos = section_position(&result, "## 7. Provider-Specific Guidance");
+    let communication_pos = section_position(&result, "## 8. Communication & Formatting");
+    let fragment_pos = result.find("provider fragment").unwrap();
+    assert!(provider_pos < fragment_pos);
+    assert!(fragment_pos < communication_pos);
+}
+
+#[test]
+fn client_editing_guidance_overrides_fallback_without_overriding_core() {
+    let payload = RepoInstructionPayload::default();
+    let fallback = render_system_prompt(&payload, "RUNTIME", None, None, &[], false);
+    assert!(fallback.contains("Make the smallest correct change"));
+
+    let custom = render_system_prompt(
+        &payload,
+        "RUNTIME",
+        None,
+        Some("client edit policy"),
+        &[],
+        false,
+    );
+    assert!(custom.contains("client edit policy"));
+    assert!(!custom.contains("Make the smallest correct change"));
+    assert!(custom.contains("## 1. Identity"));
+    assert!(custom.contains("## 6. Safety & Destructive Actions"));
+}
+
+#[test]
+fn client_injection_fragments_render_in_order() {
+    let payload = RepoInstructionPayload::default();
+    let fragments = vec![
+        ClientPromptFragment::titled("First", "alpha"),
+        ClientPromptFragment::new("beta"),
+    ];
+    let result = render_system_prompt(&payload, "RUNTIME", None, None, &fragments, false);
+    let first_pos = result.find("### First").unwrap();
+    let alpha_pos = result.find("alpha").unwrap();
+    let beta_pos = result.find("beta").unwrap();
+    assert!(first_pos < alpha_pos);
+    assert!(alpha_pos < beta_pos);
 }
 
 #[test]
@@ -143,6 +213,9 @@ fn prompt_composition_config_defaults() {
     assert!(config.repo_instructions.enabled);
     assert!(config.additional_files.is_empty());
     assert!(config.additional_inline.is_empty());
+    assert!(config.provider_guidance.is_none());
+    assert!(config.client_editing_guidance.is_none());
+    assert!(config.client_injections.is_empty());
     assert!(config.protected_resources.contains(&".git".to_string()));
     assert!(config.protected_resources.contains(&".ssh".to_string()));
     assert!(config.protected_resources.contains(&".env".to_string()));
@@ -303,7 +376,7 @@ fn baseline_prompt_describes_sandbox_boundary() {
 fn request_builder_composes_instructions() {
     let config = Config::default();
     let registry = iron_core::ToolRegistry::new();
-    let messages: Vec<iron_providers::Message> = vec![];
+    let messages: Vec<Message> = vec![];
     let result = iron_core::request_builder::build_inference_request(
         &config,
         &messages,
@@ -377,11 +450,24 @@ fn prompt_composition_builder_chaining() {
     let config = PromptCompositionConfig::new()
         .with_repo_instructions(RepoInstructionConfig::new().with_enabled(false))
         .with_additional_inline(vec!["inline block".to_string()])
-        .with_protected_resources(vec![".secret".to_string()]);
+        .with_protected_resources(vec![".secret".to_string()])
+        .with_provider_guidance("provider guidance")
+        .with_client_editing_guidance("client editing")
+        .with_client_injections(vec![ClientPromptFragment::titled("Client", "markdown")]);
 
     assert!(!config.repo_instructions.enabled);
     assert_eq!(config.additional_inline, vec!["inline block"]);
     assert_eq!(config.protected_resources, vec![".secret"]);
+    assert_eq!(
+        config.provider_guidance.as_deref(),
+        Some("provider guidance")
+    );
+    assert_eq!(
+        config.client_editing_guidance.as_deref(),
+        Some("client editing")
+    );
+    assert_eq!(config.client_injections[0].title.as_deref(), Some("Client"));
+    assert_eq!(config.client_injections[0].markdown, "markdown");
 }
 
 #[test]
@@ -437,7 +523,7 @@ fn runtime_context_falls_back_to_current_dir_when_no_roots() {
 fn request_builder_uses_configured_workspace_roots() {
     let config = Config::default().with_workspace_roots(vec![PathBuf::from("/configured/root")]);
     let registry = iron_core::ToolRegistry::new();
-    let messages: Vec<iron_providers::Message> = vec![];
+    let messages: Vec<Message> = vec![];
     let result = iron_core::request_builder::build_inference_request(
         &config,
         &messages,
@@ -456,5 +542,167 @@ fn request_builder_uses_configured_workspace_roots() {
         instr.contains("Workspace root: /configured/root"),
         "request builder should pass workspace roots, got: {}",
         instr
+    );
+}
+
+#[test]
+fn request_builder_uses_sectioned_system_prompt() {
+    let prompt_config = PromptCompositionConfig::default()
+        .with_provider_guidance("provider guidance")
+        .with_client_editing_guidance("client editing")
+        .with_client_injections(vec![ClientPromptFragment::new("client fragment")]);
+    let config = Config::default().with_prompt_composition(prompt_config);
+    let registry = iron_core::ToolRegistry::new();
+    let messages: Vec<Message> = vec![];
+    let req = iron_core::request_builder::build_inference_request(
+        &config,
+        &messages,
+        Some("session instructions"),
+        &registry,
+    )
+    .unwrap();
+    let instr = req.instructions.unwrap();
+    assert!(instr.contains("## 1. Identity"));
+    assert!(instr.contains("## 7. Provider-Specific Guidance"));
+    assert!(instr.contains("provider guidance"));
+    assert!(instr.contains("client editing"));
+    assert!(instr.contains("client fragment"));
+    assert!(instr.contains("session instructions"));
+}
+
+#[test]
+fn system_prompt_cache_reuses_output_until_inputs_change_or_invalidate() {
+    let payload = RepoInstructionPayload::default();
+    let mut cache = SystemPromptCache::default();
+    let first = cache
+        .render(&SystemPromptInputs {
+            baseline: "BASELINE",
+            runtime_context: "Working directory: /one",
+            repo_payload: &payload,
+            additional_inline: &[],
+            session_instructions: None,
+            skill_instructions: None,
+            provider_guidance: None,
+            client_editing_guidance: None,
+            client_injections: &[],
+            python_exec_available: false,
+        })
+        .to_string();
+    let second = cache
+        .render(&SystemPromptInputs {
+            baseline: "BASELINE",
+            runtime_context: "Working directory: /one",
+            repo_payload: &payload,
+            additional_inline: &[],
+            session_instructions: None,
+            skill_instructions: None,
+            provider_guidance: None,
+            client_editing_guidance: None,
+            client_injections: &[],
+            python_exec_available: false,
+        })
+        .to_string();
+    assert_eq!(first, second);
+
+    let changed = cache
+        .render(&SystemPromptInputs {
+            baseline: "BASELINE",
+            runtime_context: "Working directory: /two",
+            repo_payload: &payload,
+            additional_inline: &[],
+            session_instructions: None,
+            skill_instructions: None,
+            provider_guidance: None,
+            client_editing_guidance: None,
+            client_injections: &[],
+            python_exec_available: false,
+        })
+        .to_string();
+    assert_ne!(first, changed);
+
+    cache.invalidate_working_directory();
+    let after_invalidate = cache
+        .render(&SystemPromptInputs {
+            baseline: "BASELINE",
+            runtime_context: "Working directory: /two",
+            repo_payload: &payload,
+            additional_inline: &[],
+            session_instructions: None,
+            skill_instructions: None,
+            provider_guidance: None,
+            client_editing_guidance: None,
+            client_injections: &[],
+            python_exec_available: false,
+        })
+        .to_string();
+    assert_eq!(changed, after_invalidate);
+}
+
+#[test]
+fn tool_availability_updates_tool_philosophy() {
+    let payload = RepoInstructionPayload::default();
+    let without_python = render_system_prompt(&payload, "RUNTIME", None, None, &[], false);
+    let with_python = render_system_prompt(&payload, "RUNTIME", None, None, &[], true);
+    assert!(without_python.contains("`python_exec` is not currently available"));
+    assert!(with_python.contains("`python_exec` is available"));
+}
+
+#[test]
+fn provider_name_resolves_fragment_from_iron_providers_registry() {
+    let config = Config::default()
+        .with_provider_name("anthropic")
+        .with_model("claude-3-5-sonnet");
+    let registry = iron_core::ToolRegistry::new();
+    let messages: Vec<Message> = vec![];
+    let req =
+        iron_core::request_builder::build_inference_request(&config, &messages, None, &registry)
+            .unwrap();
+    let instr = req.instructions.unwrap();
+    assert!(
+        instr.contains("## 7. Provider-Specific Guidance"),
+        "provider section should exist"
+    );
+    assert!(
+        instr.contains("Anthropic Messages API"),
+        "should include resolved anthropic fragment"
+    );
+}
+
+#[test]
+fn provider_name_unknown_falls_back_to_manual_guidance() {
+    let prompt_config =
+        PromptCompositionConfig::default().with_provider_guidance("manual provider guidance");
+    let config = Config::default()
+        .with_provider_name("nonexistent-provider")
+        .with_prompt_composition(prompt_config);
+    let registry = iron_core::ToolRegistry::new();
+    let messages: Vec<Message> = vec![];
+    let req =
+        iron_core::request_builder::build_inference_request(&config, &messages, None, &registry)
+            .unwrap();
+    let instr = req.instructions.unwrap();
+    assert!(instr.contains("manual provider guidance"));
+}
+
+#[test]
+fn provider_name_overrides_manual_provider_guidance() {
+    let prompt_config = PromptCompositionConfig::default()
+        .with_provider_guidance("manual guidance that should be ignored");
+    let config = Config::default()
+        .with_provider_name("anthropic")
+        .with_prompt_composition(prompt_config);
+    let registry = iron_core::ToolRegistry::new();
+    let messages: Vec<Message> = vec![];
+    let req =
+        iron_core::request_builder::build_inference_request(&config, &messages, None, &registry)
+            .unwrap();
+    let instr = req.instructions.unwrap();
+    assert!(
+        !instr.contains("manual guidance that should be ignored"),
+        "registry fragment should override manual guidance"
+    );
+    assert!(
+        instr.contains("Anthropic Messages API"),
+        "should include resolved anthropic fragment"
     );
 }


### PR DESCRIPTION
## Summary
- Adds OpenSpec artifacts and a fixed nine-section system prompt model with explicit core/provider/client ownership metadata.
- Adds provider, client editing, and client injection prompt inputs, including provider fragment lookup through `iron-providers` 0.1.8.
- Updates request building and prompt composition tests for section ordering, ownership boundaries, provider fragment isolation, client guidance, and cache primitives.

## Verification
- `cargo fmt --manifest-path Cargo.toml -- --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked`
- `cargo check --locked`

Closes #14