### PR TITLE
feat(context): expose model and compaction metadata

### DIFF
--- a/src/context/accounting.rs
+++ b/src/context/accounting.rs
@@ -84,6 +84,8 @@ pub struct ContextCategoryUsage {
 pub struct ActiveContextSnapshot {
     pub total_tokens: usize,
     pub context_window_limit: Option<usize>,
+    /// Token threshold at which automatic context compaction is requested.
+    pub compact_threshold_tokens: Option<usize>,
     pub quality: ContextQuality,
     pub categories: Vec<ContextCategoryUsage>,
     /// Current model identifier for this session
@@ -217,6 +219,7 @@ impl ActiveContextAccountant {
         ActiveContextSnapshot {
             total_tokens: total,
             context_window_limit: context_window_hint,
+            compact_threshold_tokens: None,
             quality: overall_quality,
             categories,
             current_model: model_info.current_model.map(|m| m.to_string()),

--- a/src/context/compaction.rs
+++ b/src/context/compaction.rs
@@ -5,6 +5,7 @@ use serde_json::Value;
 use std::collections::BTreeSet;
 
 pub const COMPRESS_TOOL_NAME: &str = "compress";
+pub const COMPRESS_METHOD_MODEL_SUMMARY: &str = "model_summary";
 
 /// Runtime-owned compress tool: validates ranges, applies compression, and
 /// produces new compressed blocks.
@@ -130,8 +131,26 @@ impl CompressTool {
         }
         session.uncompacted_tokens = 0;
 
+        let tokens_before = blocks_created
+            .iter()
+            .filter_map(|block| block.token_estimate_before)
+            .map(usize::try_from)
+            .collect::<Result<Vec<_>, _>>()
+            .ok()
+            .map(|tokens| tokens.into_iter().sum());
+        let tokens_after = blocks_created
+            .iter()
+            .filter_map(|block| block.token_estimate_after)
+            .map(usize::try_from)
+            .collect::<Result<Vec<_>, _>>()
+            .ok()
+            .map(|tokens| tokens.into_iter().sum());
+
         Ok(CompressResult {
             blocks_created,
+            tokens_before,
+            tokens_after,
+            method: COMPRESS_METHOD_MODEL_SUMMARY.to_string(),
             pressure_state: Self::compute_pressure_state(
                 session,
                 soft_threshold,
@@ -347,5 +366,8 @@ pub struct CompressRange {
 #[derive(Debug, Clone)]
 pub struct CompressResult {
     pub blocks_created: Vec<CompressedBlock>,
+    pub tokens_before: Option<usize>,
+    pub tokens_after: Option<usize>,
+    pub method: String,
     pub pressure_state: String,
 }

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -24,8 +24,8 @@ pub use config::{
 };
 pub use handoff::{HandoffBundle, HandoffBundleMetadata, HandoffExporter, HandoffImporter};
 pub use model_switch::{
-    CapabilityDiff, ContextAdaptationPlan, ModelSwitchPlan, ModelSwitchRecord, ModelSwitchRequest,
-    PendingModelSwitch,
+    CapabilityDiff, ContextAdaptationPlan, ModelCapabilityMetadata, ModelCapabilityRegistry,
+    ModelSwitchPlan, ModelSwitchRecord, ModelSwitchRequest, PendingModelSwitch,
 };
 pub use models::{CompressedBlock, HANDOFF_DEFAULT_TARGET_TOKENS};
 pub use telemetry::ContextTelemetry;

--- a/src/context/model_switch.rs
+++ b/src/context/model_switch.rs
@@ -267,6 +267,10 @@ pub struct ModelCapabilityMetadata {
     pub context_window: usize,
     pub supports_tools: bool,
     pub supports_streaming: bool,
+    #[serde(default)]
+    pub supports_reasoning_effort: bool,
+    #[serde(default)]
+    pub reasoning_effort_values: Vec<String>,
     pub supported_modalities: Vec<String>,
     pub unsupported_tools: Vec<String>,
 }
@@ -291,6 +295,11 @@ pub fn compare_capabilities(
     // Check streaming support
     if !target.supports_streaming {
         diff.streaming_supported = false;
+    }
+
+    // Check reasoning effort support
+    if source.supports_reasoning_effort && !target.supports_reasoning_effort {
+        diff.unsupported_features.push("reasoning_effort".into());
     }
 
     // Check modalities
@@ -429,6 +438,8 @@ mod tests {
             context_window: 100000,
             supports_tools: true,
             supports_streaming: true,
+            supports_reasoning_effort: true,
+            reasoning_effort_values: vec!["low".into(), "medium".into(), "high".into()],
             supported_modalities: vec!["text".into()],
             unsupported_tools: vec![],
         };
@@ -439,6 +450,8 @@ mod tests {
             context_window: 50000,
             supports_tools: true,
             supports_streaming: true,
+            supports_reasoning_effort: true,
+            reasoning_effort_values: vec!["low".into(), "medium".into(), "high".into()],
             supported_modalities: vec!["text".into()],
             unsupported_tools: vec![],
         };
@@ -456,6 +469,8 @@ mod tests {
             context_window: 100000,
             supports_tools: true,
             supports_streaming: true,
+            supports_reasoning_effort: true,
+            reasoning_effort_values: vec!["low".into(), "medium".into(), "high".into()],
             supported_modalities: vec!["text".into()],
             unsupported_tools: vec![],
         };
@@ -466,6 +481,8 @@ mod tests {
             context_window: 100000,
             supports_tools: false,
             supports_streaming: true,
+            supports_reasoning_effort: false,
+            reasoning_effort_values: vec![],
             supported_modalities: vec!["text".into()],
             unsupported_tools: vec!["tool1".into()],
         };
@@ -473,6 +490,25 @@ mod tests {
         let diff = compare_capabilities(&source, &target);
         assert!(!diff.tools_supported);
         assert_eq!(diff.hidden_tools, vec!["tool1"]);
+        assert_eq!(diff.unsupported_features, vec!["reasoning_effort"]);
+    }
+
+    #[test]
+    fn test_model_capability_metadata_exposes_reasoning_effort() {
+        let meta = ModelCapabilityMetadata {
+            model: "o3".into(),
+            provider: "openai".into(),
+            context_window: 200000,
+            supports_tools: true,
+            supports_streaming: true,
+            supports_reasoning_effort: true,
+            reasoning_effort_values: vec!["low".into(), "medium".into(), "high".into()],
+            supported_modalities: vec!["text".into()],
+            unsupported_tools: vec![],
+        };
+
+        assert!(meta.supports_reasoning_effort);
+        assert_eq!(meta.reasoning_effort_values, vec!["low", "medium", "high"]);
     }
 
     #[test]
@@ -484,6 +520,8 @@ mod tests {
             context_window: 8192,
             supports_tools: true,
             supports_streaming: true,
+            supports_reasoning_effort: false,
+            reasoning_effort_values: vec![],
             supported_modalities: vec!["text".into()],
             unsupported_tools: vec![],
         };

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -178,6 +178,7 @@ pub enum ContextDebugEvent {
     SnapshotEstimated {
         total_tokens: usize,
         context_window_limit: Option<usize>,
+        compact_threshold_tokens: Option<usize>,
         quality: crate::ContextQuality,
         pressure: String,
         categories: Vec<(String, usize, crate::ContextQuality)>,
@@ -208,6 +209,7 @@ pub enum CompactionDebugEvent {
         block_count: usize,
         old_size_tokens: Option<usize>,
         new_size_tokens: Option<usize>,
+        method: Option<String>,
         pressure_state: String,
         reduction_pct: Option<f64>,
     },

--- a/src/facade.rs
+++ b/src/facade.rs
@@ -1815,7 +1815,7 @@ impl AgentSession {
     ) -> crate::context::ActiveContextSnapshot {
         let session = self.durable.lock();
         let tail = session.to_transcript();
-        crate::context::ContextTelemetry::for_session(
+        let mut snapshot = crate::context::ContextTelemetry::for_session(
             session.instructions.as_deref(),
             &session.compressed_blocks,
             &tail.messages,
@@ -1826,7 +1826,12 @@ impl AgentSession {
                 current_model: session.current_model.as_deref(),
                 model_switch_count: session.model_switch_history.len(),
             },
-        )
+        );
+        let context_config = &self.connection.runtime().config().context_management;
+        if context_config.enabled {
+            snapshot.compact_threshold_tokens = Some(context_config.maintenance_threshold);
+        }
+        snapshot
     }
 
     /// Check if the session is idle (no active prompts or tool calls).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,9 +198,10 @@ pub use context::{
     ActiveContextAccountant, ActiveContextSnapshot, CapabilityDiff, CompressRange, CompressResult,
     CompressTool, CompressedBlock, ContextAdaptationPlan, ContextCategory, ContextCategoryUsage,
     ContextPressure, ContextQuality, ContextTelemetry, HandoffBundle, HandoffBundleMetadata,
-    HandoffExportConfig, HandoffExporter, HandoffImporter, ModelSwitchPlan, ModelSwitchRecord,
-    ModelSwitchRequest, PendingModelSwitch, SessionModelInfo, TailRetentionPolicy,
-    TailRetentionRule, HANDOFF_DEFAULT_TARGET_TOKENS,
+    HandoffExportConfig, HandoffExporter, HandoffImporter, ModelCapabilityMetadata,
+    ModelCapabilityRegistry, ModelSwitchPlan, ModelSwitchRecord, ModelSwitchRequest,
+    PendingModelSwitch, SessionModelInfo, TailRetentionPolicy, TailRetentionRule,
+    HANDOFF_DEFAULT_TARGET_TOKENS,
 };
 pub use durable::{
     ContentBlock, DurableScriptRecord, DurableSession, DurableToolRecord, ScriptRecordStatus,

--- a/src/prompt_runner.rs
+++ b/src/prompt_runner.rs
@@ -172,7 +172,7 @@ impl PromptRunner {
                 drop(session);
 
                 let tool_registry = self.runtime.tool_registry();
-                let snapshot = crate::context::ActiveContextAccountant::estimate_snapshot(
+                let mut snapshot = crate::context::ActiveContextAccountant::estimate_snapshot(
                     instructions.as_deref(),
                     &compressed_blocks,
                     &messages,
@@ -184,6 +184,10 @@ impl PromptRunner {
                         model_switch_count: 0,
                     },
                 );
+                if config.context_management.enabled {
+                    snapshot.compact_threshold_tokens =
+                        Some(config.context_management.maintenance_threshold);
+                }
                 let context_pressure = snapshot.pressure_with_thresholds(
                     config.context_management.soft_threshold,
                     config.context_management.medium_threshold,
@@ -204,6 +208,7 @@ impl PromptRunner {
                         crate::debug::ContextDebugEvent::SnapshotEstimated {
                             total_tokens: snapshot.total_tokens,
                             context_window_limit: snapshot.context_window_limit,
+                            compact_threshold_tokens: snapshot.compact_threshold_tokens,
                             quality: snapshot.quality,
                             pressure: context_pressure.as_str().to_string(),
                             categories: snapshot
@@ -1077,11 +1082,16 @@ impl PromptRunner {
                 Ok(result) => {
                     let output = serde_json::json!({
                         "status": "compressed",
+                        "tokens_before": result.tokens_before,
+                        "tokens_after": result.tokens_after,
+                        "method": result.method,
                         "blocks_created": result.blocks_created.iter().map(|block| {
                             serde_json::json!({
                                 "id": block.id,
                                 "topic": block.topic,
                                 "source_range": block.source_range,
+                                "tokens_before": block.token_estimate_before,
+                                "tokens_after": block.token_estimate_after,
                             })
                         }).collect::<Vec<_>>(),
                         "context_pressure": result.pressure_state,
@@ -1116,10 +1126,16 @@ impl PromptRunner {
                     payload: crate::debug::DebugPayload::Compaction(
                         crate::debug::CompactionDebugEvent::Applied {
                             block_count: result.blocks_created.len(),
-                            old_size_tokens: None,
-                            new_size_tokens: None,
+                            old_size_tokens: result.tokens_before,
+                            new_size_tokens: result.tokens_after,
+                            method: Some(result.method.clone()),
                             pressure_state: result.pressure_state.clone(),
-                            reduction_pct: None,
+                            reduction_pct: match (result.tokens_before, result.tokens_after) {
+                                (Some(before), Some(after)) if before > 0 => Some(
+                                    ((before.saturating_sub(after)) as f64 / before as f64) * 100.0,
+                                ),
+                                _ => None,
+                            },
                         },
                     ),
                 });

--- a/tests/context_management_tests.rs
+++ b/tests/context_management_tests.rs
@@ -60,6 +60,7 @@ fn telemetry_with_instructions_counts_category() {
         .iter()
         .any(|c| c.category == ContextCategory::Instructions));
     assert_eq!(snapshot.context_window_limit, Some(128_000));
+    assert_eq!(snapshot.compact_threshold_tokens, None);
     let fullness = snapshot.fullness().unwrap();
     assert!(fullness > 0.0 && fullness < 1.0);
 }
@@ -222,6 +223,7 @@ fn telemetry_without_context_window_has_no_fullness() {
     let snapshot = ActiveContextSnapshot {
         total_tokens: 1000,
         context_window_limit: None,
+        compact_threshold_tokens: None,
         quality: ContextQuality::Estimated,
         categories: vec![],
         current_model: None,
@@ -1807,6 +1809,8 @@ fn compress_clears_nudges_when_below_threshold() {
 
     // After heavy compression, pressure should be reduced
     assert_eq!(result.pressure_state, "none");
+    assert_eq!(result.method, "model_summary");
+    assert!(result.tokens_before.unwrap() > result.tokens_after.unwrap());
     assert_eq!(session.compressed_blocks.len(), 1);
     assert!(session.messages.len() < 20);
 }


### PR DESCRIPTION
## Summary
- expose compact threshold tokens in active context snapshots and context debug events
- expose compaction result metrics, including tokens before/after and compaction method
- add reasoning effort metadata to model capability metadata and re-export the capability registry/types

## Verification
- cargo test --test context_management_tests
- cargo test context::model_switch
- cargo check

Closes #45

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added detailed token usage metrics for context compression, including before/after token counts and compression method identification.
  * Enhanced model capability detection to include reasoning effort support tracking.

* **Improvements**
  * Improved context management telemetry with expanded snapshot data.
  * Added more granular compression result reporting for better monitoring and debugging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->