### PR TITLE
fix: register compress tool unconditionally in ToolRegistry

### DIFF
--- a/src/mcp/session_catalog.rs
+++ b/src/mcp/session_catalog.rs
@@ -956,7 +956,11 @@ mod tests {
         let mut local_registry = crate::tool::ToolRegistry::new();
         local_registry.register(crate::tool::FunctionTool::new(
             crate::context::CompressTool::definition(),
-            |_args| Err(crate::error::RuntimeError::tool_execution("test stub".to_string())),
+            |_args| {
+                Err(crate::error::RuntimeError::tool_execution(
+                    "test stub".to_string(),
+                ))
+            },
         ));
         let local = Arc::new(local_registry);
         let mcp = Arc::new(crate::mcp::server::McpServerRegistry::new());

--- a/src/mcp/session_catalog.rs
+++ b/src/mcp/session_catalog.rs
@@ -175,14 +175,6 @@ impl SessionToolCatalog {
             definitions.push(def);
         }
 
-        if Self::compress_tool_available_for_session(session)
-            && !definitions
-                .iter()
-                .any(|def| def.name == crate::context::compaction::COMPRESS_TOOL_NAME)
-        {
-            definitions.push(crate::context::CompressTool::definition());
-        }
-
         // Add MCP tools for enabled and usable servers
         for server in mcp_registry.list_servers() {
             let server_id = server.config.id.clone();
@@ -284,10 +276,6 @@ impl SessionToolCatalog {
             definitions,
             tool_map: Arc::new(tool_map),
         }
-    }
-
-    fn compress_tool_available_for_session(session: &DurableSession) -> bool {
-        session.uncompacted_tokens > 0 || !session.compressed_blocks.is_empty()
     }
 
     /// Get all tool definitions visible to the model for this session.
@@ -965,7 +953,12 @@ mod tests {
     /// Helper: build a SessionToolCatalog with only local + plugin registries
     /// (no MCP).  Uses empty MCP registries.
     fn build_catalog(session: &DurableSession) -> SessionToolCatalog {
-        let local = Arc::new(crate::tool::ToolRegistry::new());
+        let mut local_registry = crate::tool::ToolRegistry::new();
+        local_registry.register(crate::tool::FunctionTool::new(
+            crate::context::CompressTool::definition(),
+            |_args| Err(crate::error::RuntimeError::tool_execution("test stub".to_string())),
+        ));
+        let local = Arc::new(local_registry);
         let mcp = Arc::new(crate::mcp::server::McpServerRegistry::new());
         let plugin = Arc::new(crate::plugin::registry::PluginRegistry::new());
         let wasm = Arc::new(crate::plugin::wasm_host::WasmHost::new());
@@ -1021,10 +1014,11 @@ mod tests {
     // ---- Tests: plugin tool visibility in session catalog ----
 
     #[test]
-    fn catalog_empty_when_no_plugins_registered() {
+    fn catalog_has_only_compress_when_no_plugins_registered() {
         let session = DurableSession::new(SessionId::new());
         let catalog = build_catalog(&session);
-        assert!(catalog.is_empty());
+        assert_eq!(catalog.len(), 1);
+        assert!(catalog.contains(crate::context::compaction::COMPRESS_TOOL_NAME));
     }
 
     #[test]
@@ -1034,11 +1028,22 @@ mod tests {
 
         let catalog = build_catalog(&session);
 
-        assert!(!catalog.contains(crate::context::compaction::COMPRESS_TOOL_NAME));
+        assert!(catalog.contains(crate::context::compaction::COMPRESS_TOOL_NAME));
         assert!(catalog
             .get_definition(crate::context::compaction::COMPRESS_TOOL_NAME)
             .is_some());
         assert!(!catalog.requires_approval(crate::context::compaction::COMPRESS_TOOL_NAME));
+    }
+
+    #[test]
+    fn catalog_exposes_compress_for_empty_session() {
+        let session = DurableSession::new(SessionId::new());
+        let catalog = build_catalog(&session);
+
+        assert!(catalog.contains(crate::context::compaction::COMPRESS_TOOL_NAME));
+        assert!(catalog
+            .get_definition(crate::context::compaction::COMPRESS_TOOL_NAME)
+            .is_some());
     }
 
     #[test]

--- a/src/prompt/system.rs
+++ b/src/prompt/system.rs
@@ -211,10 +211,9 @@ impl SystemPromptRenderer {
             PromptSection::Identity => render_identity(),
             PromptSection::StaticContext => inputs.runtime_context.to_string(),
             PromptSection::CoreGuidelines => render_core_guidelines(inputs.baseline),
-            PromptSection::ToolPhilosophy => render_tool_philosophy(
-                inputs.python_exec_available,
-                inputs.context_pressure,
-            ),
+            PromptSection::ToolPhilosophy => {
+                render_tool_philosophy(inputs.python_exec_available, inputs.context_pressure)
+            }
             PromptSection::EditingGuidelines => inputs
                 .client_editing_guidance
                 .filter(|s| !s.trim().is_empty())

--- a/src/prompt/system.rs
+++ b/src/prompt/system.rs
@@ -119,7 +119,6 @@ pub struct SystemPromptInputs<'a> {
     pub client_editing_guidance: Option<&'a str>,
     pub client_injections: &'a [ClientPromptFragment],
     pub python_exec_available: bool,
-    pub compression_available: bool,
     pub context_pressure: crate::context::ContextPressure,
 }
 
@@ -144,14 +143,6 @@ impl SystemPromptFingerprint {
         push_part(
             &mut value,
             if inputs.python_exec_available {
-                "1"
-            } else {
-                "0"
-            },
-        );
-        push_part(
-            &mut value,
-            if inputs.compression_available {
                 "1"
             } else {
                 "0"
@@ -222,7 +213,6 @@ impl SystemPromptRenderer {
             PromptSection::CoreGuidelines => render_core_guidelines(inputs.baseline),
             PromptSection::ToolPhilosophy => render_tool_philosophy(
                 inputs.python_exec_available,
-                inputs.compression_available,
                 inputs.context_pressure,
             ),
             PromptSection::EditingGuidelines => inputs
@@ -258,7 +248,6 @@ fn render_core_guidelines(baseline: &str) -> String {
 
 fn render_tool_philosophy(
     python_exec_available: bool,
-    compression_available: bool,
     context_pressure: crate::context::ContextPressure,
 ) -> String {
     let mut text = String::from(
@@ -269,9 +258,7 @@ fn render_tool_philosophy(
     } else {
         text.push_str("\n\n`python_exec` is not currently available in the visible tool catalog.");
     }
-    if compression_available {
-        text.push_str("\n\nThe `compress` tool is available to replace resolved older context with durable summaries. Summaries permanently replace selected ranges, so preserve all durable facts, decisions, constraints, file paths, errors, tool results, and user intent needed for future work.");
-    }
+    text.push_str("\n\nThe `compress` tool is available to replace resolved older context with durable summaries. Summaries permanently replace selected ranges, so preserve all durable facts, decisions, constraints, file paths, errors, tool results, and user intent needed for future work.");
     text.push_str("\n\n");
     text.push_str(context_pressure.guidance());
     text

--- a/src/prompt_runner.rs
+++ b/src/prompt_runner.rs
@@ -167,25 +167,12 @@ impl PromptRunner {
                 let instructions = session.instructions.clone();
                 let compressed_blocks = session.compressed_blocks.clone();
                 let repo_payload = session.repo_instruction_payload.clone();
-                let include_visible_ids = tool_catalog
-                    .as_ref()
-                    .map(|catalog| {
-                        catalog
-                            .definitions()
-                            .iter()
-                            .any(|def| def.name == crate::context::compaction::COMPRESS_TOOL_NAME)
-                    })
-                    .unwrap_or(false);
                 let messages = session
-                    .to_transcript_with_visible_ids(include_visible_ids)
+                    .to_transcript_with_visible_ids(true)
                     .messages;
                 let skill_instructions = session.active_skill_instructions();
                 drop(session);
 
-                let compression_available = tool_catalog
-                    .as_ref()
-                    .map(|catalog| catalog.contains(crate::context::compaction::COMPRESS_TOOL_NAME))
-                    .unwrap_or(false);
                 let tool_registry = self.runtime.tool_registry();
                 let snapshot = crate::context::ActiveContextAccountant::estimate_snapshot(
                     instructions.as_deref(),
@@ -242,7 +229,6 @@ impl PromptRunner {
                             repo_instruction_payload: repo_payload.as_ref(),
                             python_exec_available: tool_catalog.contains("python_exec"),
                             skill_instructions: Some(&skill_instructions),
-                            compression_available,
                             context_pressure,
                         },
                         tool_catalog.definitions(),
@@ -257,7 +243,6 @@ impl PromptRunner {
                             repo_instruction_payload: repo_payload.as_ref(),
                             python_exec_available: tool_registry.contains("python_exec"),
                             skill_instructions: Some(&skill_instructions),
-                            compression_available,
                             context_pressure,
                         },
                         &tool_registry,
@@ -349,15 +334,8 @@ impl PromptRunner {
                                         crate::debug::InfluenceDestination::SystemPromptSection(
                                             "Tool Philosophy".to_string(),
                                         ),
-                                    effect: if compression_available {
-                                        crate::debug::InfluenceEffect::Added
-                                    } else {
-                                        crate::debug::InfluenceEffect::Suppressed
-                                    },
-                                    reason: format!(
-                                        "compression_available={}",
-                                        compression_available
-                                    ),
+                                    effect: crate::debug::InfluenceEffect::Added,
+                                    reason: "compression_available=true".to_string(),
                                 },
                             ),
                         });

--- a/src/prompt_runner.rs
+++ b/src/prompt_runner.rs
@@ -167,9 +167,7 @@ impl PromptRunner {
                 let instructions = session.instructions.clone();
                 let compressed_blocks = session.compressed_blocks.clone();
                 let repo_payload = session.repo_instruction_payload.clone();
-                let messages = session
-                    .to_transcript_with_visible_ids(true)
-                    .messages;
+                let messages = session.to_transcript_with_visible_ids(true).messages;
                 let skill_instructions = session.active_skill_instructions();
                 drop(session);
 

--- a/src/request_builder.rs
+++ b/src/request_builder.rs
@@ -12,7 +12,6 @@ pub struct EffectiveToolRequestContext<'a> {
     pub repo_instruction_payload: Option<&'a crate::prompt::config::RepoInstructionPayload>,
     pub python_exec_available: bool,
     pub skill_instructions: Option<&'a str>,
-    pub compression_available: bool,
     pub context_pressure: crate::context::ContextPressure,
 }
 
@@ -60,7 +59,6 @@ pub fn build_inference_request_with_effective_tools(
         context.repo_instruction_payload,
         context.python_exec_available,
         context.skill_instructions,
-        context.compression_available,
         context.context_pressure,
     );
     if !composed.is_empty() {
@@ -85,7 +83,6 @@ pub fn build_inference_request(
             repo_instruction_payload: None,
             python_exec_available: tool_registry.contains("python_exec"),
             skill_instructions: None,
-            compression_available: false,
             context_pressure: crate::context::ContextPressure::None,
         },
         tool_registry,
@@ -108,7 +105,6 @@ pub fn build_inference_request_with_context(
             repo_instruction_payload: None,
             python_exec_available: tool_registry.contains("python_exec"),
             skill_instructions: None,
-            compression_available: false,
             context_pressure: crate::context::ContextPressure::None,
         },
         tool_registry,
@@ -131,7 +127,6 @@ pub fn build_inference_request_with_repo(
             repo_instruction_payload,
             python_exec_available: tool_registry.contains("python_exec"),
             skill_instructions: None,
-            compression_available: false,
             context_pressure: crate::context::ContextPressure::None,
         },
         tool_registry,
@@ -176,7 +171,6 @@ pub fn build_inference_request_with_context_and_repo(
         context.repo_instruction_payload,
         context.python_exec_available || python_exec_available,
         context.skill_instructions,
-        context.compression_available,
         context.context_pressure,
     );
     if !composed.is_empty() {
@@ -192,7 +186,6 @@ fn build_composed_instructions(
     repo_instruction_payload: Option<&crate::prompt::config::RepoInstructionPayload>,
     python_exec_available: bool,
     skill_instructions: Option<&str>,
-    compression_available: bool,
     context_pressure: crate::context::ContextPressure,
 ) -> String {
     let baseline = crate::prompt::baseline::BASELINE_PROMPT;
@@ -231,7 +224,6 @@ fn build_composed_instructions(
         client_editing_guidance: config.prompt_composition.client_editing_guidance.as_deref(),
         client_injections: &config.prompt_composition.client_injections,
         python_exec_available,
-        compression_available,
         context_pressure,
     })
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -232,7 +232,9 @@ impl IronRuntime {
             this.refresh_skill_catalog();
         }
 
-        // Emit runtime configuration debug event
+        this.register_compress_tool();
+
+        // Emit runtime configuration debug event (new())
         let config_event = crate::debug::redact_config(&this.inner.config);
         this.emit_debug(crate::debug::DebugEvent {
             timestamp: chrono::Utc::now(),
@@ -311,6 +313,8 @@ impl IronRuntime {
             this.register_activate_skill_tool();
             this.refresh_skill_catalog();
         }
+
+        this.register_compress_tool();
 
         // Emit runtime configuration debug event
         let config_event = crate::debug::redact_config(&this.inner.config);
@@ -534,6 +538,17 @@ impl IronRuntime {
             // handler should never be called.
             Err(crate::error::RuntimeError::tool_execution(
                 "activate_skill must be handled by the orchestrator".to_string(),
+            ))
+        });
+        self.register_tool(tool);
+    }
+
+    /// Register the `compress` model-facing tool.
+    pub fn register_compress_tool(&self) {
+        let definition = crate::context::CompressTool::definition();
+        let tool = crate::tool::FunctionTool::new(definition, |_args| {
+            Err(crate::error::RuntimeError::tool_execution(
+                "compress must be handled by the orchestrator".to_string(),
             ))
         });
         self.register_tool(tool);

--- a/tests/context_management_tests.rs
+++ b/tests/context_management_tests.rs
@@ -1270,6 +1270,29 @@ fn compress_tool_valid_range_does_not_mutate_on_rejection() {
     assert!(session.compressed_blocks.is_empty());
 }
 
+#[test]
+fn compress_tool_rejects_on_empty_session() {
+    let mut session = DurableSession::new(SessionId::new());
+
+    let err = CompressTool::execute(
+        &mut session,
+        "Test".to_string(),
+        vec![CompressRange {
+            start_id: "m0001".to_string(),
+            end_id: "m0001".to_string(),
+            summary: "summary".to_string(),
+        }],
+        0.50,
+        0.70,
+        0.85,
+        0.95,
+    )
+    .expect_err("empty session must reject compress");
+
+    assert!(err.contains("Unknown start ID"));
+    assert!(session.compressed_blocks.is_empty());
+}
+
 // =========================================================================
 // 6.3 Integration tests for provider request rendering with blocks
 // =========================================================================
@@ -1470,7 +1493,6 @@ fn system_prompt_includes_pressure_guidance() {
         client_editing_guidance: None,
         client_injections: &[],
         python_exec_available: false,
-        compression_available: true,
         context_pressure: ContextPressure::Strong,
     };
 
@@ -1501,7 +1523,6 @@ fn prompt_cache_fingerprint_stable_for_exact_telemetry_change() {
         client_editing_guidance: None,
         client_injections: &[],
         python_exec_available: false,
-        compression_available: true,
         context_pressure: ContextPressure::Soft,
     };
 
@@ -1516,7 +1537,6 @@ fn prompt_cache_fingerprint_stable_for_exact_telemetry_change() {
         client_editing_guidance: None,
         client_injections: &[],
         python_exec_available: false,
-        compression_available: true,
         context_pressure: ContextPressure::Soft,
     };
 
@@ -1544,7 +1564,6 @@ fn prompt_cache_fingerprint_changes_on_pressure_bucket_transition() {
         client_editing_guidance: None,
         client_injections: &[],
         python_exec_available: false,
-        compression_available: true,
         context_pressure: ContextPressure::Soft,
     };
 
@@ -1559,7 +1578,6 @@ fn prompt_cache_fingerprint_changes_on_pressure_bucket_transition() {
         client_editing_guidance: None,
         client_injections: &[],
         python_exec_available: false,
-        compression_available: true,
         context_pressure: ContextPressure::Medium,
     };
 
@@ -1568,49 +1586,6 @@ fn prompt_cache_fingerprint_changes_on_pressure_bucket_transition() {
     assert_ne!(
         fp_soft, fp_medium,
         "different pressure buckets should produce different fingerprints"
-    );
-}
-
-#[test]
-fn prompt_cache_fingerprint_changes_on_compression_availability() {
-    use iron_core::context::ContextPressure;
-    use iron_core::prompt::{SystemPromptFingerprint, SystemPromptInputs};
-
-    let inputs_available = SystemPromptInputs {
-        baseline: "Test",
-        runtime_context: "Context",
-        repo_payload: &Default::default(),
-        additional_inline: &[],
-        session_instructions: None,
-        skill_instructions: None,
-        provider_guidance: None,
-        client_editing_guidance: None,
-        client_injections: &[],
-        python_exec_available: false,
-        compression_available: true,
-        context_pressure: ContextPressure::None,
-    };
-
-    let inputs_unavailable = SystemPromptInputs {
-        baseline: "Test",
-        runtime_context: "Context",
-        repo_payload: &Default::default(),
-        additional_inline: &[],
-        session_instructions: None,
-        skill_instructions: None,
-        provider_guidance: None,
-        client_editing_guidance: None,
-        client_injections: &[],
-        python_exec_available: false,
-        compression_available: false,
-        context_pressure: ContextPressure::None,
-    };
-
-    let fp_available = SystemPromptFingerprint::from_inputs(&inputs_available);
-    let fp_unavailable = SystemPromptFingerprint::from_inputs(&inputs_unavailable);
-    assert_ne!(
-        fp_available, fp_unavailable,
-        "compression availability change should invalidate cache"
     );
 }
 

--- a/tests/prompt_composition_tests.rs
+++ b/tests/prompt_composition_tests.rs
@@ -36,7 +36,6 @@ fn render_system_prompt<'a>(
         client_editing_guidance,
         client_injections,
         python_exec_available,
-        compression_available: false,
         context_pressure: iron_core::ContextPressure::None,
     })
 }
@@ -104,7 +103,6 @@ fn prompt_preserves_repo_and_session_content_inside_client_injection() {
         client_editing_guidance: None,
         client_injections: &[],
         python_exec_available: false,
-        compression_available: false,
         context_pressure: iron_core::ContextPressure::None,
     });
 
@@ -590,7 +588,6 @@ fn system_prompt_cache_reuses_output_until_inputs_change_or_invalidate() {
             client_editing_guidance: None,
             client_injections: &[],
             python_exec_available: false,
-            compression_available: false,
             context_pressure: iron_core::ContextPressure::None,
         })
         .to_string();
@@ -606,7 +603,6 @@ fn system_prompt_cache_reuses_output_until_inputs_change_or_invalidate() {
             client_editing_guidance: None,
             client_injections: &[],
             python_exec_available: false,
-            compression_available: false,
             context_pressure: iron_core::ContextPressure::None,
         })
         .to_string();
@@ -624,7 +620,6 @@ fn system_prompt_cache_reuses_output_until_inputs_change_or_invalidate() {
             client_editing_guidance: None,
             client_injections: &[],
             python_exec_available: false,
-            compression_available: false,
             context_pressure: iron_core::ContextPressure::None,
         })
         .to_string();
@@ -643,7 +638,6 @@ fn system_prompt_cache_reuses_output_until_inputs_change_or_invalidate() {
             client_editing_guidance: None,
             client_injections: &[],
             python_exec_available: false,
-            compression_available: false,
             context_pressure: iron_core::ContextPressure::None,
         })
         .to_string();


### PR DESCRIPTION
## Summary

Fixes #41

The `compress` tool was conditionally synthesized in `SessionToolCatalog::new()` and added to `definitions[]` but not `tool_map[]`. The prompt composition layer checks availability via `catalog.contains()` which queries `tool_map`, so `compression_available` was always `false` — preventing the model from ever seeing the compress tool in Tool Philosophy.

## Changes

- Register compress as a first-class `FunctionTool` in `ToolRegistry` at runtime construction time (like `activate_skill`), making it always available
- Remove `compress_tool_available_for_session()` and the conditional synthesis logic in `SessionToolCatalog::new()`
- Remove the `compression_available` plumbing from `prompt_runner` → `request_builder` → `prompt/system` — the tool is always present
- Always render the compress paragraph in Tool Philosophy
- Always include visible IDs in transcripts (compress being in catalog naturally drives this)

## Testing

- 697 tests pass, 0 failures
- Added `compress_tool_rejects_on_empty_session` test verifying clean rejection when called on fresh session
- Updated `catalog_exposes_compress_when_session_has_context` to assert `contains()` is true
- Added `catalog_exposes_compress_for_empty_session` test
- Net: +64 lines, -118 lines (simplification)