### PR TITLE
feat(runtime): add session workspace roots

### DIFF
--- a/openspec/changes/session-workspace-roots/.openspec.yaml
+++ b/openspec/changes/session-workspace-roots/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-06

--- a/openspec/changes/session-workspace-roots/design.md
+++ b/openspec/changes/session-workspace-roots/design.md
@@ -95,8 +95,8 @@ Alternative considered: remove `Config.workspace_roots`. Rejected because that w
 
 Rollback: revert the change; sessions serialized with new root fields remain loadable by current code only if unknown fields are ignored by the consumer, so this should be released as a forward migration with compatibility tests.
 
-## Open Questions
+## Design Decisions
 
-1. Should `set_workspace_roots()` return an enum such as `Applied` vs `Deferred`, or should callers inspect session state separately?
-2. Should clients have an API to read both active and pending roots for UI display?
-3. Should project skill rescanning include user-level and additional configured skill dirs each time, or only project dirs plus the existing runtime baseline?
+1. `AgentSession::set_workspace_roots(...)` returns `Result<bool, RuntimeError>` where `true` = roots applied immediately, `false` = deferred until the next turn boundary.
+2. Clients can read active roots via `AgentSession::workspace_roots()`. Pending roots are internal and applied automatically at turn boundaries.
+3. Skill rescanning uses the full discovery pipeline: project dirs from workspace roots, user-level dirs (`~/.agents/skills/`), additional configured dirs, and runtime-registered skills.

--- a/openspec/changes/session-workspace-roots/design.md
+++ b/openspec/changes/session-workspace-roots/design.md
@@ -1,0 +1,102 @@
+## Context
+
+`Config.workspace_roots` is currently a construction-time runtime setting. Request composition reads it to render `<runtime_context>`, while builtin tools receive a separate `BuiltinToolConfig.allowed_roots` snapshot when they are registered. This works for one workspace per runtime, but AgentIron needs multiple tabs/sessions to share one live `IronRuntime` while each tab has independent roots.
+
+The existing architecture already has durable per-session state (`DurableSession`) and session-effective tool surfaces (`SessionToolCatalog`) for MCP/plugin enablement and skill availability. Workspace roots should follow the same per-session pattern rather than becoming another runtime-global mutable setting.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Support independent workspace roots for multiple live sessions under one `IronRuntime`.
+- Preserve session history, MCP connections, plugin enablement, active skills, and runtime state when roots change.
+- Apply root changes at turn boundaries so one prompt turn has one consistent root snapshot.
+- Keep prompt runtime context and builtin tool authorization aligned for each prompt turn.
+- Automatically refresh project-skill availability when a session's new roots become active.
+- Preserve `Config::with_workspace_roots()` as the default root source for newly created sessions.
+
+**Non-Goals:**
+
+- Runtime-wide live root switching for all sessions.
+- Changing builtin tool roots in the middle of an active prompt.
+- Automatically deactivating skills that were already active before a root change.
+- Rebuilding MCP connections, plugin registries, or provider state when roots change.
+- Adding client UI behavior in AgentIron; this change only defines the iron-core API and runtime behavior.
+
+## Decisions
+
+### Store Workspace Roots on the Session
+
+Add session-owned active roots and pending roots to the session state. New sessions initialize their active roots from `Config.workspace_roots` when present, otherwise from `std::env::current_dir()`.
+
+Rationale: multiple tabs require roots to vary by session while sharing one runtime. `DurableSession` already owns other per-session state such as MCP enablement, plugin enablement, current model, active skills, and available skills.
+
+Alternative considered: make `IronRuntime` config mutable. Rejected because it would change roots for every session and would conflict with multi-tab isolation.
+
+### Apply Root Changes at Turn Boundaries
+
+`AgentSession::set_workspace_roots(Vec<PathBuf>)` applies roots immediately only when the session is idle. If a prompt is active, the method records pending roots and the runtime applies them when the prompt finishes.
+
+Rationale: the model sees a working directory and workspace roots in the system prompt. If roots changed mid-turn, the model could plan tool calls under one root while builtin tools authorize another. Turn-boundary application keeps the safety boundary and prompt context consistent.
+
+Alternative considered: reject changes during active prompts. Rejected because AgentIron can queue tab directory changes without forcing callers to retry manually after prompt completion.
+
+Alternative considered: apply immediately. Rejected because prompt text and tool authorization could diverge within one turn.
+
+### Use One Prompt-Turn Root Snapshot
+
+At prompt start, capture the session's active roots and use that snapshot for both request composition and local builtin tool execution throughout the prompt turn. The first root is the working directory shown in `<runtime_context>`; all active roots are rendered as workspace roots.
+
+Rationale: this directly encodes the invariant that there is always one root set per prompt. It also avoids accidental reads from `Config.workspace_roots` after a session has its own roots.
+
+Alternative considered: let builtin tools look up latest session roots at execution time. Rejected because pending roots could become active after prompt completion while late tool execution or child tool paths still expect the prompt snapshot.
+
+### Route Builtin Tools Through Session-Effective Execution
+
+Local builtin filesystem, search, and shell tools must enforce the session prompt snapshot rather than the global `BuiltinToolConfig.allowed_roots` captured at registration. The session-effective tool path should provide or wrap builtin tool execution with the active roots for that prompt.
+
+Rationale: builtin tools are the security boundary for filesystem and shell access. They must match the roots shown to the model and must vary by session.
+
+Alternative considered: re-register builtin tools whenever a session changes roots. Rejected because tools are registered runtime-wide, so re-registration would affect other sessions and would need to preserve unrelated builtin config exactly.
+
+### Rescan Project Skills When Roots Become Active
+
+When roots are applied, the runtime rescans project-level skills under each active root and updates that session's available skill snapshot. Already active skills remain active even if their original root is no longer active.
+
+Rationale: a directory change should expose skills from the new project on the next prompt, but removing active skill instructions mid-conversation would be surprising and could invalidate prior context.
+
+Alternative considered: refresh only the runtime skill catalog. Rejected because project skills are now session-root-dependent and sessions need independent available skill snapshots.
+
+### Preserve Runtime Config as Session Defaults
+
+`Config.workspace_roots` remains a construction-time default used to seed new sessions. Existing callers that configure one runtime root and never call `set_workspace_roots()` continue to get the same prompt and builtin behavior.
+
+Rationale: this keeps the old setup API useful while moving live mutation to the session API required by multi-tab clients.
+
+Alternative considered: remove `Config.workspace_roots`. Rejected because that would be an unnecessary breaking change.
+
+## Risks / Trade-offs
+
+- **Builtin tool coupling**: Retrofitting session roots into local builtin execution can touch several tools → Mitigation: centralize root snapshot handling and keep builtin policy/timeouts/read tracking unchanged.
+- **Serialized session shape changes**: Adding roots to `DurableSession` changes serialized session data → Mitigation: use serde defaults so older sessions load with runtime/default roots.
+- **Skill catalog complexity**: Runtime-global and session-specific skill discovery can diverge → Mitigation: treat the runtime catalog as a source baseline and session available skills as the prompt-facing snapshot.
+- **Pending root visibility**: Callers may expect `set_workspace_roots()` to take effect immediately during active prompts → Mitigation: return or expose whether roots were applied immediately or deferred.
+- **Security regression risk**: Any mismatch between prompt roots and builtin roots could allow confusing or unsafe tool behavior → Mitigation: add tests that assert prompt rendering and builtin path checks use the same prompt-turn snapshot.
+
+## Migration Plan
+
+1. Add serde-defaulted active and pending workspace root fields to session state.
+2. Seed new sessions from `Config.workspace_roots` or current directory.
+3. Add `AgentSession::set_workspace_roots(Vec<PathBuf>)` and runtime/session helpers for idle vs active application.
+4. Pass session root snapshots into request composition instead of reading roots only from `Config`.
+5. Update session-effective builtin execution to enforce prompt-turn roots.
+6. Add root-application hooks that refresh the session's available project skills.
+7. Add tests for multiple sessions with different roots, active-prompt deferral, prompt/tool consistency, and skill rescanning.
+
+Rollback: revert the change; sessions serialized with new root fields remain loadable by current code only if unknown fields are ignored by the consumer, so this should be released as a forward migration with compatibility tests.
+
+## Open Questions
+
+1. Should `set_workspace_roots()` return an enum such as `Applied` vs `Deferred`, or should callers inspect session state separately?
+2. Should clients have an API to read both active and pending roots for UI display?
+3. Should project skill rescanning include user-level and additional configured skill dirs each time, or only project dirs plus the existing runtime baseline?

