### PR TITLE
docs: document compress tool pair boundaries

### DIFF
--- a/src/context/compaction.rs
+++ b/src/context/compaction.rs
@@ -15,7 +15,7 @@ impl CompressTool {
     pub fn definition() -> ToolDefinition {
         ToolDefinition::new(
             COMPRESS_TOOL_NAME,
-            "Compress resolved older conversation context. Your summaries permanently replace the selected ranges, so preserve all durable facts, decisions, constraints, file paths, errors, tool results, and user intent needed for future work.",
+            "Compress resolved older conversation context. Ranges must not split a tool call from its result message; include both or neither. Your summaries permanently replace the selected ranges, so preserve all durable facts, decisions, constraints, file paths, errors, tool results, and user intent needed for future work.",
             serde_json::json!({
                 "type": "object",
                 "properties": {
@@ -29,8 +29,14 @@ impl CompressTool {
                         "items": {
                             "type": "object",
                             "properties": {
-                                "start_message_id": { "type": "string" },
-                                "end_message_id": { "type": "string" },
+                                "start_message_id": {
+                                    "type": "string",
+                                    "description": "Inclusive first message ID in the range; do not choose a boundary that splits a tool call from its result."
+                                },
+                                "end_message_id": {
+                                    "type": "string",
+                                    "description": "Inclusive last message ID in the range; do not choose a boundary that splits a tool call from its result."
+                                },
                                 "summary": {
                                     "type": "string",
                                     "description": "Durable replacement summary for this range."

--- a/tests/context_management_tests.rs
+++ b/tests/context_management_tests.rs
@@ -18,6 +18,28 @@ fn make_session_with_messages(n: usize) -> DurableSession {
 }
 
 #[test]
+fn compress_tool_definition_mentions_tool_call_pair_boundary() {
+    let definition = CompressTool::definition();
+
+    assert!(definition
+        .description
+        .contains("must not split a tool call"));
+    assert!(definition.description.contains("include both or neither"));
+    assert!(
+        definition.input_schema["properties"]["content"]["items"]["properties"]["start_message_id"]
+            ["description"]
+            .as_str()
+            .is_some_and(|description| description.contains("splits a tool call"))
+    );
+    assert!(
+        definition.input_schema["properties"]["content"]["items"]["properties"]["end_message_id"]
+            ["description"]
+            .as_str()
+            .is_some_and(|description| description.contains("splits a tool call"))
+    );
+}
+
+#[test]
 fn telemetry_empty_session_reports_unknown_quality() {
     let registry = ToolRegistry::new();
     let snapshot = ContextTelemetry::for_session(


### PR DESCRIPTION
## Summary
- document that compress ranges must not split tool calls from their results
- add boundary guidance to start/end message ID schema descriptions
- cover the model-facing metadata with a regression test

## Verification
- cargo test --test context_management_tests compress_tool
- cargo clippy --all-targets --all-features -- -D warnings
- cargo fmt --check

Closes #47

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified compress tool guidance regarding proper message range selection to prevent splitting operations from their results.

* **Tests**
  * Added validation test to verify compress tool documentation correctly reflects boundary requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->