### PR TITLE
Add OAuth provider credential orchestration (Issue 18)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1028,9 +1028,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
  "const-oid",
@@ -1644,9 +1644,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2116,12 +2116,13 @@ dependencies = [
 
 [[package]]
 name = "iron-providers"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51edc31e3e112a6509915bbdfc547443fa81e13b5d5aec03382d7f9c1286f101"
+checksum = "249c2e3de6105548244f4f689f6803efebefd07c39eaf3f39115ef4c54cc3427"
 dependencies = [
  "async-openai",
  "async-stream",
+ "base64",
  "futures",
  "pin-project",
  "reqwest",
@@ -2276,9 +2277,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.46.3"
+version = "0.46.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbe92a2f8b00686061eab5cdcfd6f382c27f2084456e7be90ae9f0fe4a30552a"
+checksum = "fc59d2432e047d6090ba1d83c782d0128bd6203857978218f5614dbd3287281f"
 dependencies = [
  "ahash",
  "bytecount",
@@ -3243,9 +3244,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.46.3"
+version = "0.46.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e125f10bdcd507598c702daada18c47fe5bfba4d7a9545b015b5d432f7168ca3"
+checksum = "cb674900ca31acd75c4aaf63f48e43e719631c0539ea5a9e64163d1296bcb730"
 dependencies = [
  "ahash",
  "fluent-uri",
@@ -3363,9 +3364,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67d69668de0b0ccd9cc435f700f3b39a7861863cf37a15e1f304ea78688a4826"
+checksum = "e12ca9067b5ebfbd5b3fcdc4acfceb81aa7d5ab2a879dff7cb75d22434276aad"
 dependencies = [
  "async-trait",
  "base64",
@@ -3385,9 +3386,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48fdc01c81097b0aed18633e676e269fefa3a78ec1df56b4fe597c1241b92025"
+checksum = "7caa6743cc0888e433105fe1bc551a7f607940b126a37bc97b478e86064627eb"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -3818,9 +3819,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.18.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "f05839ce67618e14a09b286535c0d9c94e85ef25469b0e13cb4f844e5593eb19"
 dependencies = [
  "base64",
  "chrono",
@@ -3837,9 +3838,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.18.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+checksum = "cf2ebbe86054f9b45bc3881e865683ccfaccce97b9b4cb53f3039d67f355a334"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -3879,7 +3880,7 @@ checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3931,9 +3932,9 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "sized-chunks"
@@ -4265,9 +4266,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
 dependencies = [
  "bytes",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
 ]
 
 [dependencies]
-iron-providers = "0.1.8"
+iron-providers = "0.1.9"
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["compat"] }
 serde = { version = "1", features = ["derive"] }

--- a/openspec/changes/provider-oauth-credential-orchestration/.openspec.yaml
+++ b/openspec/changes/provider-oauth-credential-orchestration/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-06

--- a/openspec/changes/provider-oauth-credential-orchestration/design.md
+++ b/openspec/changes/provider-oauth-credential-orchestration/design.md
@@ -1,0 +1,101 @@
+## Context
+
+`iron-core` currently receives an already-built provider through `IronAgent::new(config, provider)` and stores it as a static `Arc<dyn Provider>`. Prompt execution calls that provider directly, so core has no opportunity to resolve current credentials, refresh OAuth tokens, rebuild provider runtime configuration, or retry provider auth failures.
+
+`iron-providers` now exposes credential-aware runtime construction through `ProviderCredential`, `CredentialKind`, `RuntimeConfig::from_credential`, provider profile credential metadata, and built-in profiles for OAuth-capable `kimi-code` and OAuth-only `codex`. It intentionally does not own login UX, refresh-token storage, refresh lifecycle, or provider auth retry.
+
+AgentIron currently stores provider API keys in its own SQLite settings data, while `iron-tui` reads API keys from flags or environment variables. This change should not move those storage policies into `iron-core`; core needs an abstraction so clients own persistence and can later choose stronger storage without changing the orchestration API.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Resolve provider credentials per prompt from app-supplied provider/model context.
+- Support one OAuth credential per provider slug for V1.
+- Keep provider selection and credential persistence owned by clients.
+- Let `iron-core` own OAuth provider metadata, device-code exchange helpers, refresh lifecycle, provider auth status, credential resolution, provider construction, and safe retry orchestration.
+- Preserve existing injected-provider and API-key behavior.
+- Support `kimi-code` OAuth device-code credentials and `codex` OpenAI device-code credentials.
+- Pass only `iron_providers::ProviderCredential::OAuthBearer` access-token material, expiry, and optional ID token into `iron-providers`.
+
+**Non-Goals:**
+- Moving existing AgentIron API-key storage into the new provider credential store.
+- Making `iron-core` responsible for SQLite, OS keyring, encryption, or secure storage policy.
+- Supporting multiple accounts or multiple credentials per provider.
+- Implementing browser redirect OAuth in V1.
+- Performing remote token revocation on disconnect.
+- Reusing plugin auth state/storage directly for provider credentials.
+
+## Decisions
+
+### Split OAuth ownership between clients and core
+Clients own UX, provider/model selection, persistence backend, and rendering connect/disconnect flows. `iron-core` owns provider OAuth metadata, device-code token exchange helpers, refresh, status derivation, credential resolution, provider construction, and retry orchestration.
+
+This is preferable to app-only OAuth because refresh and retry behavior would otherwise be duplicated across AgentIron and `iron-tui`. It is preferable to core-owned UX because terminal and desktop clients need different interaction surfaces.
+
+### Use an app-supplied provider credential store abstraction
+Introduce a core trait or equivalent boundary for reading, writing, listing, and removing provider OAuth credentials by provider slug. AgentIron can back this with SQLite for V1, but that implementation remains client-owned. Future OS keyring storage is a client concern behind the same boundary.
+
+This keeps long-lived provider secret storage out of normal `Config` and avoids declaring SQLite to be secure storage. Existing AgentIron API-key settings remain unchanged for this change.
+
+### Resolve credentials per prompt
+The managed provider path should accept app-supplied provider/model context for each prompt or request. Credential resolution happens at prompt execution time, not only when a session is constructed, so OAuth expiry and refresh are handled before each provider call.
+
+This is preferable to a globally selected provider in `iron-core` because provider selection is application-owned. It is preferable to a one-time session provider construction because `iron-providers` bakes auth headers into the HTTP client at construction time.
+
+### Keep injected-provider compatibility
+The current `IronAgent::new(config, provider)` path remains valid for callers that construct providers themselves. The new managed-provider path is additive and uses `iron-providers` registry/profile construction only when the client opts into core credential orchestration.
+
+This avoids breaking existing API-key users and tests while allowing AgentIron to adopt provider credential orchestration incrementally.
+
+### Prefer API keys over OAuth for dual-mode providers
+For providers that support both API key and OAuth, such as `kimi-code`, API-key configuration wins when both credential modes are available. OAuth is used only when no API key is available for that provider.
+
+This preserves existing behavior and avoids surprising users who already configured API keys.
+
+### Model provider auth statuses explicitly
+Expose a minimal client-visible provider auth status set:
+- `NotConfigured`
+- `ConfiguredApiKey`
+- `ConnectedOAuth { expires_at }`
+- `Refreshing`
+- `Expired`
+- `RefreshFailed { reason }`
+- `Revoked`
+- `UnsupportedCredential`
+
+These statuses are provider-credential statuses, not plugin auth statuses. They may use similar vocabulary, but they belong to inference provider execution.
+
+### Refresh five minutes before expiry
+OAuth credentials with an expiry should be refreshed when expired or within five minutes of expiry. The margin can be internal for V1 rather than a public configuration option.
+
+This avoids starting provider requests with tokens that are likely to expire mid-request.
+
+### Retry only safe OAuth auth failures
+After a provider auth failure, core may force-refresh an OAuth credential and retry exactly once. Retry is allowed only when the request has not emitted streaming output yet. API-key credentials are not retried through refresh.
+
+This avoids hiding repeated auth failures, avoids duplicate partial streaming output, and keeps provider-specific 401 recovery out of `iron-providers`.
+
+### Preserve optional Codex ID token routing metadata
+When OpenAI auth returns an ID token for Codex, core stores it with OAuth credential material and passes it to `iron-providers` as part of `OAuthBearer`. `iron-providers` can derive `chatgpt-account-id` routing metadata from it. Missing ID token does not prevent credential use, but Codex auth/routing errors should mention missing ID token when relevant.
+
+This treats the ID token as optional routing metadata while still preserving it when available.
+
+## Risks / Trade-offs
+
+- [Client-owned storage can be less secure than OS keyring] -> Keep storage behind a core abstraction and document that SQLite is an AgentIron V1 policy, not secure storage guaranteed by `iron-core`.
+- [Per-prompt provider construction may add overhead] -> Build the simplest correct path first; only cache provider instances later if profiling shows a real cost and cache invalidation remains tied to credential expiry.
+- [Retrying auth failures can duplicate side effects] -> Retry only before stream output is emitted and only once after forced OAuth refresh.
+- [OpenAI/Codex auth behavior may require ID-token/account routing details] -> Store/pass ID token when returned and surface targeted Codex auth/routing errors if it is absent.
+- [Plugin auth and provider auth terminology can blur] -> Keep provider credential modules and types separate from plugin auth storage and state.
+
+## Migration Plan
+
+- Add provider credential domain types, store/refresher traits, and OAuth provider metadata without changing the existing injected-provider path.
+- Add managed provider execution APIs that accept provider/model context per prompt and use the credential resolver before provider construction.
+- Update AgentIron or test clients to provide a credential store implementation separately from existing API-key settings.
+- Preserve current API-key tests and add OAuth resolver/refresh/retry tests around the managed-provider path.
+- Keep rollback simple by leaving the existing injected-provider path available.
+
+## Open Questions
+
+- Should provider OAuth metadata remain hardcoded in `iron-core` after V1, or should a future non-secret metadata contract be added near provider profiles without moving refresh-token handling into `iron-providers`?

--- a/openspec/changes/provider-oauth-credential-orchestration/proposal.md
+++ b/openspec/changes/provider-oauth-credential-orchestration/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+`iron-core` currently receives a fully constructed provider and has no runtime-owned path for resolving, refreshing, or retrying OAuth-backed provider credentials. This blocks AgentIron and other clients from using OAuth-only providers such as Codex, and dual-mode providers such as `kimi-code`, without duplicating refresh and retry behavior in each application.
+
+## What Changes
+
+- Add provider credential orchestration for inference providers, separate from plugin authentication.
+- Add app-owned credential persistence through an `iron-core` credential store abstraction.
+- Add OAuth device-code metadata and token exchange/refresh support for `kimi-code` and `codex`.
+- Resolve credentials per prompt using app-supplied provider/model selection.
+- Build `iron_providers::RuntimeConfig` from either API-key or OAuth bearer credentials before provider invocation.
+- Prefer API-key credentials when both API-key and OAuth credentials are configured for a dual-mode provider.
+- Expose client-visible provider auth statuses and actionable auth errors.
+- Retry once after OAuth provider auth failure when no stream output has been emitted and forced refresh succeeds.
+- Preserve existing injected-provider and API-key behavior.
+
+## Capabilities
+
+### New Capabilities
+- `provider-credential-orchestration`: Resolve, refresh, report, and apply provider credentials for per-prompt provider execution.
+
+### Modified Capabilities
+- None.
+
+## Impact
+
+- Affected code: provider invocation path in `IronRuntime`/`PromptRunner`, facade APIs for managed provider execution, new provider credential domain and OAuth refresh modules, tests for credential resolution and auth retry.
+- Affected dependencies: uses existing `iron-providers` credential abstractions (`ProviderCredential`, `RuntimeConfig::from_credential`, provider registry/profile support).
+- Affected clients: AgentIron and `iron-tui` can supply provider/model choices per prompt and provide credential store implementations; AgentIron may keep SQLite persistence for V1 as a client-owned backend.
+- Non-impact: `iron-core` will not own secure/keyring storage policy, migrate existing AgentIron API-key storage, implement browser redirect OAuth, support multiple accounts per provider, or perform remote token revocation in this change.

--- a/openspec/changes/provider-oauth-credential-orchestration/specs/provider-credential-orchestration/spec.md
+++ b/openspec/changes/provider-oauth-credential-orchestration/specs/provider-credential-orchestration/spec.md
@@ -1,0 +1,118 @@
+## ADDED Requirements
+
+### Requirement: Core SHALL support app-owned provider credential storage
+`iron-core` SHALL define a provider credential storage boundary that lets clients provide persistence for provider OAuth credential material without making `iron-core` own the concrete storage backend.
+
+#### Scenario: Client supplies provider credential storage
+- **WHEN** a client configures managed provider credential orchestration
+- **THEN** the client SHALL be able to provide a credential store implementation used by `iron-core` for provider OAuth credential lookup, update, and removal
+
+#### Scenario: Storage backend remains client-owned
+- **WHEN** AgentIron stores OAuth credentials in SQLite for V1
+- **THEN** `iron-core` SHALL interact only through the credential store boundary
+- **AND** `iron-core` SHALL NOT depend on SQLite, OS keyring, or a concrete secure-storage implementation
+
+### Requirement: Core SHALL resolve provider credentials per prompt
+`iron-core` SHALL resolve the active provider credential from app-supplied provider/model context for each managed provider prompt execution.
+
+#### Scenario: Prompt specifies provider and model
+- **WHEN** a client submits a managed provider prompt with provider and model context
+- **THEN** `iron-core` SHALL resolve credentials for that provider before constructing the provider runtime configuration
+
+#### Scenario: Existing injected provider path remains available
+- **WHEN** a caller constructs and injects a provider directly
+- **THEN** `iron-core` SHALL allow that provider to run without requiring provider credential orchestration
+
+### Requirement: Core SHALL preserve API-key compatibility
+Existing API-key provider behavior SHALL continue to work, and API-key credentials SHALL remain valid inputs for provider runtime construction.
+
+#### Scenario: API-key credential constructs runtime config
+- **WHEN** a managed provider prompt resolves an API-key credential
+- **THEN** `iron-core` SHALL construct `iron_providers::RuntimeConfig` with an API-key `ProviderCredential`
+- **AND** provider invocation SHALL use the same API-key auth behavior as before
+
+#### Scenario: API key wins for dual-mode provider
+- **WHEN** a provider supports both API-key and OAuth credentials
+- **AND** both credential modes are available for that provider
+- **THEN** `iron-core` SHALL select the API-key credential for provider invocation
+
+### Requirement: Core SHALL refresh OAuth credentials before provider invocation
+`iron-core` SHALL refresh OAuth credentials before constructing a provider when the access token is expired or within the configured refresh margin.
+
+#### Scenario: OAuth credential is near expiry
+- **WHEN** a managed provider prompt resolves an OAuth credential that expires within five minutes
+- **THEN** `iron-core` SHALL refresh the credential before provider construction
+- **AND** SHALL persist the refreshed OAuth credential through the credential store boundary
+
+#### Scenario: OAuth refresh fails
+- **WHEN** OAuth refresh fails before provider invocation
+- **THEN** `iron-core` SHALL NOT invoke the provider with the stale access token
+- **AND** SHALL return an actionable refresh failure status or error to the client
+
+### Requirement: Core SHALL pass only provider-safe OAuth credential material to iron-providers
+`iron-core` SHALL pass only the current OAuth access token, optional expiry, and optional ID token to `iron-providers` for OAuth-backed provider invocation.
+
+#### Scenario: OAuth bearer runtime config is constructed
+- **WHEN** OAuth credential resolution succeeds for a provider prompt
+- **THEN** `iron-core` SHALL construct `iron_providers::ProviderCredential::OAuthBearer` with the current access token, expiry, and optional ID token
+- **AND** SHALL NOT pass refresh tokens to `iron-providers`
+
+#### Scenario: Codex ID token is available
+- **WHEN** Codex OAuth credential material includes an ID token
+- **THEN** `iron-core` SHALL preserve and pass the ID token in the OAuth bearer credential supplied to `iron-providers`
+
+### Requirement: Core SHALL expose provider auth status to clients
+`iron-core` SHALL expose structured provider auth status so clients can render provider credential state without inspecting secret material.
+
+#### Scenario: Provider credential is not configured
+- **WHEN** no API-key or OAuth credential is available for a provider
+- **THEN** `iron-core` SHALL report `NotConfigured` for that provider
+
+#### Scenario: Provider uses API key
+- **WHEN** an API-key credential is available and selected for a provider
+- **THEN** `iron-core` SHALL report `ConfiguredApiKey` for that provider
+
+#### Scenario: Provider uses OAuth
+- **WHEN** an OAuth credential is available and valid for a provider
+- **THEN** `iron-core` SHALL report `ConnectedOAuth` with the credential expiry when known
+
+#### Scenario: Provider credential cannot be used
+- **WHEN** credential resolution or refresh cannot produce a usable provider credential
+- **THEN** `iron-core` SHALL report one of `Expired`, `RefreshFailed`, `Revoked`, or `UnsupportedCredential` with actionable context
+
+### Requirement: Core SHALL support OAuth disconnect without removing API keys
+`iron-core` SHALL provide a provider OAuth disconnect operation that removes OAuth credential material for the provider without removing API-key configuration.
+
+#### Scenario: OAuth credential is disconnected
+- **WHEN** a client disconnects OAuth for a provider
+- **THEN** `iron-core` SHALL remove OAuth credential material for that provider through the credential store boundary
+- **AND** SHALL NOT remove API-key configuration for that provider
+
+### Requirement: Core SHALL support device-code OAuth metadata and exchange helpers for V1 OAuth providers
+`iron-core` SHALL provide V1 OAuth device-code metadata and token exchange helpers for `kimi-code` and `codex` while keeping presentation of the login flow client-owned.
+
+#### Scenario: Client starts Kimi Code OAuth interaction
+- **WHEN** a client asks to start OAuth for `kimi-code`
+- **THEN** `iron-core` SHALL provide device-code interaction data using Kimi Code OAuth metadata
+- **AND** the client SHALL remain responsible for rendering the interaction to the user
+
+#### Scenario: Client starts Codex OAuth interaction
+- **WHEN** a client asks to start OAuth for `codex`
+- **THEN** `iron-core` SHALL provide device-code interaction data using OpenAI OAuth metadata for Codex
+- **AND** the client SHALL remain responsible for rendering the interaction to the user
+
+### Requirement: Core SHALL retry safe OAuth provider auth failures once
+`iron-core` SHALL coordinate one forced-refresh retry after an OAuth-backed provider auth failure when retrying is safe.
+
+#### Scenario: OAuth provider auth failure before streamed output
+- **WHEN** an OAuth-backed provider invocation fails with an auth error before any stream output is emitted
+- **THEN** `iron-core` SHALL force-refresh the OAuth credential and retry the provider invocation at most once
+
+#### Scenario: OAuth provider auth failure after streamed output
+- **WHEN** an OAuth-backed provider invocation fails after stream output has been emitted
+- **THEN** `iron-core` SHALL NOT silently retry the provider invocation
+- **AND** SHALL surface the auth failure to the client
+
+#### Scenario: API-key provider auth failure
+- **WHEN** an API-key-backed provider invocation fails with an auth error
+- **THEN** `iron-core` SHALL NOT attempt OAuth refresh retry for that invocation

--- a/openspec/changes/provider-oauth-credential-orchestration/tasks.md
+++ b/openspec/changes/provider-oauth-credential-orchestration/tasks.md
@@ -1,0 +1,54 @@
+## 1. Provider credential domain
+
+- [x] 1.1 Add provider credential modules and public domain types for provider IDs, credential mode, OAuth token material, credential status, and auth errors
+- [x] 1.2 Add an app-supplied provider credential store boundary for OAuth lookup, update, removal, and status listing by provider slug
+- [x] 1.3 Ensure refresh tokens and stored OAuth secret material are never represented in normal `Config` provider settings
+- [x] 1.4 Add unit tests for store-boundary behavior using an in-memory credential store
+
+## 2. OAuth metadata and token lifecycle
+
+- [x] 2.1 Add V1 OAuth provider metadata for `kimi-code` device-code auth against Kimi auth
+- [x] 2.2 Add V1 OAuth provider metadata for `codex` device-code auth against OpenAI auth
+- [x] 2.3 Implement device-code start, polling/token exchange, and refresh helpers behind core-owned provider OAuth interfaces
+- [x] 2.4 Preserve optional Codex ID tokens in stored OAuth material and propagated bearer credentials
+- [x] 2.5 Add tests for successful device-code completion, refresh success, refresh failure, and ID-token preservation
+
+## 3. Credential resolution
+
+- [x] 3.1 Add a credential resolver that accepts app-supplied provider/model context per prompt
+- [x] 3.2 Resolve API-key credentials without changing existing API-key behavior
+- [x] 3.3 Resolve OAuth credentials from the credential store and refresh when expired or within the five-minute refresh margin
+- [x] 3.4 Prefer API-key credentials over OAuth credentials for dual-mode providers such as `kimi-code`
+- [x] 3.5 Return actionable missing, expired, refresh-failed, revoked, and unsupported-credential errors
+- [x] 3.6 Add resolver tests for missing credentials, API-key compatibility, API-key-over-OAuth precedence, near-expiry refresh, refresh failure, and unsupported credential mode
+
+## 4. Managed provider execution path
+
+- [x] 4.1 Add an additive managed-provider runtime/facade path that keeps the existing injected-provider constructor working
+- [x] 4.2 Build `iron_providers::RuntimeConfig` from resolved `ProviderCredential::ApiKey` or `ProviderCredential::OAuthBearer`
+- [x] 4.3 Construct `GenericProvider` from the `iron-providers` registry/profile after credential resolution
+- [x] 4.4 Ensure refresh tokens are never passed into `iron-providers`
+- [x] 4.5 Add integration-style tests proving managed provider construction works for API-key, `kimi-code` OAuth, and `codex` OAuth credentials
+
+## 5. Provider auth status and disconnect
+
+- [x] 5.1 Expose provider auth statuses: `NotConfigured`, `ConfiguredApiKey`, `ConnectedOAuth`, `Refreshing`, `Expired`, `RefreshFailed`, `Revoked`, and `UnsupportedCredential`
+- [x] 5.2 Add facade/runtime APIs for clients to query provider auth status without exposing secret material
+- [x] 5.3 Add OAuth disconnect support that removes OAuth credential material through the store boundary
+- [x] 5.4 Ensure OAuth disconnect does not remove API-key configuration
+- [x] 5.5 Add tests for status derivation, disconnect/removal, and API-key preservation after OAuth disconnect
+
+## 6. OAuth auth-failure retry
+
+- [x] 6.1 Detect provider auth failures from the managed provider execution path and map them into provider auth errors
+- [x] 6.2 Force-refresh and retry exactly once for OAuth-backed auth failures before any stream output is emitted
+- [x] 6.3 Do not retry after streamed output has been emitted
+- [x] 6.4 Do not OAuth-refresh retry API-key-backed provider auth failures
+- [x] 6.5 Add tests for successful retry after forced refresh, retry suppression after output, retry suppression for API-key credentials, and repeated auth failure reporting
+
+## 7. Verification
+
+- [x] 7.1 Run unit tests covering provider credential resolution, OAuth refresh paths, disconnect/removal, API-key compatibility, and retry behavior
+- [x] 7.2 Run existing provider construction and prompt runner regression tests to confirm injected-provider behavior is unchanged
+- [x] 7.3 Run `cargo test` for `iron-core`
+- [x] 7.4 Update public documentation or examples for managed provider credential orchestration if new facade APIs are exposed

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,11 +1,12 @@
 use crate::durable::{DurableSession, SessionId};
 use crate::prompt_lifecycle::AcpPromptSink;
 use crate::prompt_runner::PromptRunner;
+use crate::provider_credential::domain::ProviderPromptContext;
 use crate::runtime::{ConnectionId, IronRuntime};
 use agent_client_protocol::schema as acp;
 use std::cell::RefCell;
 use std::rc::Rc;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 pub trait ClientChannel {
     fn send_notification(
@@ -222,6 +223,75 @@ impl IronConnection {
         let sink = AcpPromptSink::new(acp_session_id.clone(), client);
 
         let runner = PromptRunner::new(self.runtime.clone());
+        let stop_reason = runner
+            .run(&durable, &ephemeral, &sink, &config, max_iterations)
+            .await;
+
+        self.runtime.finish_prompt(iron_session_id);
+
+        if config.context_management.enabled {
+            runner.maybe_compact_post_turn(&durable, &config).await;
+        }
+
+        Ok(acp::PromptResponse::new(stop_reason))
+    }
+
+    pub async fn handle_prompt_managed(
+        &self,
+        args: acp::PromptRequest,
+        provider_context: ProviderPromptContext,
+    ) -> agent_client_protocol::Result<acp::PromptResponse> {
+        debug!(session_id = %args.session_id, provider = %provider_context.provider_slug.as_str(), "Managed prompt received");
+
+        let (iron_session_id, durable) = self.resolve_owned_session(&args.session_id)?;
+
+        let user_blocks: Vec<crate::durable::ContentBlock> = args
+            .prompt
+            .iter()
+            .map(crate::durable::ContentBlock::from_acp_content)
+            .collect();
+        {
+            let mut session = durable.lock();
+            session.add_user_message(user_blocks);
+        }
+
+        let ephemeral = self
+            .runtime
+            .try_start_prompt(iron_session_id)
+            .map_err(|e| {
+                agent_client_protocol::Error::invalid_params().data(serde_json::json!({
+                    "session_id": args.session_id.to_string(),
+                    "error": e.to_string()
+                }))
+            })?;
+
+        let acp_session_id = args.session_id.clone();
+        let client = self.client_channel();
+        let config = self.runtime.config().clone();
+        let max_iterations = config.max_iterations;
+
+        let sink = AcpPromptSink::new(acp_session_id.clone(), client);
+
+        // Resolve the managed provider for this prompt
+        let provider = match self
+            .runtime
+            .resolve_managed_provider(&provider_context)
+            .await
+        {
+            Ok(p) => p,
+            Err(e) => {
+                warn!(error = %e, "Failed to resolve managed provider");
+                {
+                    let mut session = durable.lock();
+                    session.add_agent_text(format!("[Auth error: {}]", e));
+                }
+                self.runtime.finish_prompt(iron_session_id);
+                return Ok(acp::PromptResponse::new(acp::StopReason::EndTurn));
+            }
+        };
+
+        let runner = PromptRunner::new_managed(self.runtime.clone(), provider, provider_context);
+
         let stop_reason = runner
             .run(&durable, &ephemeral, &sink, &config, max_iterations)
             .await;

--- a/src/facade.rs
+++ b/src/facade.rs
@@ -10,6 +10,8 @@ use crate::{
         TimelineEntry,
     },
     error::RuntimeError,
+    provider_credential::domain::{ProviderAuthStatus, ProviderPromptContext, ProviderSlug},
+    provider_credential::store::DynCredentialStore,
     runtime::{ConnectionId, IronRuntime},
     tool::Tool,
 };
@@ -465,6 +467,17 @@ impl IronAgent {
     ) -> Self {
         Self {
             runtime: IronRuntime::from_handle(config, provider, handle),
+        }
+    }
+
+    /// Create a new agent with a credential store for managed provider resolution.
+    pub fn new_with_credential_store<P: Provider + 'static>(
+        config: Config,
+        provider: P,
+        credential_store: DynCredentialStore,
+    ) -> Self {
+        Self {
+            runtime: IronRuntime::new_with_credential_store(config, provider, credential_store),
         }
     }
 
@@ -1284,6 +1297,84 @@ impl AgentSession {
         }
     }
 
+    /// Send a text prompt with a managed provider and await completion.
+    ///
+    /// The managed path resolves credentials from the credential store (or uses
+    /// the API key from `provider_context.api_key`) and retries once on auth
+    /// errors after refreshing the stored OAuth token.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// use iron_core::facade::{IronAgent, AgentSession};
+    /// use iron_core::provider_credential::domain::{ProviderPromptContext, ProviderSlug};
+    ///
+    /// let session: AgentSession = /* ... */;
+    /// let context = ProviderPromptContext {
+    ///     provider_slug: ProviderSlug::new("kimi-code"),
+    ///     model: "kimi-for-coding".into(),
+    ///     api_key: None,
+    /// };
+    /// let outcome = session.prompt_managed("Explain closures in Rust", context).await;
+    /// ```
+    pub async fn prompt_managed(
+        &self,
+        text: &str,
+        provider_context: ProviderPromptContext,
+    ) -> PromptOutcome {
+        let acp_session_id = acp::SessionId::new(self.id.to_string());
+        let request = acp::PromptRequest::new(
+            acp_session_id,
+            vec![acp::ContentBlock::Text(acp::TextContent::new(text))],
+        );
+        match self
+            .connection
+            .handle_prompt_managed(request, provider_context)
+            .await
+        {
+            Ok(response) => response.stop_reason.into(),
+            Err(_) => PromptOutcome::EndTurn,
+        }
+    }
+
+    /// Send a multimodal prompt with a managed provider and await completion.
+    ///
+    /// Like [`prompt_managed`](AgentSession::prompt_managed) but accepts
+    /// [`ContentBlock`]s for multimodal input (images, files, etc.).
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// use iron_core::facade::{AgentSession, ContentBlock};
+    /// use iron_core::provider_credential::domain::{ProviderPromptContext, ProviderSlug};
+    ///
+    /// let session: AgentSession = /* ... */;
+    /// let context = ProviderPromptContext {
+    ///     provider_slug: ProviderSlug::new("kimi-code"),
+    ///     model: "kimi-for-coding".into(),
+    ///     api_key: Some("sk-...".into()),
+    /// };
+    /// let blocks = vec![ContentBlock::Text("Describe this image".into())];
+    /// let outcome = session.prompt_with_blocks_managed(&blocks, context).await;
+    /// ```
+    pub async fn prompt_with_blocks_managed(
+        &self,
+        blocks: &[ContentBlock],
+        provider_context: ProviderPromptContext,
+    ) -> PromptOutcome {
+        let acp_session_id = acp::SessionId::new(self.id.to_string());
+        let acp_blocks: Vec<_> = blocks.iter().map(to_acp_content_block).collect();
+        let request = acp::PromptRequest::new(acp_session_id, acp_blocks);
+        match self
+            .connection
+            .handle_prompt_managed(request, provider_context)
+            .await
+        {
+            Ok(response) => response.stop_reason.into(),
+            Err(_) => PromptOutcome::EndTurn,
+        }
+    }
+
     /// Send a text prompt and return a stream of events.
     ///
     /// This is a convenience wrapper that wraps the text as a single text
@@ -1421,6 +1512,127 @@ impl AgentSession {
         (handle, events)
     }
 
+    /// Send a text prompt with a managed provider and return a stream of events.
+    ///
+    /// The managed path resolves credentials from the credential store (or uses
+    /// the API key from `provider_context.api_key`) and retries once on auth
+    /// errors after refreshing the stored OAuth token.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// use iron_core::provider_credential::domain::{ProviderPromptContext, ProviderSlug};
+    ///
+    /// let session: AgentSession = /* ... */;
+    /// let context = ProviderPromptContext {
+    ///     provider_slug: ProviderSlug::new("kimi-code"),
+    ///     model: "kimi-for-coding".into(),
+    ///     api_key: None,
+    /// };
+    /// let (handle, mut events) = session.prompt_stream_managed("Hello", context);
+    /// while let Some(event) = events.next().await {
+    ///     // handle PromptEvent
+    /// }
+    /// ```
+    pub fn prompt_stream_managed(
+        &self,
+        text: &str,
+        provider_context: ProviderPromptContext,
+    ) -> (PromptHandle, PromptEvents) {
+        let acp_blocks = vec![acp::ContentBlock::Text(acp::TextContent::new(text))];
+        self.prompt_stream_with_acp_blocks_managed(acp_blocks, provider_context)
+    }
+
+    /// Send a multimodal prompt with a managed provider and return a stream of events.
+    ///
+    /// Like [`prompt_stream_managed`](AgentSession::prompt_stream_managed) but
+    /// accepts [`ContentBlock`]s for multimodal input.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// use iron_core::facade::{AgentSession, ContentBlock};
+    /// use iron_core::provider_credential::domain::{ProviderPromptContext, ProviderSlug};
+    ///
+    /// let session: AgentSession = /* ... */;
+    /// let context = ProviderPromptContext {
+    ///     provider_slug: ProviderSlug::new("kimi-code"),
+    ///     model: "kimi-for-coding".into(),
+    ///     api_key: None,
+    /// };
+    /// let blocks = vec![ContentBlock::Text("Describe this".into())];
+    /// let (handle, mut events) = session.prompt_stream_with_blocks_managed(&blocks, context);
+    /// ```
+    pub fn prompt_stream_with_blocks_managed(
+        &self,
+        blocks: &[ContentBlock],
+        provider_context: ProviderPromptContext,
+    ) -> (PromptHandle, PromptEvents) {
+        let acp_blocks: Vec<_> = blocks.iter().map(to_acp_content_block).collect();
+        self.prompt_stream_with_acp_blocks_managed(acp_blocks, provider_context)
+    }
+
+    /// Shared internal streaming path for managed providers.
+    fn prompt_stream_with_acp_blocks_managed(
+        &self,
+        acp_blocks: Vec<acp::ContentBlock>,
+        provider_context: ProviderPromptContext,
+    ) -> (PromptHandle, PromptEvents) {
+        let (event_tx, event_rx) = tokio::sync::mpsc::unbounded_channel();
+        let approval_resolvers: Rc<
+            RefCell<HashMap<String, tokio::sync::oneshot::Sender<PermissionVerdict>>>,
+        > = Rc::new(RefCell::new(HashMap::new()));
+
+        let prompt_key = self.id.to_string();
+        self.active_streams.borrow_mut().insert(
+            prompt_key.clone(),
+            StreamPromptState {
+                event_tx: event_tx.clone(),
+                approval_resolvers: approval_resolvers.clone(),
+                tool_name_index: Rc::new(RefCell::new(HashMap::new())),
+            },
+        );
+
+        let status = Rc::new(RefCell::new(PromptStatus::Running));
+        let handle = PromptHandle {
+            approval_resolvers,
+            session: self.clone(),
+            status: status.clone(),
+        };
+        let events = PromptEvents { rx: event_rx };
+
+        let acp_session_id = acp::SessionId::new(self.id.to_string());
+        let request = acp::PromptRequest::new(acp_session_id, acp_blocks);
+
+        let connection = self.connection.clone();
+        let active_streams = self.active_streams.clone();
+        let status_cell = status.clone();
+
+        tokio::task::spawn_local(async move {
+            let outcome = match connection
+                .handle_prompt_managed(request, provider_context)
+                .await
+            {
+                Ok(response) => response.stop_reason.into(),
+                Err(_) => PromptOutcome::EndTurn,
+            };
+
+            {
+                let mut streams = active_streams.borrow_mut();
+                if let Some(state) = streams.remove(&prompt_key) {
+                    let _ = state.event_tx.send(PromptEvent::Complete { outcome });
+                }
+            }
+
+            *status_cell.borrow_mut() = match outcome {
+                PromptOutcome::Cancelled => PromptStatus::Cancelled,
+                _ => PromptStatus::Completed,
+            };
+        });
+
+        (handle, events)
+    }
+
     /// Cancel any active prompt on this session.
     pub async fn cancel(&self) {
         let acp_session_id = acp::SessionId::new(self.id.to_string());
@@ -1457,6 +1669,44 @@ impl AgentSession {
     /// Set the system instructions for this session.
     pub fn set_instructions(&self, instructions: impl Into<String>) {
         self.durable.lock().set_instructions(instructions);
+    }
+
+    // -- Provider Credential APIs --
+
+    /// Get the auth status for a provider.
+    pub async fn provider_auth_status(&self, slug: &ProviderSlug) -> Option<ProviderAuthStatus> {
+        self.connection.runtime().provider_auth_status(slug).await
+    }
+
+    /// Get the auth status for a provider while considering an app-owned API key.
+    pub async fn provider_auth_status_with_api_key(
+        &self,
+        slug: &ProviderSlug,
+        api_key: Option<&str>,
+    ) -> Option<ProviderAuthStatus> {
+        self.connection
+            .runtime()
+            .provider_auth_status_with_api_key(slug, api_key)
+            .await
+    }
+
+    /// Get the auth status for a managed prompt context.
+    pub async fn provider_auth_status_for_context(
+        &self,
+        context: &ProviderPromptContext,
+    ) -> Option<ProviderAuthStatus> {
+        self.connection
+            .runtime()
+            .provider_auth_status_for_context(context)
+            .await
+    }
+
+    /// Disconnect OAuth for a provider without removing API keys.
+    pub async fn disconnect_provider_oauth(&self, slug: &ProviderSlug) {
+        self.connection
+            .runtime()
+            .disconnect_provider_oauth(slug)
+            .await;
     }
 
     // -- Skill APIs --

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,6 +177,7 @@ pub mod prompt;
 pub mod prompt_lifecycle;
 pub mod prompt_runner;
 pub mod prompt_turn;
+pub mod provider_credential;
 pub mod request_builder;
 pub mod runtime;
 pub mod schema;

--- a/src/prompt_runner.rs
+++ b/src/prompt_runner.rs
@@ -7,10 +7,11 @@ use crate::plugin::rich_output::transcript_text as plugin_transcript_text;
 use crate::prompt_lifecycle::{
     ApprovalRequest, ApprovalVerdict, PromptLifecycleEvent, PromptSink, ToolUpdateStatus,
 };
+use crate::provider_credential::ProviderPromptContext;
 use crate::runtime::IronRuntime;
 use agent_client_protocol::schema as acp;
 use futures::StreamExt;
-use iron_providers::ProviderEvent;
+use iron_providers::{Provider, ProviderError, ProviderEvent};
 use parking_lot::Mutex;
 use std::sync::Arc;
 use tracing::{info, trace, warn};
@@ -49,11 +50,80 @@ fn tie_off_cancelled(durable: &Arc<Mutex<DurableSession>>) {
 
 pub(crate) struct PromptRunner {
     runtime: IronRuntime,
+    managed_provider: Option<Box<dyn Provider>>,
+    /// Provider context used for auth-failure retry.
+    provider_context: Option<ProviderPromptContext>,
+    #[cfg(test)]
+    retry_provider_factory: Option<Arc<dyn Fn() -> Box<dyn Provider> + Send + Sync>>,
 }
 
 impl PromptRunner {
     pub(crate) fn new(runtime: IronRuntime) -> Self {
-        Self { runtime }
+        Self {
+            runtime,
+            managed_provider: None,
+            provider_context: None,
+            #[cfg(test)]
+            retry_provider_factory: None,
+        }
+    }
+
+    pub(crate) fn new_managed(
+        runtime: IronRuntime,
+        provider: Box<dyn Provider>,
+        context: ProviderPromptContext,
+    ) -> Self {
+        Self {
+            runtime,
+            managed_provider: Some(provider),
+            provider_context: Some(context),
+            #[cfg(test)]
+            retry_provider_factory: None,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_managed_with_retry_provider_for_test(
+        runtime: IronRuntime,
+        provider: Box<dyn Provider>,
+        context: ProviderPromptContext,
+        retry_provider_factory: Arc<dyn Fn() -> Box<dyn Provider> + Send + Sync>,
+    ) -> Self {
+        Self {
+            runtime,
+            managed_provider: Some(provider),
+            provider_context: Some(context),
+            retry_provider_factory: Some(retry_provider_factory),
+        }
+    }
+
+    fn provider(&self) -> &dyn Provider {
+        self.managed_provider
+            .as_ref()
+            .map(|p| p.as_ref())
+            .unwrap_or_else(|| self.runtime.provider())
+    }
+
+    async fn auth_failure_is_api_key_backed(&self) -> bool {
+        let Some(context) = self.provider_context.as_ref() else {
+            return false;
+        };
+        matches!(
+            self.runtime.provider_auth_status_for_context(context).await,
+            Some(crate::provider_credential::ProviderAuthStatus::ConfiguredApiKey)
+        )
+    }
+
+    async fn refreshed_provider_for_retry(
+        &self,
+        context: &ProviderPromptContext,
+    ) -> crate::provider_credential::ProviderAuthResult<Box<dyn Provider>> {
+        #[cfg(test)]
+        if let Some(factory) = &self.retry_provider_factory {
+            return Ok(factory());
+        }
+
+        self.runtime.force_refresh_managed_provider(context).await
     }
 
     pub(crate) async fn run(
@@ -143,21 +213,116 @@ impl PromptRunner {
                 }
             };
 
-            let stream = match self.runtime.provider().infer_stream(request).await {
+            let stream = match self.provider().infer_stream(request.clone()).await {
                 Ok(s) => s,
                 Err(e) => {
-                    warn!(error = %e, "Provider inference failed");
+                    if e.is_authentication()
+                        && self.managed_provider.is_some()
+                        && self.provider_context.is_some()
+                        && !self.auth_failure_is_api_key_backed().await
                     {
-                        let mut session = durable.lock();
-                        session.add_agent_text(format!("[Provider error: {}]", e));
+                        warn!(error = %e, "Provider auth failed, attempting force-refresh and retry");
+                        let context = self.provider_context.as_ref().unwrap();
+                        match self.refreshed_provider_for_retry(context).await {
+                            Ok(refreshed_provider) => {
+                                match refreshed_provider.infer_stream(request.clone()).await {
+                                    Ok(s) => s,
+                                    Err(e2) => {
+                                        warn!(error = %e2, "Provider retry failed after refresh");
+                                        {
+                                            let mut session = durable.lock();
+                                            session.add_agent_text(format!(
+                                                "[Provider auth error: {}]",
+                                                e2
+                                            ));
+                                        }
+                                        return acp::StopReason::EndTurn;
+                                    }
+                                }
+                            }
+                            Err(refresh_err) => {
+                                warn!(error = %refresh_err, "Force-refresh failed, cannot retry");
+                                {
+                                    let mut session = durable.lock();
+                                    session.add_agent_text(format!(
+                                        "[Provider auth error: {} (refresh failed: {})]",
+                                        e, refresh_err
+                                    ));
+                                }
+                                return acp::StopReason::EndTurn;
+                            }
+                        }
+                    } else {
+                        warn!(error = %e, "Provider inference failed");
+                        {
+                            let mut session = durable.lock();
+                            session.add_agent_text(format!("[Provider error: {}]", e));
+                        }
+                        return acp::StopReason::EndTurn;
                     }
-                    return acp::StopReason::EndTurn;
                 }
             };
 
             let step = match self.process_provider_stream(durable, sink, stream).await {
-                Ok(s) => s,
-                Err(e) => return e,
+                ProviderStreamOutcome::Step(step) => step,
+                ProviderStreamOutcome::Stop(reason) => return reason,
+                ProviderStreamOutcome::AuthFailureBeforeOutput(error) => {
+                    if self.managed_provider.is_some()
+                        && self.provider_context.is_some()
+                        && !self.auth_failure_is_api_key_backed().await
+                    {
+                        warn!(error = %error, "Provider stream auth failed before output, attempting force-refresh and retry");
+                        let context = self.provider_context.as_ref().unwrap();
+                        let refreshed_provider = match self
+                            .refreshed_provider_for_retry(context)
+                            .await
+                        {
+                            Ok(provider) => provider,
+                            Err(refresh_err) => {
+                                warn!(error = %refresh_err, "Force-refresh failed, cannot retry stream auth failure");
+                                let mut session = durable.lock();
+                                session.add_agent_text(format!(
+                                    "[Provider auth error: {} (refresh failed: {})]",
+                                    error, refresh_err
+                                ));
+                                return acp::StopReason::EndTurn;
+                            }
+                        };
+
+                        let retry_stream = match refreshed_provider.infer_stream(request).await {
+                            Ok(stream) => stream,
+                            Err(retry_error) => {
+                                warn!(error = %retry_error, "Provider retry failed after refresh");
+                                let mut session = durable.lock();
+                                session.add_agent_text(format!(
+                                    "[Provider auth error: {}]",
+                                    retry_error
+                                ));
+                                return acp::StopReason::EndTurn;
+                            }
+                        };
+
+                        match self
+                            .process_provider_stream(durable, sink, retry_stream)
+                            .await
+                        {
+                            ProviderStreamOutcome::Step(step) => step,
+                            ProviderStreamOutcome::Stop(reason) => return reason,
+                            ProviderStreamOutcome::AuthFailureBeforeOutput(retry_error) => {
+                                let mut session = durable.lock();
+                                session.add_agent_text(format!(
+                                    "[Provider auth error: {}]",
+                                    retry_error
+                                ));
+                                return acp::StopReason::EndTurn;
+                            }
+                        }
+                    } else {
+                        let mut session = durable.lock();
+                        session.add_agent_text(format!("[Provider auth error: {}]", error));
+                        return acp::StopReason::EndTurn;
+                    }
+                }
             };
 
             if step.tool_calls.is_empty() {
@@ -245,29 +410,33 @@ impl PromptRunner {
             'static,
             iron_providers::ProviderResult<ProviderEvent>,
         >,
-    ) -> Result<ProviderStep, acp::StopReason> {
+    ) -> ProviderStreamOutcome {
         let mut tool_calls = Vec::new();
         let mut assistant_output = String::new();
+        let mut emitted_output = false;
 
         while let Some(result) = stream.next().await {
             let event = match result {
                 Ok(e) => e,
-                Err(_) => {
-                    if !assistant_output.is_empty() {
-                        let mut session = durable.lock();
-                        session.add_agent_text(&assistant_output);
-                    }
-                    return Err(acp::StopReason::EndTurn);
+                Err(error) => {
+                    return Self::handle_provider_stream_error(
+                        durable,
+                        &mut assistant_output,
+                        emitted_output,
+                        error,
+                    );
                 }
             };
 
             match event {
                 ProviderEvent::Output { content } => {
+                    emitted_output = true;
                     assistant_output.push_str(&content);
                     sink.emit(PromptLifecycleEvent::Output { text: content })
                         .await;
                 }
                 ProviderEvent::ToolCall { call } => {
+                    emitted_output = true;
                     {
                         let mut session = durable.lock();
                         session.propose_tool_call(
@@ -293,15 +462,16 @@ impl PromptRunner {
                         let mut session = durable.lock();
                         session.add_agent_text(&assistant_output);
                     }
-                    return Err(acp::StopReason::EndTurn);
+                    return ProviderStreamOutcome::Stop(acp::StopReason::EndTurn);
                 }
                 ProviderEvent::Complete => {}
-                ProviderEvent::Error { source: _ } => {
-                    if !assistant_output.is_empty() {
-                        let mut session = durable.lock();
-                        session.add_agent_text(&assistant_output);
-                    }
-                    return Err(acp::StopReason::EndTurn);
+                ProviderEvent::Error { source } => {
+                    return Self::handle_provider_stream_error(
+                        durable,
+                        &mut assistant_output,
+                        emitted_output,
+                        source,
+                    );
                 }
             }
         }
@@ -311,7 +481,30 @@ impl PromptRunner {
             session.add_agent_text(&assistant_output);
         }
 
-        Ok(ProviderStep { tool_calls })
+        ProviderStreamOutcome::Step(ProviderStep { tool_calls })
+    }
+
+    fn handle_provider_stream_error(
+        durable: &Arc<Mutex<DurableSession>>,
+        assistant_output: &mut String,
+        emitted_output: bool,
+        error: ProviderError,
+    ) -> ProviderStreamOutcome {
+        if !emitted_output && error.is_authentication() {
+            return ProviderStreamOutcome::AuthFailureBeforeOutput(error);
+        }
+
+        let mut session = durable.lock();
+        if !assistant_output.is_empty() {
+            session.add_agent_text(assistant_output.as_str());
+            assistant_output.clear();
+        }
+        if error.is_authentication() {
+            session.add_agent_text(format!("[Provider auth error: {}]", error));
+        } else {
+            session.add_agent_text(format!("[Provider error: {}]", error));
+        }
+        ProviderStreamOutcome::Stop(acp::StopReason::EndTurn)
     }
 
     async fn handle_permission_flow(
@@ -1371,7 +1564,7 @@ impl PromptRunner {
             )
         };
 
-        match CompactionEngine::execute(input, self.runtime.provider(), &config.model).await {
+        match CompactionEngine::execute(input, self.provider(), &config.model).await {
             Ok((compacted, tail)) => {
                 let mut session = durable.lock();
                 session.apply_compaction(compacted, tail);
@@ -1428,7 +1621,7 @@ impl PromptRunner {
             )
         };
 
-        match CompactionEngine::execute(input, self.runtime.provider(), &config.model).await {
+        match CompactionEngine::execute(input, self.provider(), &config.model).await {
             Ok((compacted, tail)) => {
                 let mut session = durable.lock();
                 session.apply_compaction(compacted, tail);
@@ -1447,4 +1640,418 @@ impl PromptRunner {
 
 struct ProviderStep {
     tool_calls: Vec<iron_providers::ToolCall>,
+}
+
+enum ProviderStreamOutcome {
+    Step(ProviderStep),
+    Stop(acp::StopReason),
+    AuthFailureBeforeOutput(ProviderError),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Config;
+    use crate::durable::{DurableSession, SessionId};
+    use crate::ephemeral::EphemeralTurn;
+    use crate::prompt_lifecycle::PromptLifecycleEvent;
+    use crate::provider_credential::domain::ProviderPromptContext;
+    use crate::runtime::IronRuntime;
+    use futures::stream::{self, BoxStream};
+    use futures::StreamExt;
+    use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+    use std::sync::Arc;
+
+    struct NopSink;
+
+    impl crate::prompt_lifecycle::PromptSink for NopSink {
+        fn emit(
+            &self,
+            _event: PromptLifecycleEvent,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()>>> {
+            Box::pin(async {})
+        }
+
+        fn request_approval(
+            &self,
+            _request: crate::prompt_lifecycle::ApprovalRequest,
+        ) -> std::pin::Pin<
+            Box<dyn std::future::Future<Output = crate::prompt_lifecycle::ApprovalVerdict>>,
+        > {
+            Box::pin(async { crate::prompt_lifecycle::ApprovalVerdict::AllowOnce })
+        }
+    }
+
+    #[derive(Clone, Default)]
+    struct AuthFailProvider {
+        call_count: Arc<AtomicUsize>,
+    }
+
+    impl Provider for AuthFailProvider {
+        fn infer(
+            &self,
+            _request: iron_providers::InferenceRequest,
+        ) -> iron_providers::ProviderFuture<'_, Vec<iron_providers::ProviderEvent>> {
+            Box::pin(async move { Ok(vec![iron_providers::ProviderEvent::Complete]) })
+        }
+
+        fn infer_stream(
+            &self,
+            _request: iron_providers::InferenceRequest,
+        ) -> iron_providers::ProviderFuture<
+            '_,
+            BoxStream<'static, iron_providers::ProviderResult<iron_providers::ProviderEvent>>,
+        > {
+            let count = self.call_count.fetch_add(1, AtomicOrdering::SeqCst);
+            Box::pin(async move {
+                if count == 0 {
+                    Err(iron_providers::ProviderError::auth("test auth failure"))
+                } else {
+                    Ok(stream::iter(vec![Ok(iron_providers::ProviderEvent::Complete)]).boxed())
+                }
+            })
+        }
+    }
+
+    #[derive(Clone, Default)]
+    struct TransportFailProvider;
+
+    impl Provider for TransportFailProvider {
+        fn infer(
+            &self,
+            _request: iron_providers::InferenceRequest,
+        ) -> iron_providers::ProviderFuture<'_, Vec<iron_providers::ProviderEvent>> {
+            Box::pin(async move { Ok(vec![iron_providers::ProviderEvent::Complete]) })
+        }
+
+        fn infer_stream(
+            &self,
+            _request: iron_providers::InferenceRequest,
+        ) -> iron_providers::ProviderFuture<
+            '_,
+            BoxStream<'static, iron_providers::ProviderResult<iron_providers::ProviderEvent>>,
+        > {
+            Box::pin(async move {
+                Err(iron_providers::ProviderError::transport(
+                    "connection refused",
+                ))
+            })
+        }
+    }
+
+    #[derive(Clone)]
+    struct StreamEventsProvider {
+        events: Arc<Vec<iron_providers::ProviderResult<iron_providers::ProviderEvent>>>,
+        call_count: Arc<AtomicUsize>,
+    }
+
+    impl StreamEventsProvider {
+        fn new(events: Vec<iron_providers::ProviderResult<iron_providers::ProviderEvent>>) -> Self {
+            Self {
+                events: Arc::new(events),
+                call_count: Arc::new(AtomicUsize::new(0)),
+            }
+        }
+
+        fn call_count(&self) -> usize {
+            self.call_count.load(AtomicOrdering::SeqCst)
+        }
+    }
+
+    impl Provider for StreamEventsProvider {
+        fn infer(
+            &self,
+            _request: iron_providers::InferenceRequest,
+        ) -> iron_providers::ProviderFuture<'_, Vec<iron_providers::ProviderEvent>> {
+            Box::pin(async move { Ok(vec![iron_providers::ProviderEvent::Complete]) })
+        }
+
+        fn infer_stream(
+            &self,
+            _request: iron_providers::InferenceRequest,
+        ) -> iron_providers::ProviderFuture<
+            '_,
+            BoxStream<'static, iron_providers::ProviderResult<iron_providers::ProviderEvent>>,
+        > {
+            self.call_count.fetch_add(1, AtomicOrdering::SeqCst);
+            let events = (*self.events).clone();
+            Box::pin(async move { Ok(stream::iter(events).boxed()) })
+        }
+    }
+
+    fn make_session_and_ephemeral() -> (Arc<Mutex<DurableSession>>, Arc<Mutex<EphemeralTurn>>) {
+        let session_id = SessionId::new();
+        let durable = Arc::new(Mutex::new(DurableSession::new(session_id)));
+        let ephemeral = Arc::new(Mutex::new(EphemeralTurn::new(session_id)));
+        ephemeral.lock().start();
+        (durable, ephemeral)
+    }
+
+    fn agent_text(durable: &Arc<Mutex<DurableSession>>) -> String {
+        let session = durable.lock();
+        session
+            .to_transcript()
+            .messages
+            .iter()
+            .filter_map(|m| match m {
+                iron_providers::Message::Assistant { content } => Some(content.clone()),
+                _ => None,
+            })
+            .collect::<String>()
+    }
+
+    #[tokio::test]
+    async fn non_managed_no_retry_on_auth_error() {
+        let provider = AuthFailProvider {
+            call_count: Arc::new(AtomicUsize::new(0)),
+        };
+        let runtime = IronRuntime::new(Config::default(), provider);
+        let runner = PromptRunner::new(runtime);
+        let (durable, ephemeral) = make_session_and_ephemeral();
+        let sink = NopSink;
+        let config = Config::default();
+
+        let stop = runner.run(&durable, &ephemeral, &sink, &config, 1).await;
+
+        assert_eq!(stop, acp::StopReason::EndTurn);
+        let agent_text = agent_text(&durable);
+        assert!(agent_text.contains("Provider error"));
+        assert!(!agent_text.contains("refresh"));
+    }
+
+    #[tokio::test]
+    async fn managed_no_retry_on_transport_error() {
+        let runtime = IronRuntime::new(Config::default(), TransportFailProvider);
+        let managed_provider = Box::new(TransportFailProvider) as Box<dyn Provider>;
+        let context = ProviderPromptContext {
+            provider_slug: crate::provider_credential::ProviderSlug::new("codex"),
+            model: "test".into(),
+            api_key: None,
+        };
+        let runner = PromptRunner::new_managed(runtime, managed_provider, context);
+        let (durable, ephemeral) = make_session_and_ephemeral();
+        let sink = NopSink;
+        let config = Config::default();
+
+        let stop = runner.run(&durable, &ephemeral, &sink, &config, 1).await;
+
+        assert_eq!(stop, acp::StopReason::EndTurn);
+        let agent_text = agent_text(&durable);
+        assert!(agent_text.contains("Provider error"));
+        assert!(!agent_text.contains("auth"));
+    }
+
+    #[tokio::test]
+    async fn managed_retry_attempted_on_auth_error_with_credential_store() {
+        use crate::provider_credential::store::InMemoryCredentialStore;
+        let store: std::sync::Arc<InMemoryCredentialStore> =
+            std::sync::Arc::new(InMemoryCredentialStore::new());
+        let provider = AuthFailProvider {
+            call_count: Arc::new(AtomicUsize::new(0)),
+        };
+        let runtime = IronRuntime::new_with_credential_store(Config::default(), provider, store);
+        let managed_provider = Box::new(AuthFailProvider {
+            call_count: Arc::new(AtomicUsize::new(0)),
+        }) as Box<dyn Provider>;
+        let context = ProviderPromptContext {
+            provider_slug: crate::provider_credential::ProviderSlug::new("codex"),
+            model: "test".into(),
+            api_key: None,
+        };
+        let runner = PromptRunner::new_managed(runtime, managed_provider, context);
+        let (durable, ephemeral) = make_session_and_ephemeral();
+        let sink = NopSink;
+        let config = Config::default();
+
+        let stop = runner.run(&durable, &ephemeral, &sink, &config, 1).await;
+
+        assert_eq!(stop, acp::StopReason::EndTurn);
+        let agent_text = agent_text(&durable);
+        assert!(
+            agent_text.contains("auth error") || agent_text.contains("NotConfigured"),
+            "expected auth error or NotConfigured in transcript, got: {}",
+            agent_text
+        );
+    }
+
+    #[tokio::test]
+    async fn managed_retries_stream_auth_failure_before_output() {
+        use crate::provider_credential::store::InMemoryCredentialStore;
+
+        let store: std::sync::Arc<InMemoryCredentialStore> =
+            std::sync::Arc::new(InMemoryCredentialStore::new());
+        let runtime = IronRuntime::new_with_credential_store(
+            Config::default(),
+            StreamEventsProvider::new(vec![Ok(iron_providers::ProviderEvent::Complete)]),
+            store,
+        );
+        let initial_provider = StreamEventsProvider::new(vec![Err(
+            iron_providers::ProviderError::auth("expired access token"),
+        )]);
+        let retry_provider = StreamEventsProvider::new(vec![
+            Ok(iron_providers::ProviderEvent::Output {
+                content: "retry ok".into(),
+            }),
+            Ok(iron_providers::ProviderEvent::Complete),
+        ]);
+        let retry_calls = retry_provider.call_count.clone();
+        let context = ProviderPromptContext {
+            provider_slug: crate::provider_credential::ProviderSlug::new("codex"),
+            model: "test".into(),
+            api_key: None,
+        };
+        let runner = PromptRunner::new_managed_with_retry_provider_for_test(
+            runtime,
+            Box::new(initial_provider.clone()),
+            context,
+            Arc::new(move || Box::new(retry_provider.clone())),
+        );
+        let (durable, ephemeral) = make_session_and_ephemeral();
+        let sink = NopSink;
+
+        let stop = runner
+            .run(&durable, &ephemeral, &sink, &Config::default(), 1)
+            .await;
+
+        assert_eq!(stop, acp::StopReason::EndTurn);
+        assert_eq!(initial_provider.call_count(), 1);
+        assert_eq!(retry_calls.load(AtomicOrdering::SeqCst), 1);
+        assert!(agent_text(&durable).contains("retry ok"));
+    }
+
+    #[tokio::test]
+    async fn managed_does_not_retry_stream_auth_failure_after_output() {
+        use crate::provider_credential::store::InMemoryCredentialStore;
+
+        let store: std::sync::Arc<InMemoryCredentialStore> =
+            std::sync::Arc::new(InMemoryCredentialStore::new());
+        let runtime = IronRuntime::new_with_credential_store(
+            Config::default(),
+            StreamEventsProvider::new(vec![Ok(iron_providers::ProviderEvent::Complete)]),
+            store,
+        );
+        let initial_provider = StreamEventsProvider::new(vec![
+            Ok(iron_providers::ProviderEvent::Output {
+                content: "partial".into(),
+            }),
+            Err(iron_providers::ProviderError::auth("expired access token")),
+        ]);
+        let retry_calls = Arc::new(AtomicUsize::new(0));
+        let retry_calls_for_factory = retry_calls.clone();
+        let context = ProviderPromptContext {
+            provider_slug: crate::provider_credential::ProviderSlug::new("codex"),
+            model: "test".into(),
+            api_key: None,
+        };
+        let runner = PromptRunner::new_managed_with_retry_provider_for_test(
+            runtime,
+            Box::new(initial_provider.clone()),
+            context,
+            Arc::new(move || {
+                retry_calls_for_factory.fetch_add(1, AtomicOrdering::SeqCst);
+                Box::new(StreamEventsProvider::new(vec![Ok(
+                    iron_providers::ProviderEvent::Complete,
+                )]))
+            }),
+        );
+        let (durable, ephemeral) = make_session_and_ephemeral();
+        let sink = NopSink;
+
+        let stop = runner
+            .run(&durable, &ephemeral, &sink, &Config::default(), 1)
+            .await;
+
+        let text = agent_text(&durable);
+        assert_eq!(stop, acp::StopReason::EndTurn);
+        assert_eq!(initial_provider.call_count(), 1);
+        assert_eq!(retry_calls.load(AtomicOrdering::SeqCst), 0);
+        assert!(text.contains("partial"));
+        assert!(text.contains("Provider auth error"));
+    }
+
+    #[tokio::test]
+    async fn managed_does_not_retry_api_key_backed_auth_failure() {
+        use crate::provider_credential::store::InMemoryCredentialStore;
+
+        let store: std::sync::Arc<InMemoryCredentialStore> =
+            std::sync::Arc::new(InMemoryCredentialStore::new());
+        let runtime = IronRuntime::new_with_credential_store(
+            Config::default(),
+            StreamEventsProvider::new(vec![Ok(iron_providers::ProviderEvent::Complete)]),
+            store,
+        );
+        let initial_provider = StreamEventsProvider::new(vec![Err(
+            iron_providers::ProviderError::auth("bad api key"),
+        )]);
+        let retry_calls = Arc::new(AtomicUsize::new(0));
+        let retry_calls_for_factory = retry_calls.clone();
+        let context = ProviderPromptContext {
+            provider_slug: crate::provider_credential::ProviderSlug::new("kimi-code"),
+            model: "test".into(),
+            api_key: Some("sk-test".into()),
+        };
+        let runner = PromptRunner::new_managed_with_retry_provider_for_test(
+            runtime,
+            Box::new(initial_provider.clone()),
+            context,
+            Arc::new(move || {
+                retry_calls_for_factory.fetch_add(1, AtomicOrdering::SeqCst);
+                Box::new(StreamEventsProvider::new(vec![Ok(
+                    iron_providers::ProviderEvent::Complete,
+                )]))
+            }),
+        );
+        let (durable, ephemeral) = make_session_and_ephemeral();
+        let sink = NopSink;
+
+        let stop = runner
+            .run(&durable, &ephemeral, &sink, &Config::default(), 1)
+            .await;
+
+        assert_eq!(stop, acp::StopReason::EndTurn);
+        assert_eq!(initial_provider.call_count(), 1);
+        assert_eq!(retry_calls.load(AtomicOrdering::SeqCst), 0);
+        assert!(agent_text(&durable).contains("Provider auth error"));
+    }
+
+    #[tokio::test]
+    async fn managed_reports_repeated_auth_failure_after_retry() {
+        use crate::provider_credential::store::InMemoryCredentialStore;
+
+        let store: std::sync::Arc<InMemoryCredentialStore> =
+            std::sync::Arc::new(InMemoryCredentialStore::new());
+        let runtime = IronRuntime::new_with_credential_store(
+            Config::default(),
+            StreamEventsProvider::new(vec![Ok(iron_providers::ProviderEvent::Complete)]),
+            store,
+        );
+        let initial_provider = StreamEventsProvider::new(vec![Err(
+            iron_providers::ProviderError::auth("expired access token"),
+        )]);
+        let retry_provider = StreamEventsProvider::new(vec![Err(
+            iron_providers::ProviderError::auth("revoked token"),
+        )]);
+        let context = ProviderPromptContext {
+            provider_slug: crate::provider_credential::ProviderSlug::new("codex"),
+            model: "test".into(),
+            api_key: None,
+        };
+        let runner = PromptRunner::new_managed_with_retry_provider_for_test(
+            runtime,
+            Box::new(initial_provider.clone()),
+            context,
+            Arc::new(move || Box::new(retry_provider.clone())),
+        );
+        let (durable, ephemeral) = make_session_and_ephemeral();
+        let sink = NopSink;
+
+        let stop = runner
+            .run(&durable, &ephemeral, &sink, &Config::default(), 1)
+            .await;
+
+        let text = agent_text(&durable);
+        assert_eq!(stop, acp::StopReason::EndTurn);
+        assert!(text.contains("Provider auth error"));
+        assert!(text.contains("revoked token"));
+    }
 }

--- a/src/provider_credential/domain.rs
+++ b/src/provider_credential/domain.rs
@@ -1,0 +1,209 @@
+//! Domain types for provider credential orchestration.
+//!
+//! These types model provider identity, stored credential material, auth status,
+//! and actionable errors. They are separate from plugin auth types to avoid
+//! terminology confusion.
+
+use std::time::SystemTime;
+
+/// Provider identifier (slug) used for credential lookup and profile resolution.
+///
+/// Examples: `"kimi-code"`, `"codex"`, `"openai"`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ProviderSlug(pub String);
+
+impl ProviderSlug {
+    /// Create a new provider slug.
+    pub fn new<S: Into<String>>(slug: S) -> Self {
+        Self(slug.into())
+    }
+
+    /// Borrow the underlying slug string.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<String> for ProviderSlug {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl From<&str> for ProviderSlug {
+    fn from(s: &str) -> Self {
+        Self(s.to_string())
+    }
+}
+
+/// Which credential mode is stored for a provider.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CredentialMode {
+    /// API key credential.
+    ApiKey,
+    /// OAuth bearer credential.
+    OAuthBearer,
+}
+
+/// OAuth token material stored for a provider.
+///
+/// This includes the refresh token, which is intentionally not passed to
+/// `iron-providers`. Only the access token (and optional ID token) are
+/// forwarded after resolution.
+#[derive(Debug, Clone, PartialEq)]
+pub struct OAuthTokenSet {
+    /// Current access token.
+    pub access_token: String,
+    /// Refresh token used to obtain new access tokens.
+    pub refresh_token: String,
+    /// When the access token expires, if known.
+    pub expires_at: Option<SystemTime>,
+    /// Optional ID token (e.g. for Codex account routing).
+    pub id_token: Option<String>,
+}
+
+/// A stored provider credential, including secret material.
+#[derive(Debug, Clone, PartialEq)]
+pub enum StoredCredential {
+    /// API key string.
+    ApiKey(String),
+    /// OAuth token set with refresh token.
+    OAuthBearer(OAuthTokenSet),
+}
+
+impl StoredCredential {
+    /// Return the credential mode.
+    pub fn mode(&self) -> CredentialMode {
+        match self {
+            StoredCredential::ApiKey(_) => CredentialMode::ApiKey,
+            StoredCredential::OAuthBearer(_) => CredentialMode::OAuthBearer,
+        }
+    }
+}
+
+/// Client-visible provider auth status without secret material.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ProviderAuthStatus {
+    /// No credential is configured for this provider.
+    NotConfigured,
+    /// An API key is configured.
+    ConfiguredApiKey,
+    /// OAuth is connected with a known expiry.
+    ConnectedOAuth { expires_at: Option<SystemTime> },
+    /// OAuth refresh is in progress.
+    Refreshing,
+    /// OAuth access token has expired.
+    Expired,
+    /// OAuth refresh failed with a reason.
+    RefreshFailed { reason: String },
+    /// OAuth credential was revoked.
+    Revoked,
+    /// The configured credential mode is not supported by the provider.
+    UnsupportedCredential,
+}
+
+/// Errors that can occur during credential resolution or refresh.
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
+pub enum ProviderAuthError {
+    /// No credential is configured for the requested provider.
+    #[error("No credential configured for provider '{0}'")]
+    NotConfigured(String),
+
+    /// The provider does not support the configured credential mode.
+    #[error("Provider '{provider}' does not support credential mode {mode:?}")]
+    UnsupportedCredential {
+        provider: String,
+        mode: CredentialMode,
+    },
+
+    /// The OAuth access token has expired and no refresh token is available.
+    #[error("OAuth token expired for provider '{0}'")]
+    Expired(String),
+
+    /// OAuth token refresh failed.
+    #[error("OAuth refresh failed for provider '{provider}': {reason}")]
+    RefreshFailed { provider: String, reason: String },
+
+    /// The OAuth credential was revoked.
+    #[error("OAuth credential revoked for provider '{0}'")]
+    Revoked(String),
+}
+
+/// Result type for provider credential operations.
+pub type ProviderAuthResult<T> = Result<T, ProviderAuthError>;
+
+/// Context supplied by the client when resolving credentials for a prompt.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProviderPromptContext {
+    /// Provider slug (e.g. "kimi-code", "codex").
+    pub provider_slug: ProviderSlug,
+    /// Model identifier for the prompt.
+    pub model: String,
+    /// Optional API key supplied by the client. When present and supported by
+    /// the provider, this takes precedence over any stored OAuth credential.
+    pub api_key: Option<String>,
+}
+
+/// A resolved credential ready for provider construction.
+///
+/// This is the output of credential resolution. It contains the
+/// `iron_providers::ProviderCredential` (which never includes refresh tokens)
+/// and metadata about the resolution.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ResolvedCredential {
+    /// The provider-safe credential to pass to `iron-providers`.
+    pub provider_credential: iron_providers::ProviderCredential,
+    /// The original stored credential mode.
+    pub mode: CredentialMode,
+    /// Whether the credential was refreshed during resolution.
+    pub was_refreshed: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn provider_slug_from_str() {
+        let slug = ProviderSlug::from("kimi-code");
+        assert_eq!(slug.as_str(), "kimi-code");
+    }
+
+    #[test]
+    fn stored_credential_mode_api_key() {
+        let cred = StoredCredential::ApiKey("sk-test".into());
+        assert_eq!(cred.mode(), CredentialMode::ApiKey);
+    }
+
+    #[test]
+    fn stored_credential_mode_oauth() {
+        let cred = StoredCredential::OAuthBearer(OAuthTokenSet {
+            access_token: "at".into(),
+            refresh_token: "rt".into(),
+            expires_at: None,
+            id_token: None,
+        });
+        assert_eq!(cred.mode(), CredentialMode::OAuthBearer);
+    }
+
+    #[test]
+    fn provider_auth_status_variants() {
+        // Just exercise construction
+        let _ = ProviderAuthStatus::NotConfigured;
+        let _ = ProviderAuthStatus::ConfiguredApiKey;
+        let _ = ProviderAuthStatus::ConnectedOAuth { expires_at: None };
+        let _ = ProviderAuthStatus::Refreshing;
+        let _ = ProviderAuthStatus::Expired;
+        let _ = ProviderAuthStatus::RefreshFailed {
+            reason: "network".into(),
+        };
+        let _ = ProviderAuthStatus::Revoked;
+        let _ = ProviderAuthStatus::UnsupportedCredential;
+    }
+
+    #[test]
+    fn provider_auth_error_display() {
+        let e = ProviderAuthError::NotConfigured("codex".into());
+        assert!(e.to_string().contains("codex"));
+    }
+}

--- a/src/provider_credential/mod.rs
+++ b/src/provider_credential/mod.rs
@@ -1,0 +1,27 @@
+//! Provider credential orchestration for inference providers.
+//!
+//! This module provides the domain types, store boundary, OAuth metadata,
+//! credential resolution, provider construction, and auth-failure retry logic
+//! needed for `iron-core` to manage OAuth-backed provider credentials without
+//! duplicating that logic in every client.
+//!
+//! The module is additive: existing injected-provider paths in `IronAgent` and
+//! `IronRuntime` continue to work without using any of these types.
+
+pub mod domain;
+pub mod oauth;
+pub mod resolver;
+pub mod store;
+
+pub use domain::{
+    CredentialMode, OAuthTokenSet, ProviderAuthError, ProviderAuthResult, ProviderAuthStatus,
+    ProviderPromptContext, ProviderSlug, ResolvedCredential, StoredCredential,
+};
+pub use oauth::{
+    poll_token_exchange, refresh_access_token, start_device_code_flow, v1_oauth_metadata,
+    DeviceCodeInteraction, DeviceCodeStartResult, OAuthProviderMetadata, TokenExchangeResult,
+};
+pub use resolver::{CredentialResolver, CredentialSupport, REFRESH_MARGIN};
+pub use store::{
+    DynCredentialStore, InMemoryCredentialStore, NullCredentialStore, ProviderCredentialStore,
+};

--- a/src/provider_credential/oauth.rs
+++ b/src/provider_credential/oauth.rs
@@ -1,0 +1,621 @@
+//! OAuth device-code metadata and token lifecycle for V1 provider credentials.
+//!
+//! This module contains hardcoded OAuth metadata for `kimi-code` and `codex`
+//! providers, plus helpers for the device-authorization-grant flow and token
+//! refresh. Clients own the login UX; core owns the metadata and exchange logic.
+
+use crate::provider_credential::domain::{OAuthTokenSet, ProviderAuthError, ProviderSlug};
+use serde::Deserialize;
+use std::time::{Duration, SystemTime};
+
+/// V1 OAuth metadata for a provider.
+#[derive(Debug, Clone, PartialEq)]
+pub struct OAuthProviderMetadata {
+    /// Provider slug this metadata applies to.
+    pub slug: ProviderSlug,
+    /// OAuth issuer base URL (e.g. `https://auth.kimi.com`).
+    pub issuer: String,
+    /// Device authorization endpoint (relative or absolute).
+    pub device_authorization_endpoint: String,
+    /// Token endpoint (relative or absolute).
+    pub token_endpoint: String,
+    /// OAuth client ID.
+    pub client_id: String,
+    /// Requested scopes.
+    pub scopes: Vec<String>,
+}
+
+impl OAuthProviderMetadata {
+    /// Resolve the full device authorization URL.
+    pub fn device_authorization_url(&self) -> String {
+        resolve_url(&self.issuer, &self.device_authorization_endpoint)
+    }
+
+    /// Resolve the full token URL.
+    pub fn token_url(&self) -> String {
+        resolve_url(&self.issuer, &self.token_endpoint)
+    }
+}
+
+fn resolve_url(base: &str, path: &str) -> String {
+    if path.starts_with("http://") || path.starts_with("https://") {
+        path.to_string()
+    } else {
+        format!("{}{}", base.trim_end_matches('/'), path)
+    }
+}
+
+/// Hardcoded V1 metadata for supported OAuth providers.
+pub fn v1_oauth_metadata(slug: &ProviderSlug) -> Option<OAuthProviderMetadata> {
+    match slug.as_str() {
+        "kimi-code" => Some(OAuthProviderMetadata {
+            slug: slug.clone(),
+            issuer: "https://auth.kimi.com".to_string(),
+            device_authorization_endpoint: "/oauth/device/code".to_string(),
+            token_endpoint: "/oauth/token".to_string(),
+            client_id: "kimi-code-device".to_string(),
+            scopes: vec![
+                "openid".to_string(),
+                "profile".to_string(),
+                "email".to_string(),
+                "offline_access".to_string(),
+            ],
+        }),
+        "codex" => Some(OAuthProviderMetadata {
+            slug: slug.clone(),
+            issuer: "https://auth.openai.com".to_string(),
+            device_authorization_endpoint: "/oauth/device/code".to_string(),
+            token_endpoint: "/oauth/token".to_string(),
+            client_id: "app_EMoamEEZ73f0CkXaXp7hrann".to_string(),
+            scopes: vec![
+                "openid".to_string(),
+                "profile".to_string(),
+                "email".to_string(),
+                "offline_access".to_string(),
+            ],
+        }),
+        _ => None,
+    }
+}
+
+/// Data returned to the client to start a device-code login interaction.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DeviceCodeInteraction {
+    /// URL the user should visit to authorize.
+    pub verification_uri: String,
+    /// Code the user should enter at the verification URI.
+    pub user_code: String,
+    /// How long the device code is valid (seconds).
+    pub expires_in_secs: u64,
+    /// Minimum polling interval (seconds).
+    pub interval_secs: u64,
+}
+
+/// Start a device-code authorization flow.
+///
+/// Calls the provider's device authorization endpoint and returns the
+/// interaction data the client should present to the user.
+fn encode_form(params: &[(&str, &str)]) -> String {
+    let mut encoded = url::form_urlencoded::Serializer::new(String::new());
+    for (k, v) in params {
+        encoded.append_pair(k, v);
+    }
+    encoded.finish()
+}
+
+fn refresh_response_error(
+    metadata: &OAuthProviderMetadata,
+    status: reqwest::StatusCode,
+    body: &str,
+) -> ProviderAuthError {
+    let body_lower = body.to_lowercase();
+    if body_lower.contains("invalid_grant")
+        || body_lower.contains("revoked")
+        || body_lower.contains("access_denied")
+    {
+        ProviderAuthError::Revoked(metadata.slug.as_str().to_string())
+    } else {
+        ProviderAuthError::RefreshFailed {
+            provider: metadata.slug.as_str().to_string(),
+            reason: format!("refresh failed ({}): {}", status, body),
+        }
+    }
+}
+
+pub async fn start_device_code_flow(
+    metadata: &OAuthProviderMetadata,
+    client: &reqwest::Client,
+) -> Result<DeviceCodeStartResult, ProviderAuthError> {
+    let body = encode_form(&[
+        ("client_id", metadata.client_id.as_str()),
+        ("scope", metadata.scopes.join(" ").as_str()),
+    ]);
+
+    let response = client
+        .post(metadata.device_authorization_url())
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .body(body)
+        .send()
+        .await
+        .map_err(|e| ProviderAuthError::RefreshFailed {
+            provider: metadata.slug.as_str().to_string(),
+            reason: format!("device-code start request failed: {}", e),
+        })?;
+
+    let status = response.status();
+    let body = response
+        .text()
+        .await
+        .map_err(|e| ProviderAuthError::RefreshFailed {
+            provider: metadata.slug.as_str().to_string(),
+            reason: format!("failed to read device-code response: {}", e),
+        })?;
+
+    if !status.is_success() {
+        return Err(ProviderAuthError::RefreshFailed {
+            provider: metadata.slug.as_str().to_string(),
+            reason: format!("device-code start failed ({}): {}", status, body),
+        });
+    }
+
+    let parsed: DeviceCodeResponse =
+        serde_json::from_str(&body).map_err(|e| ProviderAuthError::RefreshFailed {
+            provider: metadata.slug.as_str().to_string(),
+            reason: format!("failed to parse device-code response: {}", e),
+        })?;
+
+    Ok(DeviceCodeStartResult {
+        device_code: parsed.device_code,
+        interaction: DeviceCodeInteraction {
+            verification_uri: parsed.verification_uri,
+            user_code: parsed.user_code,
+            expires_in_secs: parsed.expires_in,
+            interval_secs: parsed.interval.unwrap_or(5),
+        },
+    })
+}
+
+/// Result of starting a device-code flow.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DeviceCodeStartResult {
+    /// Device code used for polling (not user-visible).
+    pub device_code: String,
+    /// Interaction data for the client to render.
+    pub interaction: DeviceCodeInteraction,
+}
+
+/// Poll the token endpoint to exchange a device code for tokens.
+///
+/// This should be called repeatedly (respecting `interval_secs`) until it
+/// returns either tokens or a terminal error.
+pub async fn poll_token_exchange(
+    metadata: &OAuthProviderMetadata,
+    device_code: &str,
+    client: &reqwest::Client,
+) -> Result<TokenExchangeResult, ProviderAuthError> {
+    let body = encode_form(&[
+        ("grant_type", "urn:ietf:params:oauth:grant-type:device_code"),
+        ("device_code", device_code),
+        ("client_id", metadata.client_id.as_str()),
+    ]);
+
+    let response = client
+        .post(metadata.token_url())
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .body(body)
+        .send()
+        .await
+        .map_err(|e| ProviderAuthError::RefreshFailed {
+            provider: metadata.slug.as_str().to_string(),
+            reason: format!("token exchange request failed: {}", e),
+        })?;
+
+    let status = response.status();
+    let body = response
+        .text()
+        .await
+        .map_err(|e| ProviderAuthError::RefreshFailed {
+            provider: metadata.slug.as_str().to_string(),
+            reason: format!("failed to read token response: {}", e),
+        })?;
+
+    // Even on "pending" the token endpoint may return 400 with a known error
+    let parsed: TokenResponse =
+        serde_json::from_str(&body).map_err(|e| ProviderAuthError::RefreshFailed {
+            provider: metadata.slug.as_str().to_string(),
+            reason: format!("failed to parse token response: {}", e),
+        })?;
+
+    if let Some(error) = parsed.error {
+        let reason = match error.as_str() {
+            "authorization_pending" => "authorization pending".to_string(),
+            "slow_down" => "polling too fast".to_string(),
+            "expired_token" => "device code expired".to_string(),
+            "access_denied" => "access denied by user".to_string(),
+            _ => format!("token exchange error: {}", error),
+        };
+        return Err(ProviderAuthError::RefreshFailed {
+            provider: metadata.slug.as_str().to_string(),
+            reason,
+        });
+    }
+
+    if !status.is_success() {
+        return Err(ProviderAuthError::RefreshFailed {
+            provider: metadata.slug.as_str().to_string(),
+            reason: format!("token exchange failed ({}): {}", status, body),
+        });
+    }
+
+    let access_token = parsed
+        .access_token
+        .ok_or_else(|| ProviderAuthError::RefreshFailed {
+            provider: metadata.slug.as_str().to_string(),
+            reason: "token response missing access_token".to_string(),
+        })?;
+
+    let expires_at = parsed
+        .expires_in
+        .map(|secs| SystemTime::now() + Duration::from_secs(secs));
+
+    Ok(TokenExchangeResult {
+        access_token,
+        refresh_token: parsed.refresh_token.unwrap_or_default(),
+        expires_at,
+        id_token: parsed.id_token,
+    })
+}
+
+/// Refresh an OAuth access token using a refresh token.
+pub async fn refresh_access_token(
+    metadata: &OAuthProviderMetadata,
+    refresh_token: &str,
+    client: &reqwest::Client,
+) -> Result<TokenExchangeResult, ProviderAuthError> {
+    let body = encode_form(&[
+        ("grant_type", "refresh_token"),
+        ("refresh_token", refresh_token),
+        ("client_id", metadata.client_id.as_str()),
+    ]);
+
+    let response = client
+        .post(metadata.token_url())
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .body(body)
+        .send()
+        .await
+        .map_err(|e| ProviderAuthError::RefreshFailed {
+            provider: metadata.slug.as_str().to_string(),
+            reason: format!("refresh request failed: {}", e),
+        })?;
+
+    let status = response.status();
+    let body = response
+        .text()
+        .await
+        .map_err(|e| ProviderAuthError::RefreshFailed {
+            provider: metadata.slug.as_str().to_string(),
+            reason: format!("failed to read refresh response: {}", e),
+        })?;
+
+    if !status.is_success() {
+        return Err(refresh_response_error(metadata, status, &body));
+    }
+
+    let parsed: TokenResponse =
+        serde_json::from_str(&body).map_err(|e| ProviderAuthError::RefreshFailed {
+            provider: metadata.slug.as_str().to_string(),
+            reason: format!("failed to parse refresh response: {}", e),
+        })?;
+
+    let access_token = parsed
+        .access_token
+        .ok_or_else(|| ProviderAuthError::RefreshFailed {
+            provider: metadata.slug.as_str().to_string(),
+            reason: "refresh response missing access_token".to_string(),
+        })?;
+
+    let expires_at = parsed
+        .expires_in
+        .map(|secs| SystemTime::now() + Duration::from_secs(secs));
+
+    Ok(TokenExchangeResult {
+        access_token,
+        refresh_token: parsed.refresh_token.unwrap_or_default(),
+        expires_at,
+        id_token: parsed.id_token,
+    })
+}
+
+/// Result of a successful token exchange or refresh.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TokenExchangeResult {
+    /// New access token.
+    pub access_token: String,
+    /// New refresh token (may be empty if the server did not return one).
+    pub refresh_token: String,
+    /// When the access token expires.
+    pub expires_at: Option<SystemTime>,
+    /// Optional ID token.
+    pub id_token: Option<String>,
+}
+
+impl TokenExchangeResult {
+    /// Convert into an `OAuthTokenSet`.
+    ///
+    /// If `refresh_token` is empty, the caller should reuse the existing one.
+    pub fn into_token_set(self, existing_refresh_token: Option<String>) -> OAuthTokenSet {
+        let refresh_token = if self.refresh_token.is_empty() {
+            existing_refresh_token.unwrap_or_default()
+        } else {
+            self.refresh_token
+        };
+        OAuthTokenSet {
+            access_token: self.access_token,
+            refresh_token,
+            expires_at: self.expires_at,
+            id_token: self.id_token,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Internal JSON types for OAuth responses
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct DeviceCodeResponse {
+    device_code: String,
+    user_code: String,
+    verification_uri: String,
+    #[serde(default)]
+    expires_in: u64,
+    #[serde(default)]
+    interval: Option<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TokenResponse {
+    #[serde(default)]
+    access_token: Option<String>,
+    #[serde(default)]
+    refresh_token: Option<String>,
+    #[serde(default)]
+    expires_in: Option<u64>,
+    #[serde(default)]
+    id_token: Option<String>,
+    #[serde(default)]
+    error: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    #[test]
+    fn v1_metadata_kimi_code() {
+        let meta = v1_oauth_metadata(&ProviderSlug::new("kimi-code")).unwrap();
+        assert_eq!(meta.issuer, "https://auth.kimi.com");
+        assert_eq!(meta.client_id, "kimi-code-device");
+        assert_eq!(
+            meta.device_authorization_url(),
+            "https://auth.kimi.com/oauth/device/code"
+        );
+        assert_eq!(meta.token_url(), "https://auth.kimi.com/oauth/token");
+    }
+
+    #[test]
+    fn v1_metadata_codex() {
+        let meta = v1_oauth_metadata(&ProviderSlug::new("codex")).unwrap();
+        assert_eq!(meta.issuer, "https://auth.openai.com");
+        assert_eq!(meta.client_id, "app_EMoamEEZ73f0CkXaXp7hrann");
+    }
+
+    #[test]
+    fn v1_metadata_unknown() {
+        assert!(v1_oauth_metadata(&ProviderSlug::new("openai")).is_none());
+    }
+
+    #[test]
+    fn resolve_url_absolute() {
+        assert_eq!(
+            resolve_url("https://auth.kimi.com", "https://other.com/path"),
+            "https://other.com/path"
+        );
+    }
+
+    #[test]
+    fn resolve_url_relative() {
+        assert_eq!(
+            resolve_url("https://auth.kimi.com", "/oauth/token"),
+            "https://auth.kimi.com/oauth/token"
+        );
+    }
+
+    #[test]
+    fn token_exchange_into_token_set_reuses_refresh() {
+        let result = TokenExchangeResult {
+            access_token: "at".into(),
+            refresh_token: "".into(),
+            expires_at: None,
+            id_token: None,
+        };
+        let set = result.into_token_set(Some("old_rt".into()));
+        assert_eq!(set.refresh_token, "old_rt");
+    }
+
+    #[test]
+    fn token_exchange_into_token_set_uses_new_refresh() {
+        let result = TokenExchangeResult {
+            access_token: "at".into(),
+            refresh_token: "new_rt".into(),
+            expires_at: None,
+            id_token: None,
+        };
+        let set = result.into_token_set(Some("old_rt".into()));
+        assert_eq!(set.refresh_token, "new_rt");
+    }
+
+    #[test]
+    fn device_code_response_parsing() {
+        let json = r#"{
+            "device_code": "dev123",
+            "user_code": "USR-CODE",
+            "verification_uri": "https://auth.example.com/verify",
+            "expires_in": 600,
+            "interval": 5
+        }"#;
+        let parsed: DeviceCodeResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.device_code, "dev123");
+        assert_eq!(parsed.interval, Some(5));
+    }
+
+    #[test]
+    fn token_response_parsing_success() {
+        let json = r#"{
+            "access_token": "at123",
+            "refresh_token": "rt456",
+            "expires_in": 3600,
+            "id_token": "id789"
+        }"#;
+        let parsed: TokenResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.access_token, Some("at123".into()));
+        assert_eq!(parsed.id_token, Some("id789".into()));
+    }
+
+    #[test]
+    fn token_response_parsing_error() {
+        let json = r#"{"error": "authorization_pending"}"#;
+        let parsed: TokenResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.error, Some("authorization_pending".into()));
+    }
+
+    async fn serve_once(status: &str, body: &'static str) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let status = status.to_string();
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut buffer = [0_u8; 2048];
+            let _ = socket.read(&mut buffer).await.unwrap();
+            let response = format!(
+                "HTTP/1.1 {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                status,
+                body.len(),
+                body
+            );
+            socket.write_all(response.as_bytes()).await.unwrap();
+        });
+        format!("http://{}", address)
+    }
+
+    fn test_metadata(issuer: String) -> OAuthProviderMetadata {
+        OAuthProviderMetadata {
+            slug: ProviderSlug::new("codex"),
+            issuer,
+            device_authorization_endpoint: "/device".into(),
+            token_endpoint: "/token".into(),
+            client_id: "client".into(),
+            scopes: vec!["openid".into(), "offline_access".into()],
+        }
+    }
+
+    #[tokio::test]
+    async fn start_device_code_flow_success() {
+        let issuer = serve_once(
+            "200 OK",
+            r#"{
+                "device_code": "device-123",
+                "user_code": "USER-123",
+                "verification_uri": "https://example.com/verify",
+                "expires_in": 600,
+                "interval": 7
+            }"#,
+        )
+        .await;
+        let metadata = test_metadata(issuer);
+
+        let result = start_device_code_flow(&metadata, &reqwest::Client::new())
+            .await
+            .unwrap();
+
+        assert_eq!(result.device_code, "device-123");
+        assert_eq!(result.interaction.user_code, "USER-123");
+        assert_eq!(result.interaction.interval_secs, 7);
+    }
+
+    #[tokio::test]
+    async fn poll_token_exchange_success() {
+        let issuer = serve_once(
+            "200 OK",
+            r#"{
+                "access_token": "access-from-device",
+                "refresh_token": "refresh-from-device",
+                "expires_in": 3600,
+                "id_token": "id-from-device"
+            }"#,
+        )
+        .await;
+        let metadata = test_metadata(issuer);
+
+        let result = poll_token_exchange(&metadata, "device-123", &reqwest::Client::new())
+            .await
+            .unwrap();
+
+        assert_eq!(result.access_token, "access-from-device");
+        assert_eq!(result.refresh_token, "refresh-from-device");
+        assert_eq!(result.id_token, Some("id-from-device".into()));
+        assert!(result.expires_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn refresh_access_token_success_preserves_id_token_and_reuses_refresh() {
+        let issuer = serve_once(
+            "200 OK",
+            r#"{
+                "access_token": "new-access",
+                "expires_in": 3600,
+                "id_token": "new-id"
+            }"#,
+        )
+        .await;
+        let metadata = test_metadata(issuer);
+
+        let result = refresh_access_token(&metadata, "old-refresh", &reqwest::Client::new())
+            .await
+            .unwrap();
+        let token_set = result.into_token_set(Some("old-refresh".into()));
+
+        assert_eq!(token_set.access_token, "new-access");
+        assert_eq!(token_set.refresh_token, "old-refresh");
+        assert_eq!(token_set.id_token, Some("new-id".into()));
+        assert!(token_set.expires_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn refresh_access_token_failure_reports_refresh_failed() {
+        let issuer = serve_once("500 Internal Server Error", r#"{"error":"server_error"}"#).await;
+        let metadata = test_metadata(issuer);
+
+        let result = refresh_access_token(&metadata, "old-refresh", &reqwest::Client::new()).await;
+
+        assert!(matches!(
+            result,
+            Err(ProviderAuthError::RefreshFailed { ref provider, .. }) if provider == "codex"
+        ));
+    }
+
+    #[tokio::test]
+    async fn refresh_access_token_invalid_grant_reports_revoked() {
+        let issuer = serve_once("400 Bad Request", r#"{"error":"invalid_grant"}"#).await;
+        let metadata = test_metadata(issuer);
+
+        let result = refresh_access_token(&metadata, "old-refresh", &reqwest::Client::new()).await;
+
+        assert!(
+            matches!(result, Err(ProviderAuthError::Revoked(ref provider)) if provider == "codex")
+        );
+    }
+}

--- a/src/provider_credential/resolver.rs
+++ b/src/provider_credential/resolver.rs
@@ -1,0 +1,788 @@
+//! Credential resolver: turn app-supplied provider context into a
+//! provider-safe `ResolvedCredential`.
+//!
+//! The resolver looks up stored credentials, checks provider-profile support,
+//! refreshes expired/near-expiry OAuth tokens, and prefers API keys over OAuth
+//! for dual-mode providers.
+
+use crate::provider_credential::domain::{
+    CredentialMode, OAuthTokenSet, ProviderAuthError, ProviderAuthResult, ProviderAuthStatus,
+    ProviderPromptContext, ProviderSlug, ResolvedCredential, StoredCredential,
+};
+use crate::provider_credential::oauth::{refresh_access_token, v1_oauth_metadata};
+use crate::provider_credential::store::DynCredentialStore;
+use iron_providers::ProviderCredential;
+use parking_lot::Mutex;
+use std::collections::HashMap;
+use std::time::{Duration, SystemTime};
+
+/// Margin before expiry to trigger proactive refresh.
+pub const REFRESH_MARGIN: Duration = Duration::from_secs(5 * 60);
+
+/// Supported credential modes for a provider.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct CredentialSupport {
+    pub api_key: bool,
+    pub oauth_bearer: bool,
+}
+
+/// Resolves provider credentials for a prompt from stored state and optional
+/// client-supplied API keys.
+pub struct CredentialResolver {
+    store: DynCredentialStore,
+    support_map: HashMap<String, CredentialSupport>,
+    http_client: reqwest::Client,
+    status_overrides: Mutex<HashMap<String, ProviderAuthStatus>>,
+}
+
+fn build_v1_support_map() -> HashMap<String, CredentialSupport> {
+    let mut map = HashMap::new();
+    // Hardcoded V1 support based on iron-providers built-in profiles.
+    // kimi-code supports both API key (x-api-key) and OAuthBearer.
+    map.insert(
+        "kimi-code".to_string(),
+        CredentialSupport {
+            api_key: true,
+            oauth_bearer: true,
+        },
+    );
+    // codex supports only OAuthBearer.
+    map.insert(
+        "codex".to_string(),
+        CredentialSupport {
+            api_key: false,
+            oauth_bearer: true,
+        },
+    );
+    // openai supports only API key (default profile).
+    map.insert(
+        "openai".to_string(),
+        CredentialSupport {
+            api_key: true,
+            oauth_bearer: false,
+        },
+    );
+    // kimi (general) supports only API key.
+    map.insert(
+        "kimi".to_string(),
+        CredentialSupport {
+            api_key: true,
+            oauth_bearer: false,
+        },
+    );
+    map
+}
+
+impl CredentialResolver {
+    /// Create a new resolver with the given store.
+    ///
+    /// Built-in provider profiles from `iron-providers` are scanned to populate
+    /// the credential-support map.
+    pub fn new(store: DynCredentialStore) -> Self {
+        Self {
+            store,
+            support_map: build_v1_support_map(),
+            http_client: reqwest::Client::new(),
+            status_overrides: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Create a new resolver with a custom HTTP client (useful for testing).
+    pub fn with_http_client(store: DynCredentialStore, http_client: reqwest::Client) -> Self {
+        let mut resolver = Self::new(store);
+        resolver.http_client = http_client;
+        resolver
+    }
+
+    fn support_for(&self, slug: &str) -> CredentialSupport {
+        self.support_map
+            .get(&slug.to_lowercase())
+            .cloned()
+            .unwrap_or(CredentialSupport {
+                api_key: true,
+                oauth_bearer: true,
+            })
+    }
+
+    /// Resolve a credential for the given prompt context.
+    ///
+    /// If `api_key` is provided and the provider supports API-key auth, it is
+    /// used immediately (API key wins over OAuth for dual-mode providers).
+    ///
+    /// Otherwise, the credential store is queried for an OAuth credential.
+    /// If found and the provider supports OAuth, the token is refreshed if
+    /// expired or within `REFRESH_MARGIN` of expiry.
+    pub async fn resolve(
+        &self,
+        context: &ProviderPromptContext,
+        api_key: Option<String>,
+    ) -> ProviderAuthResult<ResolvedCredential> {
+        let slug_str = context.provider_slug.as_str();
+        let support = self.support_for(slug_str);
+
+        // Prefer API key if available and supported
+        if let Some(key) = api_key {
+            if support.api_key {
+                self.clear_status_override(slug_str);
+                return Ok(ResolvedCredential {
+                    provider_credential: ProviderCredential::ApiKey(key),
+                    mode: CredentialMode::ApiKey,
+                    was_refreshed: false,
+                });
+            } else {
+                return Err(ProviderAuthError::UnsupportedCredential {
+                    provider: slug_str.to_string(),
+                    mode: CredentialMode::ApiKey,
+                });
+            }
+        }
+
+        // Look up OAuth credential from store
+        let stored = self.store.get(&context.provider_slug).await;
+
+        match stored {
+            Some(StoredCredential::ApiKey(key)) => {
+                if !support.api_key {
+                    return Err(ProviderAuthError::UnsupportedCredential {
+                        provider: slug_str.to_string(),
+                        mode: CredentialMode::ApiKey,
+                    });
+                }
+
+                // This path should be rare (API keys in the credential store),
+                // but handle it gracefully.
+                self.clear_status_override(slug_str);
+                Ok(ResolvedCredential {
+                    provider_credential: ProviderCredential::ApiKey(key),
+                    mode: CredentialMode::ApiKey,
+                    was_refreshed: false,
+                })
+            }
+            Some(StoredCredential::OAuthBearer(tokens)) => {
+                if !support.oauth_bearer {
+                    return Err(ProviderAuthError::UnsupportedCredential {
+                        provider: slug_str.to_string(),
+                        mode: CredentialMode::OAuthBearer,
+                    });
+                }
+
+                let needs_refresh = Self::token_needs_refresh(&tokens);
+
+                if needs_refresh {
+                    let refreshed = self.refresh_oauth(&context.provider_slug, &tokens).await?;
+                    Ok(ResolvedCredential {
+                        provider_credential: ProviderCredential::OAuthBearer {
+                            access_token: refreshed.access_token.clone(),
+                            expires_at: refreshed.expires_at,
+                            id_token: refreshed.id_token.clone(),
+                        },
+                        mode: CredentialMode::OAuthBearer,
+                        was_refreshed: true,
+                    })
+                } else {
+                    self.clear_status_override(slug_str);
+                    Ok(ResolvedCredential {
+                        provider_credential: ProviderCredential::OAuthBearer {
+                            access_token: tokens.access_token.clone(),
+                            expires_at: tokens.expires_at,
+                            id_token: tokens.id_token.clone(),
+                        },
+                        mode: CredentialMode::OAuthBearer,
+                        was_refreshed: false,
+                    })
+                }
+            }
+            None => Err(ProviderAuthError::NotConfigured(slug_str.to_string())),
+        }
+    }
+
+    /// Derive the client-visible auth status for a provider.
+    ///
+    /// This checks both the optional API key and the stored OAuth credential.
+    pub async fn status(&self, slug: &ProviderSlug, api_key: Option<&str>) -> ProviderAuthStatus {
+        let slug_str = slug.as_str();
+        let support = self.support_for(slug_str);
+
+        if api_key.is_some() {
+            return if support.api_key {
+                ProviderAuthStatus::ConfiguredApiKey
+            } else {
+                ProviderAuthStatus::UnsupportedCredential
+            };
+        }
+
+        match self.store.get(slug).await {
+            Some(StoredCredential::ApiKey(_)) => {
+                if support.api_key {
+                    ProviderAuthStatus::ConfiguredApiKey
+                } else {
+                    ProviderAuthStatus::UnsupportedCredential
+                }
+            }
+            Some(StoredCredential::OAuthBearer(tokens)) => {
+                if !support.oauth_bearer {
+                    return ProviderAuthStatus::UnsupportedCredential;
+                }
+                if let Some(status) = self.status_overrides.lock().get(slug_str).cloned() {
+                    return status;
+                }
+                if Self::token_is_expired(&tokens) {
+                    ProviderAuthStatus::Expired
+                } else if Self::token_needs_refresh(&tokens) {
+                    ProviderAuthStatus::Refreshing
+                } else {
+                    ProviderAuthStatus::ConnectedOAuth {
+                        expires_at: tokens.expires_at,
+                    }
+                }
+            }
+            None => ProviderAuthStatus::NotConfigured,
+        }
+    }
+
+    /// Remove OAuth credential for a provider without touching API keys.
+    pub async fn disconnect_oauth(&self, slug: &ProviderSlug) {
+        // Only remove if the stored credential is OAuth
+        if let Some(StoredCredential::OAuthBearer(_)) = self.store.get(slug).await {
+            self.store.remove(slug).await;
+        }
+        self.clear_status_override(slug.as_str());
+    }
+
+    fn clear_status_override(&self, slug: &str) {
+        self.status_overrides.lock().remove(slug);
+    }
+
+    fn record_refresh_error(&self, slug: &ProviderSlug, error: &ProviderAuthError) {
+        let status = match error {
+            ProviderAuthError::Revoked(_) => ProviderAuthStatus::Revoked,
+            ProviderAuthError::RefreshFailed { reason, .. } => ProviderAuthStatus::RefreshFailed {
+                reason: reason.clone(),
+            },
+            _ => return,
+        };
+        self.status_overrides
+            .lock()
+            .insert(slug.as_str().to_string(), status);
+    }
+
+    fn token_needs_refresh(tokens: &OAuthTokenSet) -> bool {
+        match tokens.expires_at {
+            Some(expires_at) => {
+                let now = SystemTime::now();
+                match expires_at.duration_since(now) {
+                    Ok(remaining) => remaining < REFRESH_MARGIN,
+                    Err(_) => true, // already expired
+                }
+            }
+            None => false, // no expiry known, assume valid
+        }
+    }
+
+    fn token_is_expired(tokens: &OAuthTokenSet) -> bool {
+        match tokens.expires_at {
+            Some(expires_at) => SystemTime::now() >= expires_at,
+            None => false,
+        }
+    }
+
+    /// Force-refresh the OAuth token for a provider regardless of expiry.
+    ///
+    /// This is used after a provider auth failure to obtain a fresh token
+    /// before retrying the request.
+    pub async fn force_refresh(
+        &self,
+        slug: &ProviderSlug,
+    ) -> ProviderAuthResult<ResolvedCredential> {
+        let stored = self.store.get(slug).await;
+
+        match stored {
+            Some(StoredCredential::OAuthBearer(tokens)) => {
+                let refreshed = self.refresh_oauth(slug, &tokens).await?;
+                Ok(ResolvedCredential {
+                    provider_credential: ProviderCredential::OAuthBearer {
+                        access_token: refreshed.access_token.clone(),
+                        expires_at: refreshed.expires_at,
+                        id_token: refreshed.id_token.clone(),
+                    },
+                    mode: CredentialMode::OAuthBearer,
+                    was_refreshed: true,
+                })
+            }
+            Some(StoredCredential::ApiKey(key)) => {
+                let support = self.support_for(slug.as_str());
+                if !support.api_key {
+                    return Err(ProviderAuthError::UnsupportedCredential {
+                        provider: slug.as_str().to_string(),
+                        mode: CredentialMode::ApiKey,
+                    });
+                }
+                self.clear_status_override(slug.as_str());
+                Ok(ResolvedCredential {
+                    provider_credential: ProviderCredential::ApiKey(key),
+                    mode: CredentialMode::ApiKey,
+                    was_refreshed: false,
+                })
+            }
+            None => Err(ProviderAuthError::NotConfigured(slug.as_str().to_string())),
+        }
+    }
+
+    async fn refresh_oauth(
+        &self,
+        slug: &ProviderSlug,
+        tokens: &OAuthTokenSet,
+    ) -> ProviderAuthResult<OAuthTokenSet> {
+        let metadata = v1_oauth_metadata(slug).ok_or_else(|| ProviderAuthError::RefreshFailed {
+            provider: slug.as_str().to_string(),
+            reason: "no OAuth metadata for provider".to_string(),
+        })?;
+
+        let result =
+            match refresh_access_token(&metadata, &tokens.refresh_token, &self.http_client).await {
+                Ok(result) => result,
+                Err(error) => {
+                    self.record_refresh_error(slug, &error);
+                    return Err(error);
+                }
+            };
+
+        let new_set = result.into_token_set(Some(tokens.refresh_token.clone()));
+
+        // Persist the refreshed credential
+        self.store
+            .set(slug, StoredCredential::OAuthBearer(new_set.clone()))
+            .await;
+
+        self.clear_status_override(slug.as_str());
+        Ok(new_set)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provider_credential::store::{InMemoryCredentialStore, ProviderCredentialStore};
+    use std::sync::Arc;
+
+    fn make_resolver(store: DynCredentialStore) -> CredentialResolver {
+        CredentialResolver::new(store)
+    }
+
+    fn make_expired_tokens() -> OAuthTokenSet {
+        OAuthTokenSet {
+            access_token: "at".into(),
+            refresh_token: "rt".into(),
+            expires_at: Some(SystemTime::now() - Duration::from_secs(1)),
+            id_token: None,
+        }
+    }
+
+    fn make_near_expiry_tokens() -> OAuthTokenSet {
+        OAuthTokenSet {
+            access_token: "at".into(),
+            refresh_token: "rt".into(),
+            expires_at: Some(SystemTime::now() + Duration::from_secs(30)),
+            id_token: None,
+        }
+    }
+
+    fn make_fresh_tokens() -> OAuthTokenSet {
+        OAuthTokenSet {
+            access_token: "at".into(),
+            refresh_token: "rt".into(),
+            expires_at: Some(SystemTime::now() + Duration::from_secs(3600)),
+            id_token: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_missing_credential() {
+        let store: DynCredentialStore = Arc::new(InMemoryCredentialStore::new());
+        let resolver = make_resolver(store);
+        let ctx = ProviderPromptContext {
+            provider_slug: ProviderSlug::new("codex"),
+            model: "codex-model".into(),
+            api_key: None,
+        };
+
+        let result = resolver.resolve(&ctx, None).await;
+        assert!(matches!(result, Err(ProviderAuthError::NotConfigured(ref s)) if s == "codex"));
+    }
+
+    #[tokio::test]
+    async fn resolve_api_key() {
+        let store: DynCredentialStore = Arc::new(InMemoryCredentialStore::new());
+        let resolver = make_resolver(store);
+        let ctx = ProviderPromptContext {
+            provider_slug: ProviderSlug::new("openai"),
+            model: "gpt-4o".into(),
+            api_key: None,
+        };
+
+        let result = resolver
+            .resolve(&ctx, Some("sk-test".into()))
+            .await
+            .unwrap();
+        assert_eq!(result.mode, CredentialMode::ApiKey);
+        assert!(!result.was_refreshed);
+        assert_eq!(
+            result.provider_credential,
+            ProviderCredential::ApiKey("sk-test".into())
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_api_key_wins_over_oauth() {
+        let store = Arc::new(InMemoryCredentialStore::new());
+        store
+            .set(
+                &ProviderSlug::new("kimi-code"),
+                StoredCredential::OAuthBearer(make_fresh_tokens()),
+            )
+            .await;
+
+        let resolver = make_resolver(store);
+        let ctx = ProviderPromptContext {
+            provider_slug: ProviderSlug::new("kimi-code"),
+            model: "kimi-model".into(),
+            api_key: None,
+        };
+
+        let result = resolver
+            .resolve(&ctx, Some("sk-test".into()))
+            .await
+            .unwrap();
+        assert_eq!(result.mode, CredentialMode::ApiKey);
+    }
+
+    #[tokio::test]
+    async fn resolve_api_key_unsupported_for_codex() {
+        let store: DynCredentialStore = Arc::new(InMemoryCredentialStore::new());
+        let resolver = make_resolver(store);
+        let ctx = ProviderPromptContext {
+            provider_slug: ProviderSlug::new("codex"),
+            model: "codex-model".into(),
+            api_key: None,
+        };
+
+        let result = resolver.resolve(&ctx, Some("sk-test".into())).await;
+        assert!(matches!(
+            result,
+            Err(ProviderAuthError::UnsupportedCredential { ref provider, ref mode })
+            if provider == "codex" && *mode == CredentialMode::ApiKey
+        ));
+    }
+
+    #[tokio::test]
+    async fn resolve_oauth_fresh() {
+        let store = Arc::new(InMemoryCredentialStore::new());
+        store
+            .set(
+                &ProviderSlug::new("codex"),
+                StoredCredential::OAuthBearer(make_fresh_tokens()),
+            )
+            .await;
+
+        let resolver = make_resolver(store);
+        let ctx = ProviderPromptContext {
+            provider_slug: ProviderSlug::new("codex"),
+            model: "codex-model".into(),
+            api_key: None,
+        };
+
+        let result = resolver.resolve(&ctx, None).await.unwrap();
+        assert_eq!(result.mode, CredentialMode::OAuthBearer);
+        assert!(!result.was_refreshed);
+        assert!(matches!(
+            result.provider_credential,
+            ProviderCredential::OAuthBearer { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn resolve_oauth_unsupported_provider() {
+        let store = Arc::new(InMemoryCredentialStore::new());
+        store
+            .set(
+                &ProviderSlug::new("openai"),
+                StoredCredential::OAuthBearer(make_fresh_tokens()),
+            )
+            .await;
+
+        let resolver = make_resolver(store);
+        let ctx = ProviderPromptContext {
+            provider_slug: ProviderSlug::new("openai"),
+            model: "gpt-4o".into(),
+            api_key: None,
+        };
+
+        // openai built-in profile does not support OAuthBearer
+        let result = resolver.resolve(&ctx, None).await;
+        assert!(matches!(
+            result,
+            Err(ProviderAuthError::UnsupportedCredential { ref provider, ref mode })
+            if provider == "openai" && *mode == CredentialMode::OAuthBearer
+        ));
+    }
+
+    #[tokio::test]
+    async fn status_api_key() {
+        let store: DynCredentialStore = Arc::new(InMemoryCredentialStore::new());
+        let resolver = make_resolver(store);
+
+        assert_eq!(
+            resolver
+                .status(&ProviderSlug::new("kimi-code"), Some("sk"))
+                .await,
+            ProviderAuthStatus::ConfiguredApiKey
+        );
+    }
+
+    #[tokio::test]
+    async fn status_external_api_key_unsupported() {
+        let store: DynCredentialStore = Arc::new(InMemoryCredentialStore::new());
+        let resolver = make_resolver(store);
+
+        assert_eq!(
+            resolver
+                .status(&ProviderSlug::new("codex"), Some("sk"))
+                .await,
+            ProviderAuthStatus::UnsupportedCredential
+        );
+    }
+
+    #[tokio::test]
+    async fn status_oauth_fresh() {
+        let store = Arc::new(InMemoryCredentialStore::new());
+        store
+            .set(
+                &ProviderSlug::new("codex"),
+                StoredCredential::OAuthBearer(make_fresh_tokens()),
+            )
+            .await;
+
+        let resolver = make_resolver(store);
+        let status = resolver.status(&ProviderSlug::new("codex"), None).await;
+        assert!(matches!(status, ProviderAuthStatus::ConnectedOAuth { .. }));
+    }
+
+    #[tokio::test]
+    async fn status_oauth_expired() {
+        let store = Arc::new(InMemoryCredentialStore::new());
+        store
+            .set(
+                &ProviderSlug::new("codex"),
+                StoredCredential::OAuthBearer(make_expired_tokens()),
+            )
+            .await;
+
+        let resolver = make_resolver(store);
+        let status = resolver.status(&ProviderSlug::new("codex"), None).await;
+        assert_eq!(status, ProviderAuthStatus::Expired);
+    }
+
+    #[tokio::test]
+    async fn status_oauth_near_expiry_reports_refreshing() {
+        let store = Arc::new(InMemoryCredentialStore::new());
+        store
+            .set(
+                &ProviderSlug::new("codex"),
+                StoredCredential::OAuthBearer(make_near_expiry_tokens()),
+            )
+            .await;
+
+        let resolver = make_resolver(store);
+        let status = resolver.status(&ProviderSlug::new("codex"), None).await;
+        assert_eq!(status, ProviderAuthStatus::Refreshing);
+    }
+
+    #[tokio::test]
+    async fn status_unsupported_credential_mode() {
+        let store = Arc::new(InMemoryCredentialStore::new());
+        store
+            .set(
+                &ProviderSlug::new("openai"),
+                StoredCredential::OAuthBearer(make_fresh_tokens()),
+            )
+            .await;
+
+        let resolver = make_resolver(store);
+        let status = resolver.status(&ProviderSlug::new("openai"), None).await;
+        assert_eq!(status, ProviderAuthStatus::UnsupportedCredential);
+    }
+
+    #[tokio::test]
+    async fn status_api_key_stored_for_oauth_only_provider() {
+        let store = Arc::new(InMemoryCredentialStore::new());
+        store
+            .set(
+                &ProviderSlug::new("codex"),
+                StoredCredential::ApiKey("sk-test".into()),
+            )
+            .await;
+
+        let resolver = make_resolver(store);
+        let status = resolver.status(&ProviderSlug::new("codex"), None).await;
+        assert_eq!(status, ProviderAuthStatus::UnsupportedCredential);
+    }
+
+    #[tokio::test]
+    async fn resolve_stored_api_key_for_oauth_only_provider_is_unsupported() {
+        let store = Arc::new(InMemoryCredentialStore::new());
+        store
+            .set(
+                &ProviderSlug::new("codex"),
+                StoredCredential::ApiKey("sk-test".into()),
+            )
+            .await;
+
+        let resolver = make_resolver(store);
+        let ctx = ProviderPromptContext {
+            provider_slug: ProviderSlug::new("codex"),
+            model: "codex-model".into(),
+            api_key: None,
+        };
+
+        let result = resolver.resolve(&ctx, None).await;
+        assert!(matches!(
+            result,
+            Err(ProviderAuthError::UnsupportedCredential { ref provider, ref mode })
+                if provider == "codex" && *mode == CredentialMode::ApiKey
+        ));
+    }
+
+    #[tokio::test]
+    async fn disconnect_oauth_removes_only_oauth() {
+        let store = Arc::new(InMemoryCredentialStore::new());
+        store
+            .set(
+                &ProviderSlug::new("codex"),
+                StoredCredential::OAuthBearer(make_fresh_tokens()),
+            )
+            .await;
+
+        let resolver = make_resolver(store.clone());
+        resolver.disconnect_oauth(&ProviderSlug::new("codex")).await;
+
+        assert!(store.get(&ProviderSlug::new("codex")).await.is_none());
+    }
+
+    #[test]
+    fn token_needs_refresh_expired() {
+        assert!(CredentialResolver::token_needs_refresh(
+            &make_expired_tokens()
+        ));
+    }
+
+    #[test]
+    fn token_needs_refresh_near_expiry() {
+        assert!(CredentialResolver::token_needs_refresh(
+            &make_near_expiry_tokens()
+        ));
+    }
+
+    #[test]
+    fn token_needs_refresh_fresh() {
+        assert!(!CredentialResolver::token_needs_refresh(
+            &make_fresh_tokens()
+        ));
+    }
+
+    #[test]
+    fn support_map_populated_from_registry() {
+        let store: DynCredentialStore = Arc::new(InMemoryCredentialStore::new());
+        let resolver = make_resolver(store);
+
+        let kimi_support = resolver.support_for("kimi-code");
+        assert!(kimi_support.api_key);
+        assert!(kimi_support.oauth_bearer);
+
+        let codex_support = resolver.support_for("codex");
+        assert!(!codex_support.api_key);
+        assert!(codex_support.oauth_bearer);
+    }
+
+    #[tokio::test]
+    async fn force_refresh_returns_not_configured_when_missing() {
+        let store: DynCredentialStore = Arc::new(InMemoryCredentialStore::new());
+        let resolver = make_resolver(store);
+
+        let result = resolver.force_refresh(&ProviderSlug::new("codex")).await;
+        assert!(matches!(result, Err(ProviderAuthError::NotConfigured(ref s)) if s == "codex"));
+    }
+
+    #[tokio::test]
+    async fn force_refresh_returns_api_key_without_refresh() {
+        let store = Arc::new(InMemoryCredentialStore::new());
+        store
+            .set(
+                &ProviderSlug::new("kimi-code"),
+                StoredCredential::ApiKey("sk-test".into()),
+            )
+            .await;
+
+        let resolver = make_resolver(store);
+        let result = resolver
+            .force_refresh(&ProviderSlug::new("kimi-code"))
+            .await
+            .unwrap();
+        assert_eq!(result.mode, CredentialMode::ApiKey);
+        assert!(!result.was_refreshed);
+        assert_eq!(
+            result.provider_credential,
+            ProviderCredential::ApiKey("sk-test".into())
+        );
+    }
+
+    #[tokio::test]
+    async fn force_refresh_oauth_attempts_refresh_and_fails_without_network() {
+        let store = Arc::new(InMemoryCredentialStore::new());
+        store
+            .set(
+                &ProviderSlug::new("codex"),
+                StoredCredential::OAuthBearer(make_fresh_tokens()),
+            )
+            .await;
+
+        let resolver = make_resolver(store);
+        let result = resolver.force_refresh(&ProviderSlug::new("codex")).await;
+        // Without a mock token server, the refresh request fails.
+        assert!(
+            matches!(result, Err(ProviderAuthError::RefreshFailed { ref provider, .. }) if provider == "codex"),
+            "expected RefreshFailed for codex, got: {:?}",
+            result
+        );
+        assert!(matches!(
+            resolver.status(&ProviderSlug::new("codex"), None).await,
+            ProviderAuthStatus::RefreshFailed { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn resolve_prefers_explicit_api_key_over_stored_oauth() {
+        let store = Arc::new(InMemoryCredentialStore::new());
+        store
+            .set(
+                &ProviderSlug::new("kimi-code"),
+                StoredCredential::OAuthBearer(make_fresh_tokens()),
+            )
+            .await;
+
+        let resolver = make_resolver(store);
+        let ctx = ProviderPromptContext {
+            provider_slug: ProviderSlug::new("kimi-code"),
+            model: "kimi-model".into(),
+            api_key: None,
+        };
+
+        let result = resolver
+            .resolve(&ctx, Some("explicit-key".into()))
+            .await
+            .unwrap();
+        assert_eq!(
+            result.provider_credential,
+            ProviderCredential::ApiKey("explicit-key".into())
+        );
+    }
+}

--- a/src/provider_credential/store.rs
+++ b/src/provider_credential/store.rs
@@ -1,0 +1,231 @@
+//! Provider credential store boundary.
+//!
+//! Clients provide a store implementation for OAuth credential persistence.
+//! `iron-core` interacts only through this boundary and has no dependency on
+//! concrete storage backends such as SQLite or OS keyrings.
+
+use crate::provider_credential::domain::{ProviderAuthStatus, ProviderSlug, StoredCredential};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// Async boundary for provider credential storage.
+///
+/// Implementations are provided by clients (e.g. AgentIron with SQLite,
+/// `iron-tui` with an in-memory store, etc.). `iron-core` uses this trait
+/// to look up, update, remove, and list provider credentials.
+#[async_trait::async_trait]
+pub trait ProviderCredentialStore: Send + Sync {
+    /// Look up the stored credential for a provider, if any.
+    async fn get(&self, slug: &ProviderSlug) -> Option<StoredCredential>;
+
+    /// Store or replace the credential for a provider.
+    async fn set(&self, slug: &ProviderSlug, credential: StoredCredential);
+
+    /// Remove the stored credential for a provider.
+    async fn remove(&self, slug: &ProviderSlug);
+
+    /// List all providers that have stored credentials.
+    async fn list_slugs(&self) -> Vec<ProviderSlug>;
+}
+
+/// An in-memory credential store for testing and lightweight clients.
+///
+/// All operations are synchronous under the hood but exposed via the async
+/// trait for compatibility.
+pub struct InMemoryCredentialStore {
+    inner: parking_lot::Mutex<HashMap<String, StoredCredential>>,
+}
+
+impl InMemoryCredentialStore {
+    /// Create a new empty in-memory store.
+    pub fn new() -> Self {
+        Self {
+            inner: parking_lot::Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Create a new store pre-populated with credentials.
+    pub fn from_map(map: HashMap<String, StoredCredential>) -> Self {
+        Self {
+            inner: parking_lot::Mutex::new(map),
+        }
+    }
+
+    /// Get a clone of the entire contents for inspection in tests.
+    pub fn snapshot(&self) -> HashMap<String, StoredCredential> {
+        self.inner.lock().clone()
+    }
+
+    /// Derive a client-visible auth status from a stored credential.
+    ///
+    /// This helper is available on the in-memory store for test convenience.
+    /// Production store implementations may compute status differently.
+    pub fn status_from_credential(cred: Option<&StoredCredential>) -> ProviderAuthStatus {
+        match cred {
+            None => ProviderAuthStatus::NotConfigured,
+            Some(StoredCredential::ApiKey(_)) => ProviderAuthStatus::ConfiguredApiKey,
+            Some(StoredCredential::OAuthBearer(tokens)) => {
+                let now = std::time::SystemTime::now();
+                match tokens.expires_at {
+                    Some(expires_at) if now >= expires_at => ProviderAuthStatus::Expired,
+                    _ => ProviderAuthStatus::ConnectedOAuth {
+                        expires_at: tokens.expires_at,
+                    },
+                }
+            }
+        }
+    }
+}
+
+impl Default for InMemoryCredentialStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait::async_trait]
+impl ProviderCredentialStore for InMemoryCredentialStore {
+    async fn get(&self, slug: &ProviderSlug) -> Option<StoredCredential> {
+        self.inner.lock().get(slug.as_str()).cloned()
+    }
+
+    async fn set(&self, slug: &ProviderSlug, credential: StoredCredential) {
+        self.inner
+            .lock()
+            .insert(slug.as_str().to_string(), credential);
+    }
+
+    async fn remove(&self, slug: &ProviderSlug) {
+        self.inner.lock().remove(slug.as_str());
+    }
+
+    async fn list_slugs(&self) -> Vec<ProviderSlug> {
+        self.inner
+            .lock()
+            .keys()
+            .cloned()
+            .map(ProviderSlug::new)
+            .collect()
+    }
+}
+
+/// A no-op store that never persists anything.
+///
+/// Useful when the managed provider path is enabled but the client does not
+/// wish to persist credentials.
+pub struct NullCredentialStore;
+
+#[async_trait::async_trait]
+impl ProviderCredentialStore for NullCredentialStore {
+    async fn get(&self, _slug: &ProviderSlug) -> Option<StoredCredential> {
+        None
+    }
+
+    async fn set(&self, _slug: &ProviderSlug, _credential: StoredCredential) {
+        // no-op
+    }
+
+    async fn remove(&self, _slug: &ProviderSlug) {
+        // no-op
+    }
+
+    async fn list_slugs(&self) -> Vec<ProviderSlug> {
+        Vec::new()
+    }
+}
+
+/// Type-erased handle to a credential store.
+pub type DynCredentialStore = Arc<dyn ProviderCredentialStore>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provider_credential::domain::{OAuthTokenSet, ProviderAuthStatus};
+
+    #[tokio::test]
+    async fn in_memory_store_roundtrip() {
+        let store = InMemoryCredentialStore::new();
+        let slug = ProviderSlug::new("kimi-code");
+        let cred = StoredCredential::ApiKey("sk-test".into());
+
+        assert!(store.get(&slug).await.is_none());
+
+        store.set(&slug, cred.clone()).await;
+        let got = store.get(&slug).await;
+        assert_eq!(got, Some(cred));
+
+        store.remove(&slug).await;
+        assert!(store.get(&slug).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn in_memory_store_list_slugs() {
+        let store = InMemoryCredentialStore::new();
+        let slug_a = ProviderSlug::new("kimi-code");
+        let slug_b = ProviderSlug::new("codex");
+
+        store
+            .set(&slug_a, StoredCredential::ApiKey("sk-a".into()))
+            .await;
+        store
+            .set(&slug_b, StoredCredential::ApiKey("sk-b".into()))
+            .await;
+
+        let mut slugs = store.list_slugs().await;
+        slugs.sort_by(|a, b| a.as_str().cmp(b.as_str()));
+        assert_eq!(slugs, vec![slug_b, slug_a]);
+    }
+
+    #[tokio::test]
+    async fn null_store_always_empty() {
+        let store = NullCredentialStore;
+        let slug = ProviderSlug::new("codex");
+        assert!(store.get(&slug).await.is_none());
+        assert!(store.list_slugs().await.is_empty());
+    }
+
+    #[test]
+    fn status_from_credential_api_key() {
+        let cred = StoredCredential::ApiKey("sk-test".into());
+        assert_eq!(
+            InMemoryCredentialStore::status_from_credential(Some(&cred)),
+            ProviderAuthStatus::ConfiguredApiKey
+        );
+    }
+
+    #[test]
+    fn status_from_credential_oauth_valid() {
+        let cred = StoredCredential::OAuthBearer(OAuthTokenSet {
+            access_token: "at".into(),
+            refresh_token: "rt".into(),
+            expires_at: Some(std::time::SystemTime::now() + std::time::Duration::from_secs(3600)),
+            id_token: None,
+        });
+        assert!(matches!(
+            InMemoryCredentialStore::status_from_credential(Some(&cred)),
+            ProviderAuthStatus::ConnectedOAuth { .. }
+        ));
+    }
+
+    #[test]
+    fn status_from_credential_oauth_expired() {
+        let cred = StoredCredential::OAuthBearer(OAuthTokenSet {
+            access_token: "at".into(),
+            refresh_token: "rt".into(),
+            expires_at: Some(std::time::SystemTime::now() - std::time::Duration::from_secs(1)),
+            id_token: None,
+        });
+        assert_eq!(
+            InMemoryCredentialStore::status_from_credential(Some(&cred)),
+            ProviderAuthStatus::Expired
+        );
+    }
+
+    #[test]
+    fn status_from_credential_none() {
+        assert_eq!(
+            InMemoryCredentialStore::status_from_credential(None),
+            ProviderAuthStatus::NotConfigured
+        );
+    }
+}

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -14,6 +14,12 @@ use crate::{
     plugin::registry::{PluginAvailabilitySummary, PluginRegistry},
     plugin::status::{PluginInfo, PluginStatus},
     plugin::wasm_host::WasmHost,
+    provider_credential::domain::{
+        ProviderAuthError, ProviderAuthResult, ProviderAuthStatus, ProviderPromptContext,
+        ProviderSlug,
+    },
+    provider_credential::resolver::CredentialResolver,
+    provider_credential::store::DynCredentialStore,
     skill::source::FilesystemSkillSource,
     skill::SkillOrigin,
     skill::{LoadedSkill, SkillCatalog, SkillDiagnostic},
@@ -46,6 +52,7 @@ struct RuntimeInner {
     is_shutdown: AtomicBool,
     shutdown_tx: watch::Sender<bool>,
     active_tasks: Mutex<Vec<JoinHandle<()>>>,
+    resolver: Option<Arc<CredentialResolver>>,
 }
 
 struct ActivePrompt {
@@ -196,6 +203,7 @@ impl IronRuntime {
             is_shutdown: AtomicBool::new(false),
             shutdown_tx,
             active_tasks: Mutex::new(Vec::new()),
+            resolver: None,
         };
 
         let this = Self {
@@ -216,6 +224,22 @@ impl IronRuntime {
         }
 
         this
+    }
+
+    /// Create a new runtime with a credential store for managed provider resolution.
+    pub fn new_with_credential_store<P>(
+        config: Config,
+        provider: P,
+        credential_store: DynCredentialStore,
+    ) -> Self
+    where
+        P: Provider + 'static,
+    {
+        let mut runtime = Self::new(config, provider);
+        if let Some(inner) = Arc::get_mut(&mut runtime.inner) {
+            inner.resolver = Some(Arc::new(CredentialResolver::new(credential_store)));
+        }
+        runtime
     }
 
     /// Create a new runtime using an existing Tokio runtime handle.
@@ -247,6 +271,7 @@ impl IronRuntime {
             is_shutdown: AtomicBool::new(false),
             shutdown_tx,
             active_tasks: Mutex::new(Vec::new()),
+            resolver: None,
         };
 
         let this = Self {
@@ -269,6 +294,24 @@ impl IronRuntime {
         this
     }
 
+    /// Create a new runtime using an existing Tokio runtime handle, with a
+    /// credential store for managed provider resolution.
+    pub fn from_handle_with_credential_store<P>(
+        config: Config,
+        provider: P,
+        handle: tokio::runtime::Handle,
+        credential_store: DynCredentialStore,
+    ) -> Self
+    where
+        P: Provider + 'static,
+    {
+        let mut runtime = Self::from_handle(config, provider, handle);
+        if let Some(inner) = Arc::get_mut(&mut runtime.inner) {
+            inner.resolver = Some(Arc::new(CredentialResolver::new(credential_store)));
+        }
+        runtime
+    }
+
     /// Borrow the validated runtime configuration.
     pub fn config(&self) -> &Config {
         &self.inner.config
@@ -277,6 +320,98 @@ impl IronRuntime {
     /// Borrow the provider implementation used for inference.
     pub fn provider(&self) -> &dyn Provider {
         self.inner.provider.as_ref()
+    }
+
+    /// Resolve a managed provider for the given prompt context.
+    ///
+    /// This looks up credentials, refreshes if needed, and constructs a
+    /// provider from the built-in registry. Returns an error if no resolver
+    /// is configured or if credential resolution fails.
+    pub async fn resolve_managed_provider(
+        &self,
+        context: &ProviderPromptContext,
+    ) -> ProviderAuthResult<Box<dyn Provider>> {
+        let resolver = self.inner.resolver.as_ref().ok_or_else(|| {
+            ProviderAuthError::NotConfigured(context.provider_slug.as_str().to_string())
+        })?;
+
+        let resolved = resolver.resolve(context, context.api_key.clone()).await?;
+        let runtime_config =
+            iron_providers::RuntimeConfig::from_credential(resolved.provider_credential);
+
+        let registry = iron_providers::ProviderRegistry::default();
+        let provider = registry
+            .get(context.provider_slug.as_str(), runtime_config)
+            .map_err(|_e| ProviderAuthError::UnsupportedCredential {
+                provider: context.provider_slug.as_str().to_string(),
+                mode: resolved.mode,
+            })?;
+
+        Ok(provider)
+    }
+
+    /// Get the client-visible auth status for a provider.
+    pub async fn provider_auth_status(&self, slug: &ProviderSlug) -> Option<ProviderAuthStatus> {
+        self.provider_auth_status_with_api_key(slug, None).await
+    }
+
+    /// Get the client-visible auth status for a provider, considering an
+    /// app-owned API key when present.
+    pub async fn provider_auth_status_with_api_key(
+        &self,
+        slug: &ProviderSlug,
+        api_key: Option<&str>,
+    ) -> Option<ProviderAuthStatus> {
+        let resolver = self.inner.resolver.as_ref()?;
+        Some(resolver.status(slug, api_key).await)
+    }
+
+    /// Get the client-visible auth status for a managed prompt context.
+    pub async fn provider_auth_status_for_context(
+        &self,
+        context: &ProviderPromptContext,
+    ) -> Option<ProviderAuthStatus> {
+        self.provider_auth_status_with_api_key(&context.provider_slug, context.api_key.as_deref())
+            .await
+    }
+
+    /// Disconnect OAuth for a provider without removing API keys.
+    pub async fn disconnect_provider_oauth(&self, slug: &ProviderSlug) {
+        if let Some(resolver) = self.inner.resolver.as_ref() {
+            resolver.disconnect_oauth(slug).await;
+        }
+    }
+
+    /// Force-refresh and resolve a managed provider for the given prompt context.
+    ///
+    /// This always refreshes OAuth tokens (if present) before constructing the
+    /// provider, regardless of expiry. Used for auth-failure retry.
+    pub async fn force_refresh_managed_provider(
+        &self,
+        context: &ProviderPromptContext,
+    ) -> ProviderAuthResult<Box<dyn Provider>> {
+        let resolver = self.inner.resolver.as_ref().ok_or_else(|| {
+            ProviderAuthError::NotConfigured(context.provider_slug.as_str().to_string())
+        })?;
+
+        let resolved = resolver.force_refresh(&context.provider_slug).await?;
+        let runtime_config =
+            iron_providers::RuntimeConfig::from_credential(resolved.provider_credential);
+
+        let registry = iron_providers::ProviderRegistry::default();
+        let provider = registry
+            .get(context.provider_slug.as_str(), runtime_config)
+            .map_err(|_e| ProviderAuthError::UnsupportedCredential {
+                provider: context.provider_slug.as_str().to_string(),
+                mode: resolved.mode,
+            })?;
+
+        Ok(provider)
+    }
+
+    /// Borrow the credential resolver, if configured.
+    pub fn credential_resolver(&self) -> Option<&CredentialResolver> {
+        self.inner.resolver.as_ref().map(|arc| arc.as_ref())
     }
 
     /// Borrow the tool registry.
@@ -1042,6 +1177,7 @@ impl std::fmt::Debug for IronRuntime {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::provider_credential::store::ProviderCredentialStore;
     use crate::skill::source::StaticSkillSource;
     use crate::skill::{LoadedSkill, SkillMetadata};
     use futures::stream::{self, BoxStream};
@@ -1188,5 +1324,251 @@ mod tests {
         assert_eq!(skill.origin, SkillOrigin::UserFilesystem);
 
         let _ = std::fs::remove_dir_all(temp_root);
+    }
+
+    // -----------------------------------------------------------------------
+    // Managed provider execution path tests
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn new_with_credential_store_creates_resolver() {
+        use crate::provider_credential::store::InMemoryCredentialStore;
+        let store: std::sync::Arc<InMemoryCredentialStore> =
+            std::sync::Arc::new(InMemoryCredentialStore::new());
+        let runtime =
+            IronRuntime::new_with_credential_store(Config::default(), MockProvider, store);
+        assert!(runtime.credential_resolver().is_some());
+    }
+
+    #[tokio::test]
+    async fn provider_auth_status_not_configured() {
+        use crate::provider_credential::store::InMemoryCredentialStore;
+        let store: std::sync::Arc<InMemoryCredentialStore> =
+            std::sync::Arc::new(InMemoryCredentialStore::new());
+        let runtime =
+            IronRuntime::new_with_credential_store(Config::default(), MockProvider, store);
+        let status = runtime
+            .provider_auth_status(&ProviderSlug::new("codex"))
+            .await;
+        assert_eq!(status, Some(ProviderAuthStatus::NotConfigured));
+    }
+
+    #[tokio::test]
+    async fn provider_auth_status_api_key() {
+        use crate::provider_credential::store::InMemoryCredentialStore;
+        let store: std::sync::Arc<InMemoryCredentialStore> =
+            std::sync::Arc::new(InMemoryCredentialStore::new());
+        store
+            .set(
+                &ProviderSlug::new("openai"),
+                crate::provider_credential::StoredCredential::ApiKey("sk-test".into()),
+            )
+            .await;
+        let runtime =
+            IronRuntime::new_with_credential_store(Config::default(), MockProvider, store);
+        let status = runtime
+            .provider_auth_status(&ProviderSlug::new("openai"))
+            .await;
+        assert_eq!(status, Some(ProviderAuthStatus::ConfiguredApiKey));
+    }
+
+    #[tokio::test]
+    async fn provider_auth_status_for_context_uses_api_key() {
+        use crate::provider_credential::store::InMemoryCredentialStore;
+        let store: std::sync::Arc<InMemoryCredentialStore> =
+            std::sync::Arc::new(InMemoryCredentialStore::new());
+        let runtime =
+            IronRuntime::new_with_credential_store(Config::default(), MockProvider, store);
+        let context = ProviderPromptContext {
+            provider_slug: ProviderSlug::new("kimi-code"),
+            model: "kimi-for-coding".into(),
+            api_key: Some("sk-test".into()),
+        };
+
+        let status = runtime.provider_auth_status_for_context(&context).await;
+
+        assert_eq!(status, Some(ProviderAuthStatus::ConfiguredApiKey));
+    }
+
+    #[tokio::test]
+    async fn provider_auth_status_for_context_reports_unsupported_api_key() {
+        use crate::provider_credential::store::InMemoryCredentialStore;
+        let store: std::sync::Arc<InMemoryCredentialStore> =
+            std::sync::Arc::new(InMemoryCredentialStore::new());
+        let runtime =
+            IronRuntime::new_with_credential_store(Config::default(), MockProvider, store);
+        let context = ProviderPromptContext {
+            provider_slug: ProviderSlug::new("codex"),
+            model: "codex-model".into(),
+            api_key: Some("sk-test".into()),
+        };
+
+        let status = runtime.provider_auth_status_for_context(&context).await;
+
+        assert_eq!(status, Some(ProviderAuthStatus::UnsupportedCredential));
+    }
+
+    #[tokio::test]
+    async fn disconnect_provider_oauth_removes_oauth_only() {
+        use crate::provider_credential::store::InMemoryCredentialStore;
+        let store: std::sync::Arc<InMemoryCredentialStore> =
+            std::sync::Arc::new(InMemoryCredentialStore::new());
+        let slug = ProviderSlug::new("kimi-code");
+        store
+            .set(
+                &slug,
+                crate::provider_credential::StoredCredential::OAuthBearer(
+                    crate::provider_credential::OAuthTokenSet {
+                        access_token: "at".into(),
+                        refresh_token: "rt".into(),
+                        expires_at: None,
+                        id_token: None,
+                    },
+                ),
+            )
+            .await;
+        let runtime =
+            IronRuntime::new_with_credential_store(Config::default(), MockProvider, store.clone());
+        runtime.disconnect_provider_oauth(&slug).await;
+        let stored = store.get(&slug).await;
+        assert!(stored.is_none());
+    }
+
+    #[tokio::test]
+    async fn resolve_managed_provider_api_key() {
+        use crate::provider_credential::store::InMemoryCredentialStore;
+        let store: std::sync::Arc<InMemoryCredentialStore> =
+            std::sync::Arc::new(InMemoryCredentialStore::new());
+        // kimi-code is a dual-mode provider in the built-in registry
+        let slug = ProviderSlug::new("kimi-code");
+        store
+            .set(
+                &slug,
+                crate::provider_credential::StoredCredential::ApiKey("sk-test".into()),
+            )
+            .await;
+        let runtime =
+            IronRuntime::new_with_credential_store(Config::default(), MockProvider, store);
+        let context = ProviderPromptContext {
+            provider_slug: slug,
+            model: "kimi-for-coding".into(),
+            api_key: None,
+        };
+        let result = runtime.resolve_managed_provider(&context).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn resolve_managed_provider_kimi_code_oauth() {
+        use crate::provider_credential::store::InMemoryCredentialStore;
+        let store: std::sync::Arc<InMemoryCredentialStore> =
+            std::sync::Arc::new(InMemoryCredentialStore::new());
+        let slug = ProviderSlug::new("kimi-code");
+        store
+            .set(
+                &slug,
+                crate::provider_credential::StoredCredential::OAuthBearer(
+                    crate::provider_credential::OAuthTokenSet {
+                        access_token: "access-token".into(),
+                        refresh_token: "refresh-token".into(),
+                        expires_at: None,
+                        id_token: None,
+                    },
+                ),
+            )
+            .await;
+        let runtime =
+            IronRuntime::new_with_credential_store(Config::default(), MockProvider, store);
+        let context = ProviderPromptContext {
+            provider_slug: slug,
+            model: "kimi-for-coding".into(),
+            api_key: None,
+        };
+
+        let result = runtime.resolve_managed_provider(&context).await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn resolve_managed_provider_codex_oauth() {
+        use crate::provider_credential::store::InMemoryCredentialStore;
+        let store: std::sync::Arc<InMemoryCredentialStore> =
+            std::sync::Arc::new(InMemoryCredentialStore::new());
+        let slug = ProviderSlug::new("codex");
+        store
+            .set(
+                &slug,
+                crate::provider_credential::StoredCredential::OAuthBearer(
+                    crate::provider_credential::OAuthTokenSet {
+                        access_token: "access-token".into(),
+                        refresh_token: "refresh-token".into(),
+                        expires_at: None,
+                        id_token: Some("id-token".into()),
+                    },
+                ),
+            )
+            .await;
+        let runtime =
+            IronRuntime::new_with_credential_store(Config::default(), MockProvider, store);
+        let context = ProviderPromptContext {
+            provider_slug: slug,
+            model: "codex-model".into(),
+            api_key: None,
+        };
+
+        let result = runtime.resolve_managed_provider(&context).await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn resolve_managed_provider_missing() {
+        use crate::provider_credential::store::InMemoryCredentialStore;
+        let store: std::sync::Arc<InMemoryCredentialStore> =
+            std::sync::Arc::new(InMemoryCredentialStore::new());
+        let runtime =
+            IronRuntime::new_with_credential_store(Config::default(), MockProvider, store);
+        let context = ProviderPromptContext {
+            provider_slug: ProviderSlug::new("codex"),
+            model: "codex-model".into(),
+            api_key: None,
+        };
+        let result = runtime.resolve_managed_provider(&context).await;
+        assert!(matches!(result, Err(ProviderAuthError::NotConfigured(ref s)) if s == "codex"),);
+    }
+
+    #[tokio::test]
+    async fn resolve_managed_provider_with_context_api_key() {
+        use crate::provider_credential::store::InMemoryCredentialStore;
+        let store: std::sync::Arc<InMemoryCredentialStore> =
+            std::sync::Arc::new(InMemoryCredentialStore::new());
+        let runtime =
+            IronRuntime::new_with_credential_store(Config::default(), MockProvider, store);
+        let context = ProviderPromptContext {
+            provider_slug: ProviderSlug::new("kimi-code"),
+            model: "kimi-for-coding".into(),
+            api_key: Some("sk-test-key".into()),
+        };
+        let result = runtime.resolve_managed_provider(&context).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn resolve_managed_provider_context_api_key_unsupported() {
+        use crate::provider_credential::store::InMemoryCredentialStore;
+        let store: std::sync::Arc<InMemoryCredentialStore> =
+            std::sync::Arc::new(InMemoryCredentialStore::new());
+        let runtime =
+            IronRuntime::new_with_credential_store(Config::default(), MockProvider, store);
+        let context = ProviderPromptContext {
+            provider_slug: ProviderSlug::new("codex"),
+            model: "codex-model".into(),
+            api_key: Some("sk-test".into()),
+        };
+        let result = runtime.resolve_managed_provider(&context).await;
+        assert!(
+            matches!(result, Err(ProviderAuthError::UnsupportedCredential { ref provider, .. }) if provider == "codex"),
+        );
     }
 }


### PR DESCRIPTION
Closes #18 

## Summary
- Add provider credential domain, store, OAuth resolver APIs, and public device-code helpers with API-key precedence.
- Wire managed provider prompt/status APIs through runtime/facade with OAuth refresh, disconnect, and safe auth-failure retry behavior.
- Add OpenSpec artifacts and coverage for OAuth helper flows, managed provider construction, and retry suppression/refresh behavior.

## Testing
- cargo test