### PR TITLE
build(deps): update iron-providers to 0.1.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2092,9 +2092,9 @@ dependencies = [
 
 [[package]]
 name = "iron-providers"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a338b1fc6ab892fc669ff8158bdd6379ae6a1ee6c064e82ceb008863428c3e"
+checksum = "b5a012422958329371b5af204714d7fec326e48b8b66ffdf473839b65c3bf3c9"
 dependencies = [
  "async-openai",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
 ]
 
 [dependencies]
-iron-providers = "0.1.12"
+iron-providers = "0.1.13"
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["compat"] }
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
## Summary

- Bumps `iron-providers` from `0.1.12` to `0.1.13`
- Verified with `cargo check` — no breaking changes

Closes #28