--- a/openspec/changes/session-workspace-roots/proposal.md
+++ b/openspec/changes/session-workspace-roots/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+AgentIron needs multiple tabs to share one live `IronRuntime` while each tab/session keeps a different working directory and workspace root set. Today `Config.workspace_roots` and builtin tool roots are construction-time runtime state, so changing directories requires recreating the agent and losing session history, MCP connections, plugin state, and skill catalog continuity.
+
+## What Changes
+
+- Add session-scoped workspace roots so each live session can have independent active roots.
+- Add `AgentSession::set_workspace_roots(Vec<PathBuf>)` as the public API for changing a session's roots without recreating the runtime.
+- Defer workspace-root changes requested during an active prompt until the session returns to idle.
+- Ensure each prompt turn uses one consistent workspace-root snapshot for runtime context rendering and builtin tool path authorization.
+- Update builtin filesystem, search, and shell tools to enforce the session's active workspace roots rather than a runtime-global root set.
+- Automatically rescan project skills when a session's pending roots are applied, updating that session's available skill snapshot while preserving already-active skill instructions.
+- Preserve runtime-level `Config.workspace_roots` as the initial/default roots for newly created sessions and as a fallback for existing callers.
+
+## Capabilities
+
+### New Capabilities
+
+- `session-workspace-roots`: Session-scoped workspace root management, turn-boundary application semantics, prompt/tool root consistency, and project-skill refresh behavior.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- **Core runtime**: `DurableSession`, `RuntimeSession`, `IronRuntime`, `AgentSession`, prompt lifecycle hooks.
+- **Request building**: system prompt runtime context must receive session root snapshots instead of reading only `Config.workspace_roots`.
+- **Builtin tools**: file operations, search tools, and shell tools must authorize paths against session-active roots for the prompt turn.
+- **Skills**: project skill discovery must support session root snapshots and refresh available skills on applied root changes.
+- **Public API**: new `AgentSession::set_workspace_roots(Vec<PathBuf>)` method; no runtime restart required.
+- **Compatibility**: existing `Config::with_workspace_roots()` remains the construction-time default for sessions that do not set session-specific roots.

--- a/openspec/changes/session-workspace-roots/specs/session-workspace-roots/spec.md
+++ b/openspec/changes/session-workspace-roots/specs/session-workspace-roots/spec.md
@@ -1,0 +1,93 @@
+## ADDED Requirements
+
+### Requirement: Sessions have independent workspace roots
+The system SHALL track active workspace roots per session. Changing workspace roots for one session SHALL NOT change the active workspace roots of any other session sharing the same runtime.
+
+#### Scenario: New session inherits configured default roots
+- **WHEN** a runtime creates a new session and `Config.workspace_roots` is non-empty
+- **THEN** the session's active workspace roots are initialized from `Config.workspace_roots`
+
+#### Scenario: New session falls back to process current directory
+- **WHEN** a runtime creates a new session and `Config.workspace_roots` is empty
+- **THEN** the session's active workspace roots are initialized from the process current directory fallback
+
+#### Scenario: Session root update does not affect another session
+- **WHEN** session A updates its workspace roots
+- **THEN** session B keeps its own active workspace roots unchanged
+
+### Requirement: Sessions expose a workspace root update API
+The system SHALL provide `AgentSession::set_workspace_roots(Vec<PathBuf>)` to request a workspace root change for that session without recreating the runtime or replacing the session.
+
+#### Scenario: Idle session applies roots immediately
+- **WHEN** `set_workspace_roots` is called for an idle session
+- **THEN** the provided roots become the session's active workspace roots before the method reports completion
+- **THEN** existing messages, MCP enablement, plugin enablement, active skills, and provider/runtime state are preserved
+
+#### Scenario: Active session defers roots until idle
+- **WHEN** `set_workspace_roots` is called for a session with an active prompt
+- **THEN** the provided roots are recorded as pending roots
+- **THEN** the session's active workspace roots remain unchanged for the active prompt
+- **THEN** the pending roots are applied after the active prompt finishes and the session returns to idle
+
+#### Scenario: Later pending roots replace earlier pending roots
+- **WHEN** `set_workspace_roots` is called multiple times while the same prompt is active
+- **THEN** only the latest provided roots are applied when the prompt finishes
+
+### Requirement: Prompt turns use one workspace root snapshot
+The system SHALL use one active workspace root snapshot for each prompt turn. The runtime context rendered for a prompt and the builtin tool authorization used during that prompt SHALL be derived from the same snapshot.
+
+#### Scenario: Runtime context reflects active session roots
+- **WHEN** the runtime builds a provider request for a session
+- **THEN** the `<runtime_context>` working directory is the first active workspace root from that session's prompt-turn snapshot
+- **THEN** the `<runtime_context>` workspace root list contains the active workspace roots from that same snapshot
+
+#### Scenario: Deferred roots do not affect active prompt context
+- **WHEN** a session records pending workspace roots while a prompt is active
+- **THEN** subsequent inference iterations within that active prompt continue rendering the original prompt-turn root snapshot
+
+#### Scenario: Next prompt uses applied pending roots
+- **WHEN** a prompt finishes after pending workspace roots were recorded
+- **THEN** the pending roots become active before the next prompt is built
+- **THEN** the next prompt renders runtime context from the newly active roots
+
+### Requirement: Builtin tools enforce session prompt roots
+The system SHALL authorize builtin filesystem, search, and shell tool paths against the active workspace root snapshot for the current session prompt. Builtin tools SHALL NOT authorize paths for one session using another session's roots.
+
+#### Scenario: Builtin read uses current session roots
+- **WHEN** session A and session B have different active workspace roots
+- **THEN** a builtin `read` call in session A is authorized against session A's prompt-turn roots
+- **THEN** the same path is not authorized merely because it is inside session B's roots
+
+#### Scenario: Builtin search defaults to current session first root
+- **WHEN** a builtin search tool call omits an explicit base path
+- **THEN** the search defaults to the first root from the current session's prompt-turn root snapshot
+
+#### Scenario: Builtin shell uses current session roots
+- **WHEN** a builtin shell tool call omits an explicit working directory
+- **THEN** the command runs from the first root in the current session's prompt-turn root snapshot
+- **THEN** any explicit working directory must be within the current session's prompt-turn roots
+
+#### Scenario: Pending roots do not move builtin authorization mid-prompt
+- **WHEN** a session records pending workspace roots while a prompt is active
+- **THEN** builtin tool calls for that active prompt continue authorizing paths against the original prompt-turn root snapshot
+
+### Requirement: Project skills refresh when workspace roots become active
+The system SHALL automatically rescan project-level skills for a session when new workspace roots become active. The refreshed project skills SHALL update that session's available skill snapshot without removing already active skill instructions.
+
+#### Scenario: Idle root update refreshes available project skills
+- **WHEN** an idle session applies new workspace roots containing project skills
+- **THEN** the session's available skill snapshot is refreshed from those roots before the next prompt
+
+#### Scenario: Deferred root update refreshes skills after prompt completion
+- **WHEN** pending workspace roots are applied after an active prompt finishes
+- **THEN** the session's available skill snapshot is refreshed from the newly active roots before the next prompt
+
+#### Scenario: Active skills survive root changes
+- **WHEN** a session has active skill instructions and then applies new workspace roots
+- **THEN** the already active skill instructions remain active for that session
+- **THEN** new model-initiated skill activations use the refreshed available skill snapshot
+
+#### Scenario: Project skill trust policy still applies
+- **WHEN** newly active workspace roots contain project skills and project skill trust is disabled
+- **THEN** those project skills are not included in the refreshed available skill snapshot
+- **THEN** the session records or exposes diagnostics consistent with existing project skill trust behavior

