### PR TITLE
fix(mcp): parse streamable HTTP SSE responses

### DIFF
--- a/src/mcp/client.rs
+++ b/src/mcp/client.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use futures::StreamExt;
+use reqwest::header::CONTENT_TYPE;
 use serde_json::Value;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, ChildStdin, ChildStdout, Command};
@@ -36,6 +37,66 @@ fn apply_headers(
         }
     }
     builder
+}
+
+async fn decode_http_rpc_response(response: reqwest::Response) -> Result<JsonRpcResponse, String> {
+    let content_type = response
+        .headers()
+        .get(CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+
+    if content_type
+        .split(';')
+        .any(|part| part.trim() == "text/event-stream")
+    {
+        let body = response
+            .text()
+            .await
+            .map_err(|e| format!("Failed to read SSE response body: {}", e))?;
+        return parse_sse_rpc_response(&body);
+    }
+
+    response
+        .json()
+        .await
+        .map_err(|e| format!("Failed to parse JSON response: {}", e))
+}
+
+fn parse_sse_rpc_response(body: &str) -> Result<JsonRpcResponse, String> {
+    let normalized = body.replace("\r\n", "\n").replace('\r', "\n");
+
+    for event_block in normalized.split("\n\n") {
+        let mut event_type: Option<&str> = None;
+        let mut data_lines = Vec::new();
+
+        for line in event_block.lines() {
+            if line.starts_with(':') || line.is_empty() {
+                continue;
+            }
+
+            if let Some(rest) = line.strip_prefix("event:") {
+                event_type = Some(rest.trim_start());
+                continue;
+            }
+
+            if let Some(rest) = line.strip_prefix("data:") {
+                data_lines.push(rest.trim_start());
+            }
+        }
+
+        if data_lines.is_empty() || matches!(event_type, Some("ping" | "keepalive")) {
+            continue;
+        }
+
+        let payload = data_lines.join("\n");
+        if let Ok(response) = serde_json::from_str(&payload) {
+            return Ok(response);
+        }
+    }
+
+    Err("Failed to parse SSE response: no JSON-RPC data event found".to_string())
 }
 
 /// Type alias for the pending-response waiter map shared across stdio client tasks.
@@ -666,10 +727,7 @@ impl HttpMcpClient {
             .await
             .map_err(|e| format!("HTTP request failed: {}", e))?;
 
-        let rpc_response: JsonRpcResponse = response
-            .json()
-            .await
-            .map_err(|e| format!("Failed to parse JSON response: {}", e))?;
+        let rpc_response = decode_http_rpc_response(response).await?;
 
         if rpc_response.id != Some(id) {
             // During bootstrap (initialize), some MCP servers return a

--- a/tests/mcp_integration_tests.rs
+++ b/tests/mcp_integration_tests.rs
@@ -1060,6 +1060,103 @@ async fn start_bootstrap_tolerance_http_server(
     port
 }
 
+async fn start_streamable_http_server() -> u16 {
+    use tokio::io::AsyncWriteExt;
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+
+    tokio::spawn(async move {
+        loop {
+            let (mut socket, _) = match listener.accept().await {
+                Ok(s) => s,
+                Err(_) => continue,
+            };
+            tokio::spawn(async move {
+                let (_request_line, _headers, body) =
+                    read_http_request_with_body(&mut socket).await;
+
+                let request: serde_json::Value = serde_json::from_slice(&body).unwrap();
+                let method = request
+                    .get("method")
+                    .and_then(|value| value.as_str())
+                    .expect("request should include method");
+                let request_id = request.get("id").and_then(|value| value.as_u64());
+
+                let response = match method {
+                    "initialize" => serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "id": request_id,
+                        "result": {
+                            "protocolVersion": "2024-11-05",
+                            "capabilities": {"tools": {"listChanged": true}},
+                            "serverInfo": {"name": "streamable-http", "version": "1.0"}
+                        }
+                    }),
+                    "tools/list" => serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "id": request_id,
+                        "result": {
+                            "tools": [{
+                                "name": "streamable_tool",
+                                "description": "Streamable HTTP tool",
+                                "inputSchema": {"type": "object", "properties": {}}
+                            }]
+                        }
+                    }),
+                    other => serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "id": request_id,
+                        "error": {"code": -32601, "message": format!("unknown method: {}", other)}
+                    }),
+                };
+
+                let sse_body = format!("event: message\r\ndata: {}\r\n\r\n", response);
+                let http_response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nContent-Length: {}\r\n\r\n{}",
+                    sse_body.len(),
+                    sse_body
+                );
+                let _ = socket.write_all(http_response.as_bytes()).await;
+            });
+        }
+    });
+
+    port
+}
+
+#[tokio::test]
+async fn test_http_mcp_client_parses_streamable_http_sse_response() {
+    let port = start_streamable_http_server().await;
+
+    let config = McpServerConfig {
+        id: "streamable-http".to_string(),
+        label: "Streamable HTTP".to_string(),
+        transport: McpTransport::Http {
+            config: HttpConfig::new(format!("http://127.0.0.1:{}", port)),
+        },
+        enabled_by_default: true,
+        working_dir: None,
+    };
+
+    let client = iron_core::mcp::create_transport_client("streamable-http", &config)
+        .expect("client creation");
+
+    let initialize = client.initialize().await;
+    assert!(
+        initialize.is_ok(),
+        "initialize should parse SSE response: {:?}",
+        initialize
+    );
+
+    let tools = client
+        .list_tools()
+        .await
+        .expect("tools/list should succeed");
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].name, "streamable_tool");
+}
+
 #[tokio::test]
 async fn test_http_mcp_client_initialize_accepts_absent_response_id() {
     let port = start_bootstrap_tolerance_http_server(


### PR DESCRIPTION
## Summary
- Decode `text/event-stream` responses from HTTP MCP POST requests by extracting JSON-RPC payloads from SSE `data:` frames.
- Preserve existing JSON response handling for non-SSE HTTP MCP servers.
- Add a regression test covering Streamable HTTP initialize and `tools/list` responses.

## Testing
- `cargo fmt --check`
- `cargo test test_http_mcp_client_parses_streamable_http_sse_response`
- `cargo test --test mcp_integration_tests`

Closes #16