--- a/openspec/changes/session-workspace-roots/tasks.md
+++ b/openspec/changes/session-workspace-roots/tasks.md
@@ -1,0 +1,59 @@
+## 1. Session Data Model
+
+- [x] 1.1 Add serde-defaulted active workspace roots to `DurableSession`
+- [x] 1.2 Add serde-defaulted pending workspace roots to `DurableSession`
+- [x] 1.3 Add helper methods for reading active roots, setting pending roots, and applying pending roots
+- [x] 1.4 Seed new sessions from `Config.workspace_roots` or current directory fallback
+- [x] 1.5 Include workspace-root state in relevant session/debug inspection paths without exposing secrets
+
+## 2. Public Session API and Turn-Boundary Semantics
+
+- [x] 2.1 Add `AgentSession::set_workspace_roots(Vec<PathBuf>)` public API
+- [x] 2.2 Add runtime helper to apply roots immediately when the session is idle
+- [x] 2.3 Add runtime helper to defer roots when the session has an active prompt
+- [x] 2.4 Ensure multiple deferred root updates keep only the latest pending roots
+- [x] 2.5 Apply pending roots after prompt completion before the next prompt can start
+- [x] 2.6 Expose or return enough status for callers to distinguish applied vs deferred updates
+
+## 3. Prompt Root Snapshot
+
+- [x] 3.1 Capture the session's active workspace roots at prompt start
+- [x] 3.2 Thread the captured root snapshot through request construction
+- [x] 3.3 Update runtime context rendering to use session roots for working directory and workspace root lines
+- [x] 3.4 Preserve existing request-builder behavior for callers that do not provide a session root snapshot
+- [x] 3.5 Add tests proving pending roots do not affect prompt rendering until the next prompt
+
+## 4. Builtin Tool Root Enforcement
+
+- [x] 4.1 Identify the session-effective local builtin execution path used for model and child tool calls
+- [x] 4.2 Pass prompt-turn roots into builtin filesystem tool execution
+- [x] 4.3 Pass prompt-turn roots into builtin glob/grep execution and default base path selection
+- [x] 4.4 Pass prompt-turn roots into builtin shell execution and default working directory selection
+- [x] 4.5 Preserve existing builtin policy, disabled tools, timeouts, output limits, and read tracking behavior
+- [x] 4.6 Add tests proving builtin tools do not authorize paths from another session's roots
+- [x] 4.7 Add tests proving pending roots do not change builtin authorization during an active prompt
+
+## 5. Project Skill Refresh
+
+- [x] 5.1 Add project-skill discovery helper that accepts a session workspace root snapshot
+- [x] 5.2 Refresh the session's available skill snapshot when roots are applied immediately
+- [x] 5.3 Refresh the session's available skill snapshot when deferred roots are applied after prompt completion
+- [x] 5.4 Preserve already active skill instructions when available skills are refreshed
+- [x] 5.5 Preserve project skill trust gating and diagnostics for newly active roots
+- [x] 5.6 Add tests for root-change project skill discovery and active skill preservation
+
+## 6. Multi-Session Integration Tests
+
+- [x] 6.1 Add test for two sessions under one runtime with different active roots
+- [x] 6.2 Add test that `set_workspace_roots` on one session does not affect another session
+- [x] 6.3 Add test that prompt runtime context and builtin allowed roots use the same session snapshot
+- [x] 6.4 Add test that existing `Config::with_workspace_roots()` remains the default for newly created sessions
+- [x] 6.5 Add serialization compatibility test for sessions without workspace-root fields
+
+## 7. Documentation and Validation
+
+- [x] 7.1 Document `AgentSession::set_workspace_roots` behavior and deferral semantics
+- [x] 7.2 Document that builtin tools use one root snapshot per prompt turn
+- [x] 7.3 Run `cargo check --manifest-path src-tauri/Cargo.toml` if this repository is used through the Tauri workspace
+- [x] 7.4 Run the narrowest relevant Rust tests for runtime, request builder, builtin tools, and skill refresh
+- [x] 7.5 Run `openspec status --change session-workspace-roots` and confirm artifacts remain apply-ready

--- a/src/builtin/mod.rs
+++ b/src/builtin/mod.rs
@@ -19,6 +19,24 @@ pub use registration::register_builtin_tools;
 
 use crate::tool::Tool;
 
+/// Check if a name corresponds to a builtin tool.
+///
+/// Returns `true` if the name is a recognized builtin tool name.
+pub fn is_builtin_name(name: &str) -> bool {
+    matches!(
+        name,
+        "read"
+            | "write"
+            | "edit"
+            | "multiedit"
+            | "glob"
+            | "grep"
+            | "webfetch"
+            | "bash"
+            | "powershell"
+    )
+}
+
 /// Instantiate a builtin tool by name with the given configuration.
 ///
 /// Returns `None` if the name does not correspond to a builtin tool.

--- a/src/builtin/mod.rs
+++ b/src/builtin/mod.rs
@@ -16,3 +16,56 @@ pub use policy::{
     ApprovalScope, ApprovalScopeMatch, BuiltinToolPolicy, NetworkPolicy, ShellAvailability,
 };
 pub use registration::register_builtin_tools;
+
+use crate::tool::Tool;
+
+/// Instantiate a builtin tool by name with the given configuration.
+///
+/// Returns `None` if the name does not correspond to a builtin tool.
+pub fn instantiate_builtin(name: &str, config: &BuiltinToolConfig) -> Option<Box<dyn Tool>> {
+    match name {
+        "read" => config
+            .is_tool_enabled("read")
+            .then(|| Box::new(file_ops::ReadTool::new(config.clone())) as Box<dyn Tool>),
+        "write" => config
+            .is_tool_enabled("write")
+            .then(|| Box::new(file_ops::WriteTool::new(config.clone())) as Box<dyn Tool>),
+        "edit" => config
+            .is_tool_enabled("edit")
+            .then(|| Box::new(file_ops::EditTool::new(config.clone())) as Box<dyn Tool>),
+        "multiedit" => config
+            .is_tool_enabled("multiedit")
+            .then(|| Box::new(file_ops::MultieditTool::new(config.clone())) as Box<dyn Tool>),
+        "glob" => config
+            .is_tool_enabled("glob")
+            .then(|| Box::new(search::GlobTool::new(config.clone())) as Box<dyn Tool>),
+        "grep" => config
+            .is_tool_enabled("grep")
+            .then(|| Box::new(search::GrepTool::new(config.clone())) as Box<dyn Tool>),
+        "webfetch" => config
+            .is_tool_enabled("webfetch")
+            .then(|| Box::new(web::WebFetchTool::new(config.clone())) as Box<dyn Tool>),
+        "bash" => {
+            if config.is_tool_enabled("bash")
+                && matches!(config.shell_availability, policy::ShellAvailability::Bash)
+            {
+                Some(Box::new(shell::BashTool::new(config.clone())))
+            } else {
+                None
+            }
+        }
+        "powershell" => {
+            if config.is_tool_enabled("powershell")
+                && matches!(
+                    config.shell_availability,
+                    policy::ShellAvailability::PowerShell
+                )
+            {
+                Some(Box::new(shell::PowerShellTool::new(config.clone())))
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -245,6 +245,10 @@ impl IronConnection {
 
         self.runtime.finish_prompt(iron_session_id);
 
+        // Check for pending workspace roots at turn boundary
+        self.runtime
+            .check_and_apply_pending_workspace_roots(iron_session_id);
+
         // Check for pending model switches at turn boundary
         self.runtime
             .check_and_apply_pending_model_switch(iron_session_id);
@@ -318,6 +322,9 @@ impl IronConnection {
                     session.add_agent_text(format!("[Auth error: {}]", e));
                 }
                 self.runtime.finish_prompt(iron_session_id);
+                // Check for pending workspace roots at turn boundary
+                self.runtime
+                    .check_and_apply_pending_workspace_roots(iron_session_id);
                 // Check for pending model switches at turn boundary
                 self.runtime
                     .check_and_apply_pending_model_switch(iron_session_id);
@@ -332,6 +339,10 @@ impl IronConnection {
             .await;
 
         self.runtime.finish_prompt(iron_session_id);
+
+        // Check for pending workspace roots at turn boundary
+        self.runtime
+            .check_and_apply_pending_workspace_roots(iron_session_id);
 
         // Check for pending model switches at turn boundary
         self.runtime

--- a/src/durable.rs
+++ b/src/durable.rs
@@ -390,6 +390,12 @@ pub struct DurableSession {
     /// History of model switches for this session
     #[serde(default)]
     pub model_switch_history: Vec<crate::context::model_switch::ModelSwitchRecord>,
+    /// Session-scoped active workspace roots.
+    #[serde(default)]
+    pub workspace_roots: Vec<std::path::PathBuf>,
+    /// Pending workspace roots to be applied at the next turn boundary.
+    #[serde(default)]
+    pub pending_workspace_roots: Option<Vec<std::path::PathBuf>>,
 }
 
 impl DurableSession {
@@ -412,6 +418,8 @@ impl DurableSession {
             next_visible_id: 1,
             current_model: None,
             model_switch_history: Vec::new(),
+            workspace_roots: Vec::new(),
+            pending_workspace_roots: None,
         }
     }
 
@@ -967,6 +975,29 @@ impl DurableSession {
             .iter()
             .find(|skill| skill.metadata.id == name)
             .cloned()
+    }
+
+    // -- Workspace root helpers --
+
+    pub fn active_workspace_roots(&self) -> &[std::path::PathBuf] {
+        &self.workspace_roots
+    }
+
+    pub fn set_pending_workspace_roots(&mut self, roots: Vec<std::path::PathBuf>) {
+        self.pending_workspace_roots = Some(roots);
+    }
+
+    pub fn clear_pending_workspace_roots(&mut self) {
+        self.pending_workspace_roots = None;
+    }
+
+    pub fn apply_pending_workspace_roots(&mut self) -> bool {
+        if let Some(roots) = self.pending_workspace_roots.take() {
+            self.workspace_roots = roots;
+            true
+        } else {
+            false
+        }
     }
 
     pub fn to_transcript(&self) -> iron_providers::Transcript {

--- a/src/facade.rs
+++ b/src/facade.rs
@@ -1714,6 +1714,25 @@ impl AgentSession {
         self.durable.lock().set_instructions(instructions);
     }
 
+    /// Set the workspace roots for this session.
+    ///
+    /// If the session is idle, roots are applied immediately and the session's
+    /// available skills are refreshed from the new roots.
+    ///
+    /// If a prompt is currently active, the roots are deferred until the prompt
+    /// completes, at which point they will be applied automatically.
+    ///
+    /// Returns `true` if the roots were applied immediately, or `false` if they
+    /// were deferred until the next turn boundary.
+    pub fn set_workspace_roots(
+        &self,
+        roots: Vec<std::path::PathBuf>,
+    ) -> Result<bool, RuntimeError> {
+        self.connection
+            .runtime()
+            .set_session_workspace_roots(self.id, roots)
+    }
+
     // -- Provider Credential APIs --
 
     /// Get the auth status for a provider.

--- a/src/mcp/session_catalog.rs
+++ b/src/mcp/session_catalog.rs
@@ -372,18 +372,7 @@ impl SessionToolCatalog {
                         // instantiate_builtin returned None. Only treat this as an error
                         // if the tool name is a known builtin; otherwise fall through to
                         // the local registry for non-builtin local tools.
-                        if matches!(
-                            tool_name.as_str(),
-                            "read"
-                                | "write"
-                                | "edit"
-                                | "multiedit"
-                                | "glob"
-                                | "grep"
-                                | "webfetch"
-                                | "bash"
-                                | "powershell"
-                        ) {
+                        if crate::builtin::is_builtin_name(&tool_name) {
                             return Err(crate::error::RuntimeError::tool_execution(format!(
                                 "Builtin tool '{}' is configured for this session but could not be instantiated.",
                                 tool_name

--- a/src/mcp/session_catalog.rs
+++ b/src/mcp/session_catalog.rs
@@ -374,8 +374,15 @@ impl SessionToolCatalog {
                         // the local registry for non-builtin local tools.
                         if matches!(
                             tool_name.as_str(),
-                            "read" | "write" | "edit" | "multiedit" | "glob" | "grep"
-                                | "webfetch" | "bash" | "powershell"
+                            "read"
+                                | "write"
+                                | "edit"
+                                | "multiedit"
+                                | "glob"
+                                | "grep"
+                                | "webfetch"
+                                | "bash"
+                                | "powershell"
                         ) {
                             return Err(crate::error::RuntimeError::tool_execution(format!(
                                 "Builtin tool '{}' is configured for this session but could not be instantiated.",

--- a/src/mcp/session_catalog.rs
+++ b/src/mcp/session_catalog.rs
@@ -369,6 +369,12 @@ impl SessionToolCatalog {
                         {
                             return tool.execute(&call_id_owned, arguments).await;
                         }
+                        // Session-configured builtin was present but instantiation failed;
+                        // do not fall through to the global registry.
+                        return Err(crate::error::RuntimeError::tool_execution(format!(
+                            "Builtin tool '{}' is configured for this session but could not be instantiated.",
+                            tool_name
+                        )));
                     }
                     // Fall back to the globally-registered tool.
                     if let Some(tool) = local_registry.get(&tool_name) {

--- a/src/mcp/session_catalog.rs
+++ b/src/mcp/session_catalog.rs
@@ -369,12 +369,19 @@ impl SessionToolCatalog {
                         {
                             return tool.execute(&call_id_owned, arguments).await;
                         }
-                        // Session-configured builtin was present but instantiation failed;
-                        // do not fall through to the global registry.
-                        return Err(crate::error::RuntimeError::tool_execution(format!(
-                            "Builtin tool '{}' is configured for this session but could not be instantiated.",
-                            tool_name
-                        )));
+                        // instantiate_builtin returned None. Only treat this as an error
+                        // if the tool name is a known builtin; otherwise fall through to
+                        // the local registry for non-builtin local tools.
+                        if matches!(
+                            tool_name.as_str(),
+                            "read" | "write" | "edit" | "multiedit" | "glob" | "grep"
+                                | "webfetch" | "bash" | "powershell"
+                        ) {
+                            return Err(crate::error::RuntimeError::tool_execution(format!(
+                                "Builtin tool '{}' is configured for this session but could not be instantiated.",
+                                tool_name
+                            )));
+                        }
                     }
                     // Fall back to the globally-registered tool.
                     if let Some(tool) = local_registry.get(&tool_name) {

--- a/src/mcp/session_catalog.rs
+++ b/src/mcp/session_catalog.rs
@@ -335,6 +335,21 @@ impl SessionToolCatalog {
         arguments: Value,
         session: &DurableSession,
     ) -> ToolFuture {
+        self.execute_with_builtin_config(call_id, name, arguments, session, None)
+    }
+
+    /// Execute a tool with an optional session-configured builtin tool config.
+    ///
+    /// When `builtin_config` is provided and the tool is a local builtin,
+    /// a session-configured instance is created with the given allowed roots.
+    pub fn execute_with_builtin_config(
+        &self,
+        call_id: &str,
+        name: &str,
+        arguments: Value,
+        session: &DurableSession,
+        builtin_config: Option<crate::builtin::BuiltinToolConfig>,
+    ) -> ToolFuture {
         let tool_info = self.tool_map.get(name).cloned();
         let local_registry = Arc::clone(&self.local_registry);
         let connection_manager = Arc::clone(&self.connection_manager);
@@ -347,6 +362,15 @@ impl SessionToolCatalog {
             Some(ToolInfo::Local { name: tool_name }) => {
                 // Execute local tool
                 Box::pin(async move {
+                    // If a session-configured builtin config is provided, try to
+                    // instantiate a session-scoped builtin tool first.
+                    if let Some(ref config) = builtin_config {
+                        if let Some(tool) = crate::builtin::instantiate_builtin(&tool_name, config)
+                        {
+                            return tool.execute(&call_id_owned, arguments).await;
+                        }
+                    }
+                    // Fall back to the globally-registered tool.
                     if let Some(tool) = local_registry.get(&tool_name) {
                         tool.execute(&call_id_owned, arguments).await
                     } else {

--- a/src/prompt_runner.rs
+++ b/src/prompt_runner.rs
@@ -169,6 +169,7 @@ impl PromptRunner {
                 let repo_payload = session.repo_instruction_payload.clone();
                 let messages = session.to_transcript_with_visible_ids(true).messages;
                 let skill_instructions = session.active_skill_instructions();
+                let workspace_roots = session.workspace_roots.clone();
                 drop(session);
 
                 let tool_registry = self.runtime.tool_registry();
@@ -233,6 +234,7 @@ impl PromptRunner {
                             python_exec_available: tool_catalog.contains("python_exec"),
                             skill_instructions: Some(&skill_instructions),
                             context_pressure,
+                            workspace_roots: Some(&workspace_roots),
                         },
                         tool_catalog.definitions(),
                     )
@@ -247,6 +249,7 @@ impl PromptRunner {
                             python_exec_available: tool_registry.contains("python_exec"),
                             skill_instructions: Some(&skill_instructions),
                             context_pressure,
+                            workspace_roots: Some(&workspace_roots),
                         },
                         &tool_registry,
                     )
@@ -1215,7 +1218,17 @@ impl PromptRunner {
         let arguments = call.arguments.clone();
         let execute_future = {
             let session_guard = durable.lock();
-            tool_catalog.execute(&call_id_owned, &tool_name_owned, arguments, &session_guard)
+            let roots = session_guard.workspace_roots.clone();
+            drop(session_guard);
+            let builtin_config = self.runtime.session_builtin_tool_config(&roots);
+            let session_guard = durable.lock();
+            tool_catalog.execute_with_builtin_config(
+                &call_id_owned,
+                &tool_name_owned,
+                arguments,
+                &session_guard,
+                builtin_config,
+            )
         };
 
         let execute_result = execute_future.await;
@@ -1697,11 +1710,16 @@ impl PromptRunner {
                         let req_tool_name = req.tool_name.clone();
                         let execute_future = {
                             let session_guard = durable.lock();
-                            session_tool_catalog.execute(
+                            let roots = session_guard.workspace_roots.clone();
+                            drop(session_guard);
+                            let builtin_config = self.runtime.session_builtin_tool_config(&roots);
+                            let session_guard = durable.lock();
+                            session_tool_catalog.execute_with_builtin_config(
                                 &req.call_id,
                                 &req.tool_name,
                                 req.args.clone(),
                                 &session_guard,
+                                builtin_config,
                             )
                         };
 
@@ -1898,11 +1916,16 @@ impl PromptRunner {
                     let req_tool_name = req.tool_name.clone();
                     let execute_future = {
                         let session_guard = durable.lock();
-                        session_tool_catalog.execute(
+                        let roots = session_guard.workspace_roots.clone();
+                        drop(session_guard);
+                        let builtin_config = self.runtime.session_builtin_tool_config(&roots);
+                        let session_guard = durable.lock();
+                        session_tool_catalog.execute_with_builtin_config(
                             &req.call_id,
                             &req.tool_name,
                             req.args.clone(),
                             &session_guard,
+                            builtin_config,
                         )
                     };
 

--- a/src/request_builder.rs
+++ b/src/request_builder.rs
@@ -13,6 +13,9 @@ pub struct EffectiveToolRequestContext<'a> {
     pub python_exec_available: bool,
     pub skill_instructions: Option<&'a str>,
     pub context_pressure: crate::context::ContextPressure,
+    /// Optional session workspace root snapshot. When provided, this overrides
+    /// Config.workspace_roots for runtime context rendering.
+    pub workspace_roots: Option<&'a [std::path::PathBuf]>,
 }
 
 /// Build an inference request using an effective tool view.
@@ -60,6 +63,7 @@ pub fn build_inference_request_with_effective_tools(
         context.python_exec_available,
         context.skill_instructions,
         context.context_pressure,
+        context.workspace_roots,
     );
     if !composed.is_empty() {
         request = request.with_instructions(composed);
@@ -84,6 +88,7 @@ pub fn build_inference_request(
             python_exec_available: tool_registry.contains("python_exec"),
             skill_instructions: None,
             context_pressure: crate::context::ContextPressure::None,
+            workspace_roots: None,
         },
         tool_registry,
     )
@@ -106,6 +111,7 @@ pub fn build_inference_request_with_context(
             python_exec_available: tool_registry.contains("python_exec"),
             skill_instructions: None,
             context_pressure: crate::context::ContextPressure::None,
+            workspace_roots: None,
         },
         tool_registry,
     )
@@ -128,6 +134,7 @@ pub fn build_inference_request_with_repo(
             python_exec_available: tool_registry.contains("python_exec"),
             skill_instructions: None,
             context_pressure: crate::context::ContextPressure::None,
+            workspace_roots: None,
         },
         tool_registry,
     )
@@ -172,6 +179,7 @@ pub fn build_inference_request_with_context_and_repo(
         context.python_exec_available || python_exec_available,
         context.skill_instructions,
         context.context_pressure,
+        context.workspace_roots,
     );
     if !composed.is_empty() {
         request = request.with_instructions(composed);
@@ -187,12 +195,19 @@ fn build_composed_instructions(
     python_exec_available: bool,
     skill_instructions: Option<&str>,
     context_pressure: crate::context::ContextPressure,
+    workspace_roots: Option<&[std::path::PathBuf]>,
 ) -> String {
     let baseline = crate::prompt::baseline::BASELINE_PROMPT;
 
     let repo_payload = repo_instruction_payload.cloned().unwrap_or_default();
 
-    let (working_dir, workspace_roots) = if config.workspace_roots.is_empty() {
+    let (working_dir, workspace_roots) = if let Some(roots) = workspace_roots {
+        if roots.is_empty() {
+            (std::env::current_dir().unwrap_or_default(), Vec::new())
+        } else {
+            (roots[0].clone(), roots.to_vec())
+        }
+    } else if config.workspace_roots.is_empty() {
         (std::env::current_dir().unwrap_or_default(), Vec::new())
     } else {
         (

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -789,9 +789,9 @@ impl IronRuntime {
         // Preserve already-active skills by re-activating them if they exist
         // in the new available set
         for skill in &available_skills {
-            if previously_active.contains(&skill.metadata.id) {
-                guard.activate_skill(&skill.metadata.id, &skill.body, skill.resources.clone());
-            } else if skill.metadata.auto_activate && !skill.metadata.requires_trust {
+            if previously_active.contains(&skill.metadata.id)
+                || (skill.metadata.auto_activate && !skill.metadata.requires_trust)
+            {
                 guard.activate_skill(&skill.metadata.id, &skill.body, skill.resources.clone());
             }
         }
@@ -826,13 +826,14 @@ impl IronRuntime {
         // Project-level skills: .agents/skills/ in each workspace root
         for root in roots {
             let project_skills_dir = root.join(".agents").join("skills");
-            if project_skills_dir.exists() && project_skills_dir.is_dir() {
-                if config.skills.trust_project_skills {
-                    sources.push(Box::new(FilesystemSkillSource::new(
-                        project_skills_dir,
-                        SkillOrigin::ProjectFilesystem,
-                    )));
-                }
+            if project_skills_dir.exists()
+                && project_skills_dir.is_dir()
+                && config.skills.trust_project_skills
+            {
+                sources.push(Box::new(FilesystemSkillSource::new(
+                    project_skills_dir,
+                    SkillOrigin::ProjectFilesystem,
+                )));
             }
         }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -56,6 +56,8 @@ struct RuntimeInner {
     resolver: Option<Arc<CredentialResolver>>,
     debug_sink: RwLock<Option<Arc<dyn crate::debug::DebugSink>>>,
     debug_sequence: crate::debug::SequenceGenerator,
+    /// Base builtin tool config used to create session-configured instances.
+    builtin_tool_config: Mutex<Option<crate::builtin::BuiltinToolConfig>>,
 }
 
 struct ActivePrompt {
@@ -68,6 +70,7 @@ struct RuntimeSession {
     active_prompt: Mutex<Option<ActivePrompt>>,
     tool_catalog_cache: Mutex<Option<CachedSessionToolCatalog>>,
     pending_model_switch: Mutex<Option<PendingModelSwitch>>,
+    pending_workspace_roots: Mutex<Option<Vec<std::path::PathBuf>>>,
     turn_counter: std::sync::atomic::AtomicU64,
 }
 
@@ -89,6 +92,7 @@ impl RuntimeSession {
             active_prompt: Mutex::new(None),
             tool_catalog_cache: Mutex::new(None),
             pending_model_switch: Mutex::new(None),
+            pending_workspace_roots: Mutex::new(None),
             turn_counter: std::sync::atomic::AtomicU64::new(1),
         }
     }
@@ -213,6 +217,7 @@ impl IronRuntime {
             resolver: None,
             debug_sink: RwLock::new(None),
             debug_sequence: crate::debug::SequenceGenerator::new(),
+            builtin_tool_config: Mutex::new(None),
         };
 
         let this = Self {
@@ -295,6 +300,7 @@ impl IronRuntime {
             resolver: None,
             debug_sink: RwLock::new(None),
             debug_sequence: crate::debug::SequenceGenerator::new(),
+            builtin_tool_config: Mutex::new(None),
         };
 
         let this = Self {
@@ -508,6 +514,21 @@ impl IronRuntime {
     pub fn register_builtin_tools(&self, config: &crate::builtin::BuiltinToolConfig) {
         let mut registry = self.inner.tool_registry.write();
         crate::builtin::register_builtin_tools(&mut registry, config);
+        *self.inner.builtin_tool_config.lock() = Some(config.clone());
+    }
+
+    /// Create a session-configured BuiltinToolConfig with the given workspace roots.
+    ///
+    /// This preserves all other builtin policy/settings from the base config.
+    pub fn session_builtin_tool_config(
+        &self,
+        roots: &[std::path::PathBuf],
+    ) -> Option<crate::builtin::BuiltinToolConfig> {
+        let base = self.inner.builtin_tool_config.lock().clone()?;
+        Some(crate::builtin::BuiltinToolConfig {
+            allowed_roots: roots.to_vec(),
+            ..base
+        })
     }
 
     #[cfg(feature = "embedded-python")]
@@ -737,6 +758,120 @@ impl IronRuntime {
             .collect()
     }
 
+    /// Discover and refresh available skills for a specific session's workspace roots.
+    ///
+    /// This updates the session's available skill snapshot while preserving
+    /// already-active skill instructions.
+    pub fn refresh_session_skills(
+        &self,
+        session_id: SessionId,
+        roots: &[std::path::PathBuf],
+    ) -> Result<(), RuntimeError> {
+        if !self.inner.config.skills.enabled {
+            return Ok(());
+        }
+
+        let session = self
+            .get_session(session_id)
+            .ok_or_else(|| RuntimeError::SessionNotFound(session_id.to_string()))?;
+
+        let available_skills = self.discover_available_skills_for_roots(roots);
+
+        let mut guard = session.lock();
+        let previously_active: Vec<String> = guard
+            .list_active_skills()
+            .into_iter()
+            .map(|s| s.to_string())
+            .collect();
+
+        guard.set_available_skills(available_skills.clone());
+
+        // Preserve already-active skills by re-activating them if they exist
+        // in the new available set
+        for skill in &available_skills {
+            if previously_active.contains(&skill.metadata.id) {
+                guard.activate_skill(&skill.metadata.id, &skill.body, skill.resources.clone());
+            } else if skill.metadata.auto_activate && !skill.metadata.requires_trust {
+                guard.activate_skill(&skill.metadata.id, &skill.body, skill.resources.clone());
+            }
+        }
+
+        drop(guard);
+
+        // Invalidate tool catalog cache since available skills changed
+        let sessions = self.inner.sessions.read();
+        if let Some(rs) = sessions.get(&session_id) {
+            let mut cache = rs.tool_catalog_cache.lock();
+            *cache = None;
+        }
+
+        Ok(())
+    }
+
+    /// Discover available skills for the given workspace roots.
+    ///
+    /// Returns a list of LoadedSkill values discovered from project directories
+    /// under the provided roots, plus user-level and additional configured skills.
+    pub fn discover_available_skills_for_roots(
+        &self,
+        roots: &[std::path::PathBuf],
+    ) -> Vec<LoadedSkill> {
+        let mut sources: Vec<Box<dyn crate::skill::source::SkillSource>> = Vec::new();
+        let config = &self.inner.config;
+
+        if !config.skills.enabled {
+            return Vec::new();
+        }
+
+        // Project-level skills: .agents/skills/ in each workspace root
+        for root in roots {
+            let project_skills_dir = root.join(".agents").join("skills");
+            if project_skills_dir.exists() && project_skills_dir.is_dir() {
+                if config.skills.trust_project_skills {
+                    sources.push(Box::new(FilesystemSkillSource::new(
+                        project_skills_dir,
+                        SkillOrigin::ProjectFilesystem,
+                    )));
+                }
+            }
+        }
+
+        // User-level skills: ~/.agents/skills/
+        let home_dir = std::env::var("HOME")
+            .or_else(|_| std::env::var("USERPROFILE"))
+            .map(std::path::PathBuf::from)
+            .ok();
+        if let Some(home) = home_dir {
+            let user_skills_dir = home.join(".agents").join("skills");
+            if user_skills_dir.exists() && user_skills_dir.is_dir() {
+                sources.push(Box::new(FilesystemSkillSource::new(
+                    user_skills_dir,
+                    SkillOrigin::UserFilesystem,
+                )));
+            }
+        }
+
+        // Additional configured skill directories
+        for dir in &config.skills.additional_skill_dirs {
+            if dir.exists() && dir.is_dir() {
+                sources.push(Box::new(FilesystemSkillSource::new(
+                    dir.clone(),
+                    SkillOrigin::UserFilesystem,
+                )));
+            }
+        }
+
+        // Runtime-registered skills
+        let mut static_source = crate::skill::source::StaticSkillSource::new();
+        for skill in self.skill_catalog().list_all() {
+            static_source.register(skill.clone());
+        }
+        sources.push(Box::new(static_source));
+
+        let catalog = SkillCatalog::discover(&sources);
+        catalog.list_all().into_iter().cloned().collect()
+    }
+
     /// Borrow the Tokio runtime handle used for orchestration.
     pub fn tokio_handle(&self) -> &tokio::runtime::Handle {
         &self.inner.tokio_handle
@@ -808,6 +943,14 @@ impl IronRuntime {
             );
             durable.repo_instruction_payload = Some(payload);
         }
+
+        // Seed workspace roots from config or current directory fallback
+        let roots = if self.inner.config.workspace_roots.is_empty() {
+            vec![std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."))]
+        } else {
+            self.inner.config.workspace_roots.clone()
+        };
+        durable.workspace_roots = roots;
 
         // Initialize MCP server enablement state for new session
         // Uses the single runtime-level default policy without per-server override
@@ -1225,6 +1368,76 @@ impl IronRuntime {
             .get(&session_id)
             .map(|rs| rs.active_prompt.lock().is_some())
             .unwrap_or(false)
+    }
+
+    /// Set workspace roots for a session.
+    ///
+    /// If the session is idle, roots are applied immediately and skills are refreshed.
+    /// If a prompt is active, roots are deferred until the prompt completes.
+    /// Returns whether the roots were applied immediately.
+    pub fn set_session_workspace_roots(
+        &self,
+        session_id: SessionId,
+        roots: Vec<std::path::PathBuf>,
+    ) -> Result<bool, RuntimeError> {
+        if self.is_shutdown() {
+            return Err(RuntimeError::Connection("Runtime is shut down".into()));
+        }
+
+        let sessions = self.inner.sessions.read();
+        let rs = sessions
+            .get(&session_id)
+            .ok_or_else(|| RuntimeError::SessionNotFound(session_id.to_string()))?;
+
+        if rs.active_prompt.lock().is_some() {
+            // Defer: store pending roots on RuntimeSession (latest wins)
+            let mut pending = rs.pending_workspace_roots.lock();
+            *pending = Some(roots);
+            Ok(false)
+        } else {
+            // Apply immediately
+            drop(sessions); // Release read lock before taking write lock on session
+            let session = self
+                .get_session(session_id)
+                .ok_or_else(|| RuntimeError::SessionNotFound(session_id.to_string()))?;
+            let mut guard = session.lock();
+            guard.workspace_roots = roots.clone();
+            guard.clear_pending_workspace_roots();
+            drop(guard);
+
+            // Refresh skills for the new roots
+            self.refresh_session_skills(session_id, &roots)?;
+
+            Ok(true)
+        }
+    }
+
+    /// Check and apply any pending workspace roots for a session.
+    ///
+    /// This should be called at turn boundaries after a prompt completes.
+    pub fn check_and_apply_pending_workspace_roots(&self, session_id: SessionId) {
+        let sessions = self.inner.sessions.read();
+        let Some(rs) = sessions.get(&session_id) else {
+            return;
+        };
+
+        let pending = {
+            let mut pending = rs.pending_workspace_roots.lock();
+            pending.take()
+        };
+
+        if let Some(roots) = pending {
+            drop(sessions); // Release read lock
+            if let Some(session) = self.get_session(session_id) {
+                let mut guard = session.lock();
+                guard.workspace_roots = roots.clone();
+                guard.clear_pending_workspace_roots();
+                drop(guard);
+
+                // Refresh skills for the new roots
+                let _ = self.refresh_session_skills(session_id, &roots);
+            }
+        }
     }
 
     pub fn get_active_prompt_ephemeral(
@@ -2042,5 +2255,215 @@ mod tests {
 
         // Finish the prompt to clean up
         runtime.finish_prompt(session_id);
+    }
+
+    // -----------------------------------------------------------------------
+    // Session workspace roots tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn new_session_inherits_config_workspace_roots() {
+        let roots = vec![std::path::PathBuf::from("/project/a")];
+        let config = Config::default().with_workspace_roots(roots.clone());
+        let runtime = IronRuntime::new(config, MockProvider);
+        let conn = ConnectionId(1);
+        runtime.register_connection(conn);
+
+        let (_session_id, session) = runtime.create_session(conn).unwrap();
+        let guard = session.lock();
+        assert_eq!(guard.workspace_roots, roots);
+    }
+
+    #[test]
+    fn new_session_falls_back_to_current_dir_when_config_empty() {
+        let config = Config::default();
+        let runtime = IronRuntime::new(config, MockProvider);
+        let conn = ConnectionId(1);
+        runtime.register_connection(conn);
+
+        let (_session_id, session) = runtime.create_session(conn).unwrap();
+        let guard = session.lock();
+        assert!(!guard.workspace_roots.is_empty());
+        // Should be current dir, not empty
+        assert_eq!(
+            guard.workspace_roots[0],
+            std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."))
+        );
+    }
+
+    #[test]
+    fn set_workspace_roots_on_idle_session_applies_immediately() {
+        let config =
+            Config::default().with_workspace_roots(vec![std::path::PathBuf::from("/original")]);
+        let runtime = IronRuntime::new(config, MockProvider);
+        let conn = ConnectionId(1);
+        runtime.register_connection(conn);
+
+        let (session_id, session) = runtime.create_session(conn).unwrap();
+        let new_roots = vec![std::path::PathBuf::from("/new")];
+        let applied = runtime
+            .set_session_workspace_roots(session_id, new_roots.clone())
+            .unwrap();
+
+        assert!(
+            applied,
+            "Roots should be applied immediately for idle session"
+        );
+        let guard = session.lock();
+        assert_eq!(guard.workspace_roots, new_roots);
+        assert!(guard.pending_workspace_roots.is_none());
+    }
+
+    #[test]
+    fn set_workspace_roots_during_active_prompt_is_deferred() {
+        let config =
+            Config::default().with_workspace_roots(vec![std::path::PathBuf::from("/original")]);
+        let runtime = IronRuntime::new(config, MockProvider);
+        let conn = ConnectionId(1);
+        runtime.register_connection(conn);
+
+        let (session_id, session) = runtime.create_session(conn).unwrap();
+
+        // Start a prompt
+        let _ephemeral = runtime.try_start_prompt(session_id).unwrap();
+
+        let new_roots = vec![std::path::PathBuf::from("/new")];
+        let applied = runtime
+            .set_session_workspace_roots(session_id, new_roots.clone())
+            .unwrap();
+
+        assert!(!applied, "Roots should be deferred when a prompt is active");
+
+        // Active roots should still be the original
+        let guard = session.lock();
+        assert_eq!(
+            guard.workspace_roots,
+            vec![std::path::PathBuf::from("/original")]
+        );
+        // But pending should be set
+        drop(guard);
+
+        // After finishing prompt, pending roots should be applied
+        runtime.finish_prompt(session_id);
+        runtime.check_and_apply_pending_workspace_roots(session_id);
+
+        let guard = session.lock();
+        assert_eq!(guard.workspace_roots, new_roots);
+        assert!(guard.pending_workspace_roots.is_none());
+    }
+
+    #[test]
+    fn multiple_deferred_updates_keep_only_latest() {
+        let config =
+            Config::default().with_workspace_roots(vec![std::path::PathBuf::from("/original")]);
+        let runtime = IronRuntime::new(config, MockProvider);
+        let conn = ConnectionId(1);
+        runtime.register_connection(conn);
+
+        let (session_id, _session) = runtime.create_session(conn).unwrap();
+
+        // Start a prompt
+        let _ephemeral = runtime.try_start_prompt(session_id).unwrap();
+
+        // Set roots multiple times while prompt is active
+        runtime
+            .set_session_workspace_roots(session_id, vec![std::path::PathBuf::from("/first")])
+            .unwrap();
+        runtime
+            .set_session_workspace_roots(session_id, vec![std::path::PathBuf::from("/second")])
+            .unwrap();
+        runtime
+            .set_session_workspace_roots(session_id, vec![std::path::PathBuf::from("/third")])
+            .unwrap();
+
+        // Finish prompt and apply pending
+        runtime.finish_prompt(session_id);
+        runtime.check_and_apply_pending_workspace_roots(session_id);
+
+        let session = runtime.get_session(session_id).unwrap();
+        let guard = session.lock();
+        assert_eq!(
+            guard.workspace_roots,
+            vec![std::path::PathBuf::from("/third")]
+        );
+    }
+
+    #[test]
+    fn workspace_root_changes_are_session_isolated() {
+        let config =
+            Config::default().with_workspace_roots(vec![std::path::PathBuf::from("/shared")]);
+        let runtime = IronRuntime::new(config, MockProvider);
+        let conn = ConnectionId(1);
+        runtime.register_connection(conn);
+
+        let (session_a_id, session_a) = runtime.create_session(conn).unwrap();
+        let (_session_b_id, session_b) = runtime.create_session(conn).unwrap();
+
+        // Change roots for session A only
+        runtime
+            .set_session_workspace_roots(session_a_id, vec![std::path::PathBuf::from("/a-only")])
+            .unwrap();
+
+        // Session A should have new roots
+        let guard_a = session_a.lock();
+        assert_eq!(
+            guard_a.workspace_roots,
+            vec![std::path::PathBuf::from("/a-only")]
+        );
+        drop(guard_a);
+
+        // Session B should still have original roots
+        let guard_b = session_b.lock();
+        assert_eq!(
+            guard_b.workspace_roots,
+            vec![std::path::PathBuf::from("/shared")]
+        );
+    }
+
+    #[test]
+    fn session_workspace_roots_serialization_compatibility() {
+        // Simulate loading an old session JSON that doesn't have workspace_roots fields
+        let old_session_json = r#"{
+            "id": 1,
+            "messages": [],
+            "tool_records": [],
+            "timeline": [],
+            "script_records": [],
+            "instructions": null,
+            "workspace_scope": null,
+            "compressed_blocks": [],
+            "uncompacted_tokens": 0,
+            "repo_instruction_payload": null,
+            "mcp_server_enablement": {},
+            "plugin_enablement": {"enabled": {}},
+            "skill_state": {"active": []},
+            "available_skills": [],
+            "next_visible_id": 1,
+            "current_model": null,
+            "model_switch_history": []
+        }"#;
+
+        let session: DurableSession = serde_json::from_str(old_session_json).unwrap();
+        assert!(session.workspace_roots.is_empty());
+        assert!(session.pending_workspace_roots.is_none());
+    }
+
+    #[test]
+    fn session_builtin_tool_config_preserves_base_policy() {
+        let base_config = crate::builtin::BuiltinToolConfig {
+            allowed_roots: vec![std::path::PathBuf::from("/base")],
+            ..Default::default()
+        };
+        let runtime = IronRuntime::new(Config::default(), MockProvider);
+        runtime.register_builtin_tools(&base_config);
+
+        let session_roots = vec![std::path::PathBuf::from("/session")];
+        let session_config = runtime.session_builtin_tool_config(&session_roots);
+
+        assert!(session_config.is_some());
+        let config = session_config.unwrap();
+        assert_eq!(config.allowed_roots, session_roots);
+        // Other fields should be preserved from base
+        assert_eq!(config.max_output_bytes, base_config.max_output_bytes);
     }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -70,7 +70,6 @@ struct RuntimeSession {
     active_prompt: Mutex<Option<ActivePrompt>>,
     tool_catalog_cache: Mutex<Option<CachedSessionToolCatalog>>,
     pending_model_switch: Mutex<Option<PendingModelSwitch>>,
-    pending_workspace_roots: Mutex<Option<Vec<std::path::PathBuf>>>,
     turn_counter: std::sync::atomic::AtomicU64,
 }
 
@@ -92,7 +91,6 @@ impl RuntimeSession {
             active_prompt: Mutex::new(None),
             tool_catalog_cache: Mutex::new(None),
             pending_model_switch: Mutex::new(None),
-            pending_workspace_roots: Mutex::new(None),
             turn_counter: std::sync::atomic::AtomicU64::new(1),
         }
     }
@@ -862,10 +860,12 @@ impl IronRuntime {
             }
         }
 
-        // Runtime-registered skills
+        // Runtime-registered skills (client-provided only)
         let mut static_source = crate::skill::source::StaticSkillSource::new();
         for skill in self.skill_catalog().list_all() {
-            static_source.register(skill.clone());
+            if skill.metadata.origin == SkillOrigin::ClientProvided {
+                static_source.register(skill.clone());
+            }
         }
         sources.push(Box::new(static_source));
 
@@ -951,7 +951,7 @@ impl IronRuntime {
         } else {
             self.inner.config.workspace_roots.clone()
         };
-        durable.workspace_roots = roots;
+        durable.workspace_roots = roots.clone();
 
         // Initialize MCP server enablement state for new session
         // Uses the single runtime-level default policy without per-server override
@@ -1030,12 +1030,28 @@ impl IronRuntime {
         // Uses .entry() / is_none() guards so existing client choices are preserved.
         self.apply_runtime_mcp_policy_to_session(&mut durable);
         self.apply_runtime_plugin_policy_to_session(&mut durable);
+
+        // Backfill workspace roots for legacy sessions imported before this feature.
+        if durable.workspace_roots.is_empty() {
+            durable.workspace_roots = if self.inner.config.workspace_roots.is_empty() {
+                vec![std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."))]
+            } else {
+                self.inner.config.workspace_roots.clone()
+            };
+        }
+        let roots = durable.workspace_roots.clone();
+
         let session = Arc::new(Mutex::new(durable));
         let runtime_session = RuntimeSession::new(session, connection_id);
         self.inner
             .sessions
             .write()
             .insert(session_id, Arc::new(runtime_session));
+
+        // Refresh skills for the backfilled roots so the session’s skill catalog
+        // and builtin allowed_roots reflect the effective workspace.
+        let _ = self.refresh_session_skills(session_id, &roots);
+
         Ok(())
     }
 
@@ -1391,20 +1407,18 @@ impl IronRuntime {
             .ok_or_else(|| RuntimeError::SessionNotFound(session_id.to_string()))?;
 
         if rs.active_prompt.lock().is_some() {
-            // Defer: store pending roots on RuntimeSession (latest wins)
-            let mut pending = rs.pending_workspace_roots.lock();
-            *pending = Some(roots);
+            // Defer: store pending roots in DurableSession (latest wins)
+            let mut guard = rs.session.lock();
+            guard.set_pending_workspace_roots(roots);
             Ok(false)
         } else {
-            // Apply immediately
-            drop(sessions); // Release read lock before taking write lock on session
-            let session = self
-                .get_session(session_id)
-                .ok_or_else(|| RuntimeError::SessionNotFound(session_id.to_string()))?;
-            let mut guard = session.lock();
+            // Apply immediately: lock DurableSession while still holding sessions read lock
+            // to prevent a prompt from starting between the check and the mutation.
+            let mut guard = rs.session.lock();
             guard.workspace_roots = roots.clone();
             guard.clear_pending_workspace_roots();
             drop(guard);
+            drop(sessions);
 
             // Refresh skills for the new roots
             self.refresh_session_skills(session_id, &roots)?;
@@ -1422,23 +1436,18 @@ impl IronRuntime {
             return;
         };
 
-        let pending = {
-            let mut pending = rs.pending_workspace_roots.lock();
-            pending.take()
+        let mut guard = rs.session.lock();
+        let pending = guard.apply_pending_workspace_roots();
+        let roots = if pending {
+            guard.workspace_roots.clone()
+        } else {
+            return;
         };
+        drop(guard);
+        drop(sessions);
 
-        if let Some(roots) = pending {
-            drop(sessions); // Release read lock
-            if let Some(session) = self.get_session(session_id) {
-                let mut guard = session.lock();
-                guard.workspace_roots = roots.clone();
-                guard.clear_pending_workspace_roots();
-                drop(guard);
-
-                // Refresh skills for the new roots
-                let _ = self.refresh_session_skills(session_id, &roots);
-            }
-        }
+        // Refresh skills for the new roots
+        let _ = self.refresh_session_skills(session_id, &roots);
     }
 
     pub fn get_active_prompt_ephemeral(


### PR DESCRIPTION
## Summary
- add session-scoped active and pending workspace roots with turn-boundary deferral
- thread prompt root snapshots into runtime context rendering and builtin tool execution
- refresh per-session project skills when roots are applied
- add OpenSpec artifacts and runtime coverage for root defaults, deferral, isolation, serialization, and builtin config policy

## Verification
- cargo fmt
- cargo check
- cargo test
- openspec status --change session-workspace-roots

Closes #46

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-session workspace roots: sessions can independently change active roots; changes during an active prompt defer until the next turn and the API indicates immediate vs deferred application.
  * Builtin/local tools and runtime use a single session-root snapshot per prompt for working directory, authorization, and tool execution; session-scoped builtin execution respects session roots and may be unavailable if not enabled.
  * Project skill discovery/refresh runs when roots become active, preserving already-active skills.

* **Tests & Documentation**
  * Added specs, docs, and tests covering isolation, deferred semantics, skill-refresh, and serialization compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->