### PR TITLE
feat(config): add shared runtime settings store

### DIFF
--- a/openspec/changes/archive/2026-06-09-add-runtime-settings-config-store-apis/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-09-add-runtime-settings-config-store-apis/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-09

--- a/openspec/changes/archive/2026-06-09-add-runtime-settings-config-store-apis/design.md
+++ b/openspec/changes/archive/2026-06-09-add-runtime-settings-config-store-apis/design.md
@@ -1,0 +1,241 @@
+## Context
+
+IC-1 established `ConfigStore` as the durable core-owned configuration abstraction for profiles, prompts, schedules, and encrypted provider credentials. Issue #67 covers the next layer of shared runtime setup currently owned by the AgentIron desktop app: provider config, default model selection, custom models, MCP servers, and skill settings.
+
+The boundary is runtime setup, not every app preference. AgentIron-only preferences such as starred models stay in the app. Custom models move into `iron-core` because they affect provider/model selection and may be required for headless operation. Provider credentials stay in the encrypted credential API/store and must not be serialized into provider runtime config.
+
+## Goals
+
+- Add typed `ConfigStore` APIs for shared runtime settings needed by app and headless consumers.
+- Keep the public abstraction named `ConfigStore`; the database is an implementation detail.
+- Persist provider runtime config without credential fields or `iron-providers` protocol metadata.
+- Persist provider display names copied from provider metadata for stable presentation, without user-editable naming semantics for now.
+- Persist custom model records as core-owned provider/model metadata.
+- Persist default model selection as typed `provider_slug` plus `model_id`.
+- Persist MCP server definitions with `inherited_env_vars` for selected parent-env inheritance by name.
+- Persist skill discovery/trust settings already represented by runtime `SkillConfig`.
+- Provide a runtime settings snapshot API that validates cross-record relationships and projects durable settings into runtime startup inputs.
+- Add persistence round-trip and missing/default behavior tests.
+
+## Non-Goals
+
+- Moving AgentIron `starredModels` into `iron-core`.
+- Moving theme, autostart, shortcuts, user profile UI state, or other desktop-only preferences into `iron-core`.
+- Persisting provider credentials in provider runtime config.
+- Owning provider protocol metadata that belongs in `iron-providers`.
+- Migrating existing AgentIron app settings rows; AgentIron/AgentIron#56 owns app migration.
+- Letting frontends write SQLite directly.
+- Normalizing MCP env/header values into a separate secret store in this change.
+- Adding remote/cloud config sync.
+
+## Public API Shape
+
+`iron_core::config` should expose typed records and inputs for the runtime settings domains. Exact method names may be refined during implementation, but callers should not need SQL table names or app-owned JSON keys.
+
+Representative API groups:
+
+```rust
+impl ConfigStore {
+    async fn set_provider_config(&self, input: ProviderConfigInput) -> Result<ProviderConfigRecord, ConfigError>;
+    async fn get_provider_config(&self, provider_slug: &str) -> Result<Option<ProviderConfigRecord>, ConfigError>;
+    async fn list_provider_configs(&self) -> Result<Vec<ProviderConfigRecord>, ConfigError>;
+    async fn remove_provider_config(&self, provider_slug: &str) -> Result<(), ConfigError>;
+
+    async fn set_custom_model(&self, input: CustomModelInput) -> Result<CustomModelRecord, ConfigError>;
+    async fn get_custom_model(&self, provider_slug: &str, model_id: &str) -> Result<Option<CustomModelRecord>, ConfigError>;
+    async fn list_custom_models(&self, provider_slug: Option<&str>) -> Result<Vec<CustomModelRecord>, ConfigError>;
+    async fn remove_custom_model(&self, provider_slug: &str, model_id: &str) -> Result<(), ConfigError>;
+
+    async fn set_default_model(&self, input: DefaultModelInput) -> Result<DefaultModelRecord, ConfigError>;
+    async fn get_default_model(&self) -> Result<Option<DefaultModelRecord>, ConfigError>;
+    async fn clear_default_model(&self) -> Result<(), ConfigError>;
+
+    async fn set_mcp_server(&self, input: McpServerConfigInput) -> Result<McpServerConfigRecord, ConfigError>;
+    async fn get_mcp_server(&self, id: &str) -> Result<Option<McpServerConfigRecord>, ConfigError>;
+    async fn list_mcp_servers(&self) -> Result<Vec<McpServerConfigRecord>, ConfigError>;
+    async fn remove_mcp_server(&self, id: &str) -> Result<(), ConfigError>;
+
+    async fn set_skill_settings(&self, input: SkillSettingsInput) -> Result<SkillSettingsRecord, ConfigError>;
+    async fn get_skill_settings(&self) -> Result<SkillSettingsRecord, ConfigError>;
+
+    async fn load_runtime_settings(&self) -> Result<RuntimeSettingsSnapshot, ConfigError>;
+}
+```
+
+All methods should return `Result<T, ConfigError>`. Read-by-ID methods should return `Ok(None)` for missing optional records. Singleton reads may return a default record where the domain has clear defaults, such as skill settings defaulting to untrusted project skills and an empty additional directory list.
+
+## Runtime Settings Types
+
+Provider runtime config should include only non-secret, user/runtime fields:
+
+- `provider_slug: String`
+- `display_name: String`, copied from provider metadata when created or refreshed
+- `enabled: bool`
+- `base_url: Option<String>`
+- store-maintained timestamps
+
+Provider runtime config must not contain API keys, OAuth tokens, or auth mode. Provider credentials remain in the credential APIs and encrypted store.
+
+Custom model config should be keyed by `(provider_slug, model_id)` and include display/capability/cost metadata needed for runtime selection:
+
+- `provider_slug: String`
+- `model_id: String`
+- `display_name: String`
+- `context_window: Option<u32>`
+- `output_limit: Option<u32>`
+- `supports_tool_calls: bool`
+- `supports_reasoning: bool`
+- `supports_vision: bool`
+- `cost_input_per_million: Option<f64>`
+- `cost_output_per_million: Option<f64>`
+- store-maintained timestamps
+
+Default model config should be a typed singleton with:
+
+- `provider_slug: String`
+- `model_id: String`
+- store-maintained updated timestamp
+
+MCP server config should align with the runtime server shape and add durable fields needed by the app:
+
+- `id: String`
+- `label: String`
+- `description: Option<String>`
+- `transport: Stdio | Http | HttpSse`
+- stdio: `command`, `args`, `env`, `inherited_env_vars`
+- http/http_sse: `url`, `headers`
+- `working_dir: Option<PathBuf>`
+- `enabled_by_default: bool`
+- store-maintained timestamps
+
+Skill settings should include:
+
+- `trust_project_skills: bool`
+- `additional_skill_dirs: Vec<PathBuf>`
+- store-maintained updated timestamp
+
+## Runtime Settings Snapshot
+
+Fine-grained CRUD APIs are useful for settings UIs. Runtime startup and headless consumers need a single read path that applies consistent interpretation and validation. `load_runtime_settings()` should return a `RuntimeSettingsSnapshot` containing provider configs, custom models, default model selection, MCP server definitions, and skill settings.
+
+The snapshot loader should validate core-owned invariants such as non-empty IDs/slugs, unique MCP server IDs, valid transport-specific field combinations, valid skill directory values, and default model shape. It should not require every built-in provider to have a persisted provider row because built-in provider metadata may come from `iron-providers`. Validation of whether a default model exists may consider built-in metadata plus persisted custom models where available.
+
+The snapshot may provide helper methods to project durable settings into runtime `Config`, `McpServerConfig`, and `SkillConfig` inputs, but it should not replace existing runtime configuration APIs.
+
+## SQLite Schema
+
+Add a compiled-in migration v2. Keep the IC-1 v1 tables untouched.
+
+Recommended table layout:
+
+```sql
+provider_configs (
+  provider_slug TEXT PRIMARY KEY,
+  display_name TEXT NOT NULL,
+  enabled INTEGER NOT NULL,
+  base_url TEXT NULL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+)
+
+custom_models (
+  provider_slug TEXT NOT NULL,
+  model_id TEXT NOT NULL,
+  display_name TEXT NOT NULL,
+  context_window INTEGER NULL,
+  output_limit INTEGER NULL,
+  supports_tool_calls INTEGER NOT NULL DEFAULT 0,
+  supports_reasoning INTEGER NOT NULL DEFAULT 0,
+  supports_vision INTEGER NOT NULL DEFAULT 0,
+  cost_input_per_million REAL NULL,
+  cost_output_per_million REAL NULL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  PRIMARY KEY (provider_slug, model_id)
+)
+
+runtime_defaults (
+  id INTEGER PRIMARY KEY CHECK (id = 1),
+  provider_slug TEXT NOT NULL,
+  model_id TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+)
+
+mcp_servers (
+  id TEXT PRIMARY KEY,
+  label TEXT NOT NULL,
+  description TEXT NULL,
+  transport_kind TEXT NOT NULL,
+  command TEXT NULL,
+  args_json TEXT NULL,
+  env_json TEXT NULL,
+  inherited_env_vars_json TEXT NULL,
+  url TEXT NULL,
+  headers_json TEXT NULL,
+  working_dir TEXT NULL,
+  enabled_by_default INTEGER NOT NULL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+)
+
+skill_settings (
+  id INTEGER PRIMARY KEY CHECK (id = 1),
+  trust_project_skills INTEGER NOT NULL,
+  additional_skill_dirs_json TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+)
+```
+
+Do not add a SQL foreign key from `runtime_defaults.provider_slug` to `provider_configs` yet. Built-in providers may exist in `iron-providers` without a persisted provider row, and Rust-level validation can reconcile built-in provider metadata plus custom model rows more accurately than SQLite foreign keys can.
+
+Use JSON columns for MCP arrays/maps and skill directory lists to avoid over-normalizing settings that are naturally read/written as whole records. Validate these JSON payloads at the API boundary.
+
+## MCP Environment Handling
+
+Stdio MCP servers should continue to start with the sanitized parent environment: non-sensitive parent vars are inherited, sensitive vars are stripped by pattern/name, and stripped names may be logged without values.
+
+`inherited_env_vars` adds a second, explicit parent-env layer. For each configured name, if the parent process contains that variable, the runtime should copy the parent value into the subprocess environment even if the name matches a sensitive pattern. This lets users pass credentials from their shell or service manager without storing the secret in `ConfigStore`.
+
+Merge precedence for stdio subprocess env should be:
+
+1. sanitized parent environment
+2. explicit inherited parent values named by `inherited_env_vars`
+3. configured `env` map values
+
+Configured `env` values win if the same variable appears in both `inherited_env_vars` and `env`.
+
+## Validation
+
+Validation should happen at the core API boundary before records are persisted and again where needed during snapshot loading.
+
+Validation rules should include:
+
+- provider slug, model ID, MCP server ID, MCP label, and stdio command are non-empty after trimming
+- model numeric fields are positive when present
+- cost fields are non-negative when present
+- provider config has no credential fields
+- default model stores provider/model as separate fields
+- MCP transport kind has the required fields for its transport and rejects irrelevant field combinations where practical
+- MCP `args`, `env`, `headers`, and `inherited_env_vars` deserialize to the expected collection types
+- `inherited_env_vars` entries are names only, not `KEY=value` strings
+- skill directory entries are non-empty paths
+
+## Testing Strategy
+
+Tests should cover:
+
+- migration from v1 to v2 and opening an already-current v2 database
+- in-memory store applying v2 migrations
+- provider config CRUD and credential-field exclusion
+- custom model CRUD, list by provider, and `(provider_slug, model_id)` uniqueness
+- default model set/get/clear round-trips using typed provider/model fields
+- MCP server CRUD for stdio, HTTP, and HTTP+SSE transports
+- `inherited_env_vars` persistence and validation as names only
+- skill settings defaults and round-trips
+- runtime settings snapshot missing/default behavior
+- snapshot validation for invalid default model, duplicate/invalid MCP definitions, and malformed persisted JSON where reachable
+- confirmation that provider credentials are still read/written through credential APIs rather than provider config APIs
+
+## Follow-Up Work
+
+AgentIron/AgentIron#56 should migrate the desktop app from direct settings-table SQL to these typed `iron-core` APIs. That migration should move custom models into `iron-core`, leave starred models in AgentIron, and migrate provider API keys to the existing credential APIs rather than provider config JSON.

--- a/openspec/changes/archive/2026-06-09-add-runtime-settings-config-store-apis/proposal.md
+++ b/openspec/changes/archive/2026-06-09-add-runtime-settings-config-store-apis/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+AgentIron/iron-core#67 extends the IC-1 config-store foundation so runtime setup can be shared by the AgentIron desktop app and headless/CLI consumers. Today the desktop app persists provider configuration, default model selection, custom models, MCP server definitions, and skill settings in an app-owned settings table. That blocks shared runtime setup because headless workflows cannot read the same settings through typed `iron-core` APIs.
+
+This change makes `ConfigStore` the owner of shared runtime settings while preserving the existing boundary that provider credentials are stored through the encrypted credential API, not in provider config JSON. App-only preferences such as starred models remain owned by AgentIron.
+
+## What Changes
+
+- Add typed `ConfigStore` APIs for provider runtime configuration: provider slug, metadata display name, enabled flag, and optional base URL.
+- Keep provider credentials out of provider runtime configuration; credentials remain in the existing encrypted credentials API/store.
+- Add typed `ConfigStore` APIs for custom model records because custom models are needed for core provider/model selection in app and headless flows.
+- Add a typed default model selection record using `provider_slug` and `model_id` rather than app-specific encoded strings.
+- Add typed `ConfigStore` APIs for durable MCP server definitions, including stdio/http/http_sse transports, enabled-by-default behavior, optional description, working directory, env/header maps, and `inherited_env_vars` names.
+- Add typed `ConfigStore` APIs for skill settings: `trust_project_skills` and `additional_skill_dirs`.
+- Add a runtime settings snapshot read API that loads and validates the effective provider/default-model/custom-model/MCP/skill settings needed to start a runtime.
+- Add migration v2 for the runtime-settings tables while preserving the existing IC-1 schema and compiled-in migration strategy.
+- Update MCP stdio environment behavior so selected sensitive parent env vars can be reintroduced by name through `inherited_env_vars`, with explicit configured env values taking final precedence.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `core-config-store`: Adds typed runtime settings APIs and schema ownership for provider config, custom models, default model selection, MCP server definitions, skill settings, and runtime settings snapshots.
+- `session-scoped-mcp-support`: Adds explicit inherited environment variable names to MCP stdio server configuration and defines environment merge precedence.
+
+## Impact
+
+- **Core API**: `iron_core::config::ConfigStore` gains runtime-settings record/input types, CRUD APIs, and a snapshot loader.
+- **Storage**: SQLite migration v2 adds runtime-settings tables. SQLite remains an implementation detail behind `ConfigStore`.
+- **Runtime setup**: AgentIron and headless/CLI consumers can use the same typed core APIs to construct provider/model/MCP/skill runtime configuration.
+- **Credential boundary**: provider credentials remain in the encrypted credential store; provider config stores only non-secret runtime fields.
+- **Model settings boundary**: custom models move to `iron-core`; starred models remain AgentIron-owned UI preference.
+- **MCP secrets**: MCP server config can store raw env/header maps as supplied and can store `inherited_env_vars` names to pass selected parent env values without persisting those secret values.
+- **Compatibility**: existing runtime `Config`, `McpConfig`, `SkillConfig`, and IC-1 profile/prompt/schedule/credential APIs remain available.
+- **Out of scope**: migrating AgentIron app settings data, storing starred models in `iron-core`, provider protocol metadata owned by `iron-providers`, credential migration from existing app JSON, cloud sync, direct frontend SQL access, and user-editable provider display names.

--- a/openspec/changes/archive/2026-06-09-add-runtime-settings-config-store-apis/specs/core-config-store/spec.md
+++ b/openspec/changes/archive/2026-06-09-add-runtime-settings-config-store-apis/specs/core-config-store/spec.md
@@ -1,0 +1,114 @@
+## ADDED Requirements
+
+### Requirement: Config store supports provider runtime configuration
+
+The system SHALL provide typed `ConfigStore` APIs for provider runtime configuration used by app and headless consumers. Provider runtime configuration SHALL include provider slug, display name copied from provider metadata, enabled flag, optional base URL, and store-maintained timestamps. Provider runtime configuration SHALL NOT include API keys, OAuth tokens, credential mode, or provider protocol metadata owned by `iron-providers`.
+
+#### Scenario: Provider config roundtrips
+- **WHEN** a caller stores provider runtime configuration with a provider slug, display name, enabled flag, and optional base URL
+- **THEN** the caller can retrieve the same non-secret provider configuration by provider slug
+- **AND** the returned record includes store-maintained timestamps
+
+#### Scenario: Provider config excludes credentials
+- **WHEN** a caller uses provider runtime configuration APIs
+- **THEN** the API does not accept or return provider API keys, OAuth tokens, credential mode, or decrypted credential payloads
+- **AND** provider credentials remain accessible only through the credential APIs/store
+
+#### Scenario: Provider display name is copied metadata
+- **WHEN** provider runtime configuration is stored
+- **THEN** the display name represents provider metadata copied into the config record
+- **AND** the config API does not define user-editable provider naming semantics
+
+### Requirement: Config store supports custom model records
+
+The system SHALL provide typed `ConfigStore` APIs for custom model records because custom models are shared runtime configuration required by app and headless provider/model selection. Custom model records SHALL be keyed by provider slug and model ID and SHALL include display, context window, output limit, capability, cost, and store-maintained timestamp metadata.
+
+#### Scenario: Custom model roundtrips
+- **WHEN** a caller stores a custom model for a provider slug and model ID
+- **THEN** the caller can retrieve the custom model by the same provider slug and model ID
+- **AND** model metadata such as display name, context window, output limit, capabilities, and costs roundtrips through typed fields
+
+#### Scenario: Custom models list by provider
+- **WHEN** a caller lists custom models for a provider slug
+- **THEN** the system returns only custom models associated with that provider slug
+
+#### Scenario: Starred models remain outside core config
+- **WHEN** a caller needs app-specific starred model preferences
+- **THEN** those preferences are not represented by the core custom model APIs
+- **AND** the app remains responsible for starred model persistence
+
+### Requirement: Config store supports typed default model selection
+
+The system SHALL provide typed `ConfigStore` APIs for the default model selection. The default model SHALL be stored as separate `provider_slug` and `model_id` fields rather than an app-specific encoded provider/model string.
+
+#### Scenario: Default model roundtrips
+- **WHEN** a caller stores a default model with provider slug `openai` and model ID `gpt-4o`
+- **THEN** the caller can retrieve provider slug `openai` and model ID `gpt-4o` as separate typed fields
+
+#### Scenario: Default model is absent
+- **WHEN** no default model has been stored
+- **THEN** the default model read API returns an explicit missing/default result according to its method contract
+- **AND** callers do not need to parse a missing app-specific encoded string
+
+### Requirement: Config store supports durable MCP server definitions
+
+The system SHALL provide typed `ConfigStore` APIs for durable MCP server definitions used to initialize runtime MCP inventory. MCP server records SHALL support stable ID, label, optional description, transport type, transport-specific fields for stdio/HTTP/HTTP+SSE, optional working directory, enabled-by-default flag, configured env/header maps, explicit `inherited_env_vars` names for stdio transports, and store-maintained timestamps.
+
+#### Scenario: Stdio MCP server roundtrips
+- **WHEN** a caller stores a stdio MCP server with command, args, configured env, inherited env var names, working directory, and enabled-by-default state
+- **THEN** the caller can retrieve the same server definition through typed MCP server APIs
+- **AND** `inherited_env_vars` contains environment variable names rather than secret values
+
+#### Scenario: HTTP MCP server roundtrips
+- **WHEN** a caller stores an HTTP or HTTP+SSE MCP server with URL and headers
+- **THEN** the caller can retrieve the same transport kind, URL, headers, and enabled-by-default state through typed MCP server APIs
+
+#### Scenario: Runtime snapshot includes MCP servers
+- **WHEN** a caller loads runtime settings from the config store
+- **THEN** the snapshot includes the durable MCP server definitions needed to initialize runtime-local MCP inventory
+
+### Requirement: Config store supports skill settings
+
+The system SHALL provide typed `ConfigStore` APIs for skill settings used by runtime skill discovery. Skill settings SHALL include `trust_project_skills`, `additional_skill_dirs`, and store-maintained updated timestamp metadata.
+
+#### Scenario: Skill settings roundtrip
+- **WHEN** a caller stores skill settings with project skill trust and additional skill directories
+- **THEN** the caller can retrieve the same settings through typed skill settings APIs
+
+#### Scenario: Missing skill settings use safe defaults
+- **WHEN** no skill settings record exists
+- **THEN** the read API or runtime settings snapshot uses safe defaults
+- **AND** project skills are not trusted by default
+- **AND** additional skill directories default to an empty list
+
+### Requirement: Config store exposes a runtime settings snapshot
+
+The system SHALL provide a `ConfigStore` API that loads a validated runtime settings snapshot containing provider configs, custom models, default model selection, MCP server definitions, and skill settings. The snapshot SHALL centralize cross-record validation and interpretation needed by app and headless runtime startup.
+
+#### Scenario: Headless runtime loads shared settings
+- **WHEN** a headless consumer opens the config store and loads the runtime settings snapshot
+- **THEN** it receives the same shared runtime settings available to the app through typed `iron_core::config` APIs
+- **AND** it does not read SQLite tables or app-owned settings JSON directly
+
+#### Scenario: Snapshot validates cross-record settings
+- **WHEN** persisted runtime settings contain invalid IDs, malformed transport fields, malformed JSON collections, or invalid default model fields
+- **THEN** loading the runtime settings snapshot returns an actionable `ConfigError`
+- **AND** invalid settings are not silently projected into runtime startup
+
+#### Scenario: Snapshot supports missing/default config behavior
+- **WHEN** optional runtime settings have not yet been persisted
+- **THEN** snapshot loading applies documented missing/default behavior instead of requiring callers to know table-level details
+
+### Requirement: Runtime settings schema is migrated on open
+
+The SQLite-backed config store SHALL add compiled-in migrations for provider configs, custom models, runtime defaults, MCP servers, and skill settings. The migration SHALL preserve existing IC-1 profile, prompt, schedule, and credential data.
+
+#### Scenario: Existing v1 config store opens after runtime settings migration
+- **WHEN** a config store database created with the IC-1 schema is opened
+- **THEN** the system applies the runtime-settings migration
+- **AND** existing profile, prompt, schedule, and credential records remain available
+
+#### Scenario: In-memory store includes runtime settings schema
+- **WHEN** an in-memory config store is created for tests or embedders
+- **THEN** the same compiled-in runtime-settings migrations are applied
+- **AND** runtime settings CRUD APIs are available without user configuration files

--- a/openspec/changes/archive/2026-06-09-add-runtime-settings-config-store-apis/specs/session-scoped-mcp-support/spec.md
+++ b/openspec/changes/archive/2026-06-09-add-runtime-settings-config-store-apis/specs/session-scoped-mcp-support/spec.md
@@ -1,0 +1,98 @@
+## MODIFIED Requirements
+
+### Requirement: Runtime supports concrete MCP transport clients
+
+The runtime SHALL provide concrete transport support for configured MCP servers using the declared transport type, including stdio, HTTP, and HTTP+SSE. For stdio transports, the runtime SHALL spawn the subprocess with the parent process environment minus environment variables whose names match sensitive credential patterns, rather than a hardcoded allowlist. The runtime SHALL strip vars matching case-insensitive suffix patterns associated with secrets (`_API_KEY`, `_SECRET`, `_SECRET_KEY`, `_TOKEN`, `_PASSWORD`, `_CREDENTIALS`, `_AUTH_TOKEN`, `_ACCESS_KEY`, `_ACCESS_TOKEN`) and well-known credential var names (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AZURE_CLIENT_SECRET`, `GOOGLE_APPLICATION_CREDENTIALS`, `DATABASE_URL`, `GITHUB_TOKEN`, `GH_TOKEN`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`). The runtime SHALL log the names of stripped vars at debug level without logging their values. Stdio MCP server config MAY include `inherited_env_vars`, a list of parent environment variable names to copy into the subprocess environment after sanitization without persisting the variable values. User-configured env vars from the MCP server config SHALL be merged after inherited env vars and SHALL override any stripped, inherited, or explicitly inherited values. For all MCP transports, the runtime SHALL encode outbound MCP protocol messages using the MCP camelCase wire format and SHALL decode inbound MCP protocol messages using the MCP camelCase wire format. This includes initialize, tool listing, tool calling, and related structured payloads whose wire field names differ from Rust snake_case naming. For MCP bootstrap, the runtime SHALL accept a successful `initialize` response whose JSON-RPC `id` is null or absent only when that response can be correlated unambiguously to the single in-flight bootstrap request. For MCP requests after bootstrap, the runtime SHALL continue to require valid request/response ID correlation and SHALL NOT accept ambiguous id-less responses as successful replies. HTTP and HTTP+SSE transports SHALL use a shared `HttpConfig` struct that carries the server URL and optional custom headers. The runtime SHALL send the `Accept: application/json, text/event-stream` header by default for HTTP and HTTP+SSE transports and SHALL include configured custom headers when present.
+
+#### Scenario: Stdio subprocess inherits non-sensitive parent environment vars
+- **WHEN** a configured MCP server uses stdio transport and the parent process has environment variables that do not match sensitive patterns
+- **THEN** the spawned subprocess inherits those non-sensitive vars
+- **THEN** common toolchain vars like `PATH`, `HOME`, `APPDATA`, `XDG_CONFIG_HOME`, `CARGO_HOME`, `GOPATH`, `NODE_PATH` are available to the subprocess without requiring explicit MCP server config
+
+#### Scenario: Stdio subprocess strips vars matching sensitive suffix patterns
+- **WHEN** the parent process has environment variables whose names end in `_API_KEY`, `_SECRET`, `_TOKEN`, `_PASSWORD`, or similar sensitive suffixes
+- **THEN** those vars are not present in the spawned subprocess environment after the sanitization layer
+- **THEN** the runtime logs the names of stripped vars at debug level
+- **AND** the runtime does not log their values
+
+#### Scenario: Stdio subprocess strips well-known credential vars
+- **WHEN** the parent process has environment variables like `AWS_ACCESS_KEY_ID`, `GITHUB_TOKEN`, `ANTHROPIC_API_KEY`, or other well-known credential names
+- **THEN** those vars are not present in the spawned subprocess environment after the sanitization layer
+
+#### Scenario: Explicit inherited env vars reintroduce selected parent values
+- **WHEN** an MCP stdio server config lists an environment variable name in `inherited_env_vars`
+- **AND** the parent process contains that environment variable
+- **THEN** the subprocess environment includes the parent value for that named variable after sanitization
+- **AND** the config store persists only the variable name, not the variable value
+
+#### Scenario: Explicit inherited env var is absent from parent
+- **WHEN** an MCP stdio server config lists an environment variable name in `inherited_env_vars`
+- **AND** the parent process does not contain that environment variable
+- **THEN** the runtime does not synthesize a value for that variable
+- **AND** MCP startup proceeds unless the server fails because the variable is required by the external command
+
+#### Scenario: User-configured env overrides inherited vars
+- **WHEN** an MCP server config specifies an env var that is also listed in `inherited_env_vars`
+- **THEN** the user-configured value is present in the subprocess environment
+- **AND** the user-configured env map has final precedence
+
+#### Scenario: User-configured env overrides stripped vars
+- **WHEN** an MCP server config specifies an env var that would otherwise be stripped by the sensitive pattern matching
+- **THEN** the user-configured value is present in the subprocess environment
+- **THEN** the user config acts as an explicit override
+
+#### Scenario: Sensitive pattern matching is case-insensitive
+- **WHEN** the parent process has an environment variable whose name matches a sensitive pattern with different casing (e.g., `My_Api_Key` matching `_API_KEY`)
+- **THEN** that var is still stripped by the sanitization layer unless explicitly reintroduced through `inherited_env_vars` or configured env
+
+#### Scenario: Initialize request uses camelCase wire fields
+- **WHEN** the runtime sends an MCP `initialize` request
+- **THEN** the JSON payload uses `protocolVersion` and `clientInfo` field names
+- **THEN** the runtime does not send snake_case field names like `protocol_version` or `client_info`
+
+#### Scenario: Initialize response parses camelCase wire fields
+- **WHEN** an MCP server returns an `initialize` response using `protocolVersion` and `serverInfo`
+- **THEN** the runtime successfully parses the response into its internal protocol structs
+
+#### Scenario: Tool list response parses camelCase pagination and schema fields
+- **WHEN** an MCP server returns a `tools/list` response using camelCase fields such as `nextCursor` and `inputSchema`
+- **THEN** the runtime successfully parses pagination state and tool schemas
+
+#### Scenario: Tool call response parses camelCase error and resource metadata fields
+- **WHEN** an MCP server returns a `tools/call` response using camelCase fields such as `isError` and `mimeType`
+- **THEN** the runtime successfully parses the response content and error state
+
+#### Scenario: SSE transport handles structured event responses
+- **WHEN** a configured MCP server uses the HTTP+SSE transport
+- **THEN** the runtime handles SSE framing explicitly rather than assuming the first data block is always the response payload
+- **THEN** the runtime correlates the server response to the initiating MCP request sufficiently to avoid accepting unrelated stream events as a successful response
+
+#### Scenario: HTTP bootstrap accepts an id-less initialize response in the safe case
+- **WHEN** a configured MCP server using plain HTTP returns a successful `initialize` response with a null or absent `id`
+- **THEN** the runtime accepts that response if it corresponds to the single in-flight bootstrap request
+- **THEN** the runtime marks the server initialized rather than failing with an ID mismatch
+
+#### Scenario: Stdio bootstrap does not drop an id-less initialize response before correlation
+- **WHEN** a configured MCP server using stdio returns a successful `initialize` response with a null or absent `id`
+- **THEN** the runtime does not discard that bootstrap response as a notification before evaluating bootstrap correlation
+- **THEN** the runtime accepts that response if it corresponds to the single in-flight bootstrap request
+
+#### Scenario: HTTP+SSE bootstrap does not drop an id-less initialize response before correlation
+- **WHEN** a configured MCP server using HTTP+SSE returns a successful `initialize` response with a null or absent `id`
+- **THEN** the runtime does not discard that bootstrap response solely because the `id` is missing before evaluating bootstrap correlation
+- **THEN** the runtime accepts that response if it corresponds to the single in-flight bootstrap request
+
+#### Scenario: Ordinary MCP traffic still requires valid response correlation
+- **WHEN** an MCP server returns a response without a usable `id` after bootstrap or while multiple requests could be outstanding
+- **THEN** the runtime does not treat that response as a successful reply to an ordinary request
+- **THEN** the runtime preserves strict request/response correlation semantics for post-bootstrap MCP traffic
+
+#### Scenario: HTTP transport uses HttpConfig for URL and headers
+- **WHEN** a configured MCP server uses the HTTP transport
+- **THEN** the transport reads its URL and optional custom headers from the `HttpConfig` struct
+- **THEN** all requests include the default `Accept` header and any configured custom headers
+
+#### Scenario: SSE transport uses HttpConfig for URL and headers
+- **WHEN** a configured MCP server uses the HTTP+SSE transport
+- **THEN** the transport reads its URL and optional custom headers from the `HttpConfig` struct
+- **THEN** both the SSE bootstrap GET and JSON-RPC POST requests include the default `Accept` header and any configured custom headers

--- a/openspec/changes/archive/2026-06-09-add-runtime-settings-config-store-apis/tasks.md
+++ b/openspec/changes/archive/2026-06-09-add-runtime-settings-config-store-apis/tasks.md
@@ -1,0 +1,70 @@
+## 1. Public Runtime Settings Types
+
+- [x] 1.1 Add public provider runtime config input/record types with provider slug, copied metadata display name, enabled flag, optional base URL, and timestamps.
+- [x] 1.2 Add public custom model input/record types keyed by provider slug and model ID with display, capability, limit, and cost metadata.
+- [x] 1.3 Add public default model input/record types using separate `provider_slug` and `model_id` fields.
+- [x] 1.4 Add public MCP server config input/record types covering stdio, HTTP, HTTP+SSE, optional description, working directory, enabled-by-default, env/header maps, and `inherited_env_vars`.
+- [x] 1.5 Add public skill settings input/record types for `trust_project_skills` and `additional_skill_dirs`.
+- [x] 1.6 Add `RuntimeSettingsSnapshot` type containing provider configs, custom models, default model, MCP servers, and skill settings.
+
+## 2. ConfigStore APIs
+
+- [x] 2.1 Add provider config CRUD/list APIs to `ConfigStore`.
+- [x] 2.2 Add custom model CRUD/list APIs to `ConfigStore`, including list-by-provider support.
+- [x] 2.3 Add default model set/get/clear APIs to `ConfigStore`.
+- [x] 2.4 Add MCP server CRUD/list APIs to `ConfigStore`.
+- [x] 2.5 Add skill settings get/set APIs to `ConfigStore`, including missing-record defaults.
+- [x] 2.6 Add `ConfigStore::load_runtime_settings()` or equivalent snapshot loader.
+- [x] 2.7 Ensure all APIs return `Result<T, ConfigError>` and use `Result<Option<T>, ConfigError>` for optional read-by-ID records.
+
+## 3. Schema and Migrations
+
+- [x] 3.1 Add compiled-in migration v2 for `provider_configs`.
+- [x] 3.2 Add compiled-in migration v2 for `custom_models` with primary key `(provider_slug, model_id)`.
+- [x] 3.3 Add compiled-in migration v2 for singleton `runtime_defaults`.
+- [x] 3.4 Add compiled-in migration v2 for `mcp_servers` using JSON columns for args, env, inherited env vars, and headers.
+- [x] 3.5 Add compiled-in migration v2 for singleton `skill_settings`.
+- [x] 3.6 Update schema version handling so v1 databases migrate to v2 and current v2 databases open without caller-visible changes.
+- [x] 3.7 Keep existing v1 profile, prompt, schedule, and credential tables unchanged.
+
+## 4. Validation and Snapshot Behavior
+
+- [x] 4.1 Validate non-empty provider slugs, model IDs, MCP server IDs, MCP labels, stdio commands, and skill directory paths.
+- [x] 4.2 Validate optional numeric model metadata is positive or non-negative as appropriate.
+- [x] 4.3 Validate provider config cannot contain or expose credential fields.
+- [x] 4.4 Validate MCP transport-specific field combinations before persistence and during snapshot loading.
+- [x] 4.5 Validate `inherited_env_vars` entries are environment variable names, not `KEY=value` pairs.
+- [x] 4.6 Validate default model selection as typed provider/model fields and reconcile persisted custom models where possible.
+- [x] 4.7 Ensure snapshot loading returns clear `ConfigError` values for malformed persisted JSON or invalid runtime settings.
+- [x] 4.8 Ensure snapshot loading applies missing/default behavior for absent skill settings and absent optional runtime settings.
+
+## 5. MCP Inherited Environment Variables
+
+- [x] 5.1 Add `inherited_env_vars` to durable MCP server config records and runtime MCP stdio config as needed.
+- [x] 5.2 Preserve sanitized parent-env behavior for stdio MCP subprocesses.
+- [x] 5.3 Reintroduce parent env values named by `inherited_env_vars` after sanitization, including sensitive names when explicitly requested.
+- [x] 5.4 Apply configured `env` map values after `inherited_env_vars` so explicit config wins on conflicts.
+- [x] 5.5 Ensure logs never include inherited or configured env values.
+
+## 6. Tests
+
+- [x] 6.1 Add migration tests for empty, v1, and current v2 config databases.
+- [x] 6.2 Add provider config persistence round-trip and list/delete tests.
+- [x] 6.3 Add custom model persistence round-trip, list-by-provider, uniqueness, and delete tests.
+- [x] 6.4 Add default model set/get/clear and typed field round-trip tests.
+- [x] 6.5 Add MCP server persistence round-trip tests for stdio, HTTP, and HTTP+SSE.
+- [x] 6.6 Add MCP `inherited_env_vars` validation and stdio env merge precedence tests.
+- [x] 6.7 Add skill settings default and round-trip tests.
+- [x] 6.8 Add runtime settings snapshot tests for complete settings, missing/default settings, and invalid persisted records.
+- [x] 6.9 Add tests proving provider credentials are not persisted or exposed through provider config APIs.
+
+## 7. Documentation and Verification
+
+- [x] 7.1 Document the runtime settings APIs and their distinction from runtime `Config` snapshots.
+- [x] 7.2 Document the provider config credential boundary and point callers to credential APIs.
+- [x] 7.3 Document custom models as core-owned runtime settings and starred models as app-owned preferences.
+- [x] 7.4 Document MCP `inherited_env_vars` behavior and env merge precedence.
+- [x] 7.5 Run focused config store tests.
+- [x] 7.6 Run focused MCP stdio env tests.
+- [x] 7.7 Run `cargo check --manifest-path src-tauri/Cargo.toml` only if this repository contains that manifest for the changed Rust code path; otherwise run the narrowest crate-level Rust check available.
+- [x] 7.8 Run `openspec status --change add-runtime-settings-config-store-apis` or the repo-supported OpenSpec validation command.

--- a/openspec/specs/core-config-store/spec.md
+++ b/openspec/specs/core-config-store/spec.md
@@ -222,3 +222,116 @@ Frontends and apps SHALL use `iron_core::config` APIs for durable AgentIron conf
 #### Scenario: App needs unsupported durable config
 - **WHEN** an app or frontend needs durable AgentIron configuration not yet covered by the core config API
 - **THEN** the missing config domain should be added to `iron-core` rather than creating divergent frontend-owned persistence
+
+### Requirement: Config store supports provider runtime configuration
+
+The system SHALL provide typed `ConfigStore` APIs for provider runtime configuration used by app and headless consumers. Provider runtime configuration SHALL include provider slug, display name copied from provider metadata, enabled flag, optional base URL, and store-maintained timestamps. Provider runtime configuration SHALL NOT include API keys, OAuth tokens, credential mode, or provider protocol metadata owned by `iron-providers`.
+
+#### Scenario: Provider config roundtrips
+- **WHEN** a caller stores provider runtime configuration with a provider slug, display name, enabled flag, and optional base URL
+- **THEN** the caller can retrieve the same non-secret provider configuration by provider slug
+- **AND** the returned record includes store-maintained timestamps
+
+#### Scenario: Provider config excludes credentials
+- **WHEN** a caller uses provider runtime configuration APIs
+- **THEN** the API does not accept or return provider API keys, OAuth tokens, credential mode, or decrypted credential payloads
+- **AND** provider credentials remain accessible only through the credential APIs/store
+
+#### Scenario: Provider display name is copied metadata
+- **WHEN** provider runtime configuration is stored
+- **THEN** the display name represents provider metadata copied into the config record
+- **AND** the config API does not define user-editable provider naming semantics
+
+### Requirement: Config store supports custom model records
+
+The system SHALL provide typed `ConfigStore` APIs for custom model records because custom models are shared runtime configuration required by app and headless provider/model selection. Custom model records SHALL be keyed by provider slug and model ID and SHALL include display, context window, output limit, capability, cost, and store-maintained timestamp metadata.
+
+#### Scenario: Custom model roundtrips
+- **WHEN** a caller stores a custom model for a provider slug and model ID
+- **THEN** the caller can retrieve the custom model by the same provider slug and model ID
+- **AND** model metadata such as display name, context window, output limit, capabilities, and costs roundtrips through typed fields
+
+#### Scenario: Custom models list by provider
+- **WHEN** a caller lists custom models for a provider slug
+- **THEN** the system returns only custom models associated with that provider slug
+
+#### Scenario: Starred models remain outside core config
+- **WHEN** a caller needs app-specific starred model preferences
+- **THEN** those preferences are not represented by the core custom model APIs
+- **AND** the app remains responsible for starred model persistence
+
+### Requirement: Config store supports typed default model selection
+
+The system SHALL provide typed `ConfigStore` APIs for the default model selection. The default model SHALL be stored as separate `provider_slug` and `model_id` fields rather than an app-specific encoded provider/model string.
+
+#### Scenario: Default model roundtrips
+- **WHEN** a caller stores a default model with provider slug `openai` and model ID `gpt-4o`
+- **THEN** the caller can retrieve provider slug `openai` and model ID `gpt-4o` as separate typed fields
+
+#### Scenario: Default model is absent
+- **WHEN** no default model has been stored
+- **THEN** the default model read API returns an explicit missing/default result according to its method contract
+- **AND** callers do not need to parse a missing app-specific encoded string
+
+### Requirement: Config store supports durable MCP server definitions
+
+The system SHALL provide typed `ConfigStore` APIs for durable MCP server definitions used to initialize runtime MCP inventory. MCP server records SHALL support stable ID, label, optional description, transport type, transport-specific fields for stdio/HTTP/HTTP+SSE, optional working directory, enabled-by-default flag, configured env/header maps, explicit `inherited_env_vars` names for stdio transports, and store-maintained timestamps.
+
+#### Scenario: Stdio MCP server roundtrips
+- **WHEN** a caller stores a stdio MCP server with command, args, configured env, inherited env var names, working directory, and enabled-by-default state
+- **THEN** the caller can retrieve the same server definition through typed MCP server APIs
+- **AND** `inherited_env_vars` contains environment variable names rather than secret values
+
+#### Scenario: HTTP MCP server roundtrips
+- **WHEN** a caller stores an HTTP or HTTP+SSE MCP server with URL and headers
+- **THEN** the caller can retrieve the same transport kind, URL, headers, and enabled-by-default state through typed MCP server APIs
+
+#### Scenario: Runtime snapshot includes MCP servers
+- **WHEN** a caller loads runtime settings from the config store
+- **THEN** the snapshot includes the durable MCP server definitions needed to initialize runtime-local MCP inventory
+
+### Requirement: Config store supports skill settings
+
+The system SHALL provide typed `ConfigStore` APIs for skill settings used by runtime skill discovery. Skill settings SHALL include `trust_project_skills`, `additional_skill_dirs`, and store-maintained updated timestamp metadata.
+
+#### Scenario: Skill settings roundtrip
+- **WHEN** a caller stores skill settings with project skill trust and additional skill directories
+- **THEN** the caller can retrieve the same settings through typed skill settings APIs
+
+#### Scenario: Missing skill settings use safe defaults
+- **WHEN** no skill settings record exists
+- **THEN** the read API or runtime settings snapshot uses safe defaults
+- **AND** project skills are not trusted by default
+- **AND** additional skill directories default to an empty list
+
+### Requirement: Config store exposes a runtime settings snapshot
+
+The system SHALL provide a `ConfigStore` API that loads a validated runtime settings snapshot containing provider configs, custom models, default model selection, MCP server definitions, and skill settings. The snapshot SHALL centralize cross-record validation and interpretation needed by app and headless runtime startup.
+
+#### Scenario: Headless runtime loads shared settings
+- **WHEN** a headless consumer opens the config store and loads the runtime settings snapshot
+- **THEN** it receives the same shared runtime settings available to the app through typed `iron_core::config` APIs
+- **AND** it does not read SQLite tables or app-owned settings JSON directly
+
+#### Scenario: Snapshot validates cross-record settings
+- **WHEN** persisted runtime settings contain invalid IDs, malformed transport fields, malformed JSON collections, or invalid default model fields
+- **THEN** loading the runtime settings snapshot returns an actionable `ConfigError`
+- **AND** invalid settings are not silently projected into runtime startup
+
+#### Scenario: Snapshot supports missing/default config behavior
+- **WHEN** optional runtime settings have not yet been persisted
+- **THEN** snapshot loading applies documented missing/default behavior instead of requiring callers to know table-level details
+
+### Requirement: Runtime settings schema is migrated on open
+
+The SQLite-backed config store SHALL add compiled-in migrations for provider configs, custom models, runtime defaults, MCP servers, and skill settings. The migration SHALL preserve existing IC-1 profile, prompt, schedule, and credential data.
+
+#### Scenario: Existing v1 config store opens after runtime settings migration
+- **WHEN** a config store database created with the IC-1 schema is opened
+- **THEN** the system applies the runtime-settings migration
+- **AND** existing profile, prompt, schedule, and credential records remain available
+
+#### Scenario: In-memory store includes runtime settings schema
+- **WHEN** an in-memory config store is created for tests or embedders
+- **THEN** the same compiled-in runtime-settings migrations are applied
+- **AND** runtime settings CRUD APIs are available without user configuration files

--- a/openspec/specs/session-scoped-mcp-support/spec.md
+++ b/openspec/specs/session-scoped-mcp-support/spec.md
@@ -94,7 +94,7 @@ The runtime SHALL execute MCP-backed tool calls through the same validation, app
 - **THEN** the runtime does not request approval solely because the MCP-backed tool definition reports `requires_approval()`
 
 ### Requirement: Runtime supports concrete MCP transport clients
-The runtime SHALL provide concrete transport support for configured MCP servers using the declared transport type, including stdio, HTTP, and HTTP+SSE. For stdio transports, the runtime SHALL spawn the subprocess with the parent process environment minus environment variables whose names match sensitive credential patterns, rather than a hardcoded allowlist. The runtime SHALL strip vars matching case-insensitive suffix patterns associated with secrets (`_API_KEY`, `_SECRET`, `_SECRET_KEY`, `_TOKEN`, `_PASSWORD`, `_CREDENTIALS`, `_AUTH_TOKEN`, `_ACCESS_KEY`, `_ACCESS_TOKEN`) and well-known credential var names (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AZURE_CLIENT_SECRET`, `GOOGLE_APPLICATION_CREDENTIALS`, `DATABASE_URL`, `GITHUB_TOKEN`, `GH_TOKEN`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`). The runtime SHALL log the names of stripped vars at debug level without logging their values. User-configured env vars from the MCP server config SHALL be merged after stripping and SHALL override any stripped or inherited values. For all MCP transports, the runtime SHALL encode outbound MCP protocol messages using the MCP camelCase wire format and SHALL decode inbound MCP protocol messages using the MCP camelCase wire format. This includes initialize, tool listing, tool calling, and related structured payloads whose wire field names differ from Rust snake_case naming. For MCP bootstrap, the runtime SHALL accept a successful `initialize` response whose JSON-RPC `id` is null or absent only when that response can be correlated unambiguously to the single in-flight bootstrap request. For MCP requests after bootstrap, the runtime SHALL continue to require valid request/response ID correlation and SHALL NOT accept ambiguous id-less responses as successful replies. HTTP and HTTP+SSE transports SHALL use a shared `HttpConfig` struct that carries the server URL and optional custom headers. The runtime SHALL send the `Accept: application/json, text/event-stream` header on all HTTP-based MCP requests and merge any configured custom headers.
+The runtime SHALL provide concrete transport support for configured MCP servers using the declared transport type, including stdio, HTTP, and HTTP+SSE. For stdio transports, the runtime SHALL spawn the subprocess with the parent process environment minus environment variables whose names match sensitive credential patterns, rather than a hardcoded allowlist. The runtime SHALL strip vars matching case-insensitive suffix patterns associated with secrets (`_API_KEY`, `_SECRET`, `_SECRET_KEY`, `_TOKEN`, `_PASSWORD`, `_CREDENTIALS`, `_AUTH_TOKEN`, `_ACCESS_KEY`, `_ACCESS_TOKEN`) and well-known credential var names (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AZURE_CLIENT_SECRET`, `GOOGLE_APPLICATION_CREDENTIALS`, `DATABASE_URL`, `GITHUB_TOKEN`, `GH_TOKEN`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`). The runtime SHALL log the names of stripped vars at debug level without logging their values. Stdio MCP server config MAY include `inherited_env_vars`, a list of parent environment variable names to copy into the subprocess environment after sanitization without persisting the variable values. User-configured env vars from the MCP server config SHALL be merged after inherited env vars and SHALL override any stripped, inherited, or explicitly inherited values. For all MCP transports, the runtime SHALL encode outbound MCP protocol messages using the MCP camelCase wire format and SHALL decode inbound MCP protocol messages using the MCP camelCase wire format. This includes initialize, tool listing, tool calling, and related structured payloads whose wire field names differ from Rust snake_case naming. For MCP bootstrap, the runtime SHALL accept a successful `initialize` response whose JSON-RPC `id` is null or absent only when that response can be correlated unambiguously to the single in-flight bootstrap request. For MCP requests after bootstrap, the runtime SHALL continue to require valid request/response ID correlation and SHALL NOT accept ambiguous id-less responses as successful replies. HTTP and HTTP+SSE transports SHALL use a shared `HttpConfig` struct that carries the server URL and optional custom headers. The runtime SHALL send the `Accept: application/json, text/event-stream` header on all HTTP-based MCP requests and merge any configured custom headers.
 
 #### Scenario: Stdio subprocess inherits non-sensitive parent environment vars
 - **WHEN** a configured MCP server uses stdio transport and the parent process has environment variables that do not match sensitive patterns
@@ -103,12 +103,30 @@ The runtime SHALL provide concrete transport support for configured MCP servers 
 
 #### Scenario: Stdio subprocess strips vars matching sensitive suffix patterns
 - **WHEN** the parent process has environment variables whose names end in `_API_KEY`, `_SECRET`, `_TOKEN`, `_PASSWORD`, or similar sensitive suffixes
-- **THEN** those vars are not present in the spawned subprocess environment
+- **THEN** those vars are not present in the spawned subprocess environment after the sanitization layer
 - **THEN** the runtime logs the names of stripped vars at debug level
+- **AND** the runtime does not log their values
 
 #### Scenario: Stdio subprocess strips well-known credential vars
 - **WHEN** the parent process has environment variables like `AWS_ACCESS_KEY_ID`, `GITHUB_TOKEN`, `ANTHROPIC_API_KEY`, or other well-known credential names
-- **THEN** those vars are not present in the spawned subprocess environment
+- **THEN** those vars are not present in the spawned subprocess environment after the sanitization layer
+
+#### Scenario: Explicit inherited env vars reintroduce selected parent values
+- **WHEN** an MCP stdio server config lists an environment variable name in `inherited_env_vars`
+- **AND** the parent process contains that environment variable
+- **THEN** the subprocess environment includes the parent value for that named variable after sanitization
+- **AND** the config store persists only the variable name, not the variable value
+
+#### Scenario: Explicit inherited env var is absent from parent
+- **WHEN** an MCP stdio server config lists an environment variable name in `inherited_env_vars`
+- **AND** the parent process does not contain that environment variable
+- **THEN** the runtime does not synthesize a value for that variable
+- **AND** MCP startup proceeds unless the server fails because the variable is required by the external command
+
+#### Scenario: User-configured env overrides inherited vars
+- **WHEN** an MCP server config specifies an env var that is also listed in `inherited_env_vars`
+- **THEN** the user-configured value is present in the subprocess environment
+- **AND** the user-configured env map has final precedence
 
 #### Scenario: User-configured env overrides stripped vars
 - **WHEN** an MCP server config specifies an env var that would otherwise be stripped by the sensitive pattern matching
@@ -117,7 +135,7 @@ The runtime SHALL provide concrete transport support for configured MCP servers 
 
 #### Scenario: Sensitive pattern matching is case-insensitive
 - **WHEN** the parent process has an environment variable whose name matches a sensitive pattern with different casing (e.g., `My_Api_Key` matching `_API_KEY`)
-- **THEN** that var is still stripped
+- **THEN** that var is still stripped by the sanitization layer unless explicitly reintroduced through `inherited_env_vars` or configured env
 
 #### Scenario: Initialize request uses camelCase wire fields
 - **WHEN** the runtime sends an MCP `initialize` request

--- a/src/config/migrations.rs
+++ b/src/config/migrations.rs
@@ -1,55 +1,119 @@
 /// Embedded migration SQL for the config store schema.
 ///
 /// Migrations are applied in order. Each migration is idempotent where possible.
-pub const MIGRATIONS: &[(i64, &str)] = &[(
-    1,
-    r#"
-        CREATE TABLE IF NOT EXISTS schema_version (
-            id INTEGER PRIMARY KEY CHECK (id = 1),
-            version INTEGER NOT NULL
-        );
+pub const MIGRATIONS: &[(i64, &str)] = &[
+    (
+        1,
+        r#"
+            CREATE TABLE IF NOT EXISTS schema_version (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                version INTEGER NOT NULL
+            );
 
-        CREATE TABLE IF NOT EXISTS profiles (
-            id TEXT PRIMARY KEY,
-            schema_version INTEGER NOT NULL,
-            payload TEXT NOT NULL,
-            created_at TEXT NOT NULL,
-            updated_at TEXT NOT NULL
-        );
+            CREATE TABLE IF NOT EXISTS profiles (
+                id TEXT PRIMARY KEY,
+                schema_version INTEGER NOT NULL,
+                payload TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
 
-        CREATE TABLE IF NOT EXISTS prompts (
-            id TEXT PRIMARY KEY,
-            schema_version INTEGER NOT NULL,
-            payload TEXT NOT NULL,
-            created_at TEXT NOT NULL,
-            updated_at TEXT NOT NULL
-        );
+            CREATE TABLE IF NOT EXISTS prompts (
+                id TEXT PRIMARY KEY,
+                schema_version INTEGER NOT NULL,
+                payload TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
 
-        CREATE TABLE IF NOT EXISTS schedule (
-            id TEXT PRIMARY KEY,
-            schema_version INTEGER NOT NULL,
-            payload TEXT NOT NULL,
-            created_at TEXT NOT NULL,
-            updated_at TEXT NOT NULL
-        );
+            CREATE TABLE IF NOT EXISTS schedule (
+                id TEXT PRIMARY KEY,
+                schema_version INTEGER NOT NULL,
+                payload TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
 
-        CREATE TABLE IF NOT EXISTS credentials (
-            provider_slug TEXT PRIMARY KEY,
-            credential_mode TEXT NOT NULL,
-            encrypted_payload BLOB NOT NULL,
-            nonce BLOB NOT NULL,
-            encryption_metadata TEXT NOT NULL,
-            created_at TEXT NOT NULL,
-            updated_at TEXT NOT NULL
-        );
+            CREATE TABLE IF NOT EXISTS credentials (
+                provider_slug TEXT PRIMARY KEY,
+                credential_mode TEXT NOT NULL,
+                encrypted_payload BLOB NOT NULL,
+                nonce BLOB NOT NULL,
+                encryption_metadata TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
 
-        INSERT OR IGNORE INTO schema_version (id, version) VALUES (1, 1);
-        "#,
-)];
+            INSERT OR IGNORE INTO schema_version (id, version) VALUES (1, 1);
+            "#,
+    ),
+    (
+        2,
+        r#"
+            CREATE TABLE IF NOT EXISTS provider_configs (
+                provider_slug TEXT PRIMARY KEY,
+                display_name TEXT NOT NULL,
+                enabled INTEGER NOT NULL,
+                base_url TEXT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS custom_models (
+                provider_slug TEXT NOT NULL,
+                model_id TEXT NOT NULL,
+                display_name TEXT NOT NULL,
+                context_window INTEGER NULL,
+                output_limit INTEGER NULL,
+                supports_tool_calls INTEGER NOT NULL DEFAULT 0,
+                supports_reasoning INTEGER NOT NULL DEFAULT 0,
+                supports_vision INTEGER NOT NULL DEFAULT 0,
+                cost_input_per_million REAL NULL,
+                cost_output_per_million REAL NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                PRIMARY KEY (provider_slug, model_id)
+            );
+
+            CREATE TABLE IF NOT EXISTS runtime_defaults (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                provider_slug TEXT NOT NULL,
+                model_id TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS mcp_servers (
+                id TEXT PRIMARY KEY,
+                label TEXT NOT NULL,
+                description TEXT NULL,
+                transport_kind TEXT NOT NULL,
+                command TEXT NULL,
+                args_json TEXT NULL,
+                env_json TEXT NULL,
+                inherited_env_vars_json TEXT NULL,
+                url TEXT NULL,
+                headers_json TEXT NULL,
+                working_dir TEXT NULL,
+                enabled_by_default INTEGER NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS skill_settings (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                trust_project_skills INTEGER NOT NULL,
+                additional_skill_dirs_json TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+
+            INSERT OR IGNORE INTO schema_version (id, version) VALUES (1, 2);
+            "#,
+    ),
+];
 
 /// The current schema version.
 #[allow(dead_code)]
-pub const CURRENT_SCHEMA_VERSION: i64 = 1;
+pub const CURRENT_SCHEMA_VERSION: i64 = 2;
 
 /// Apply all pending migrations to the database.
 pub async fn apply_migrations(pool: &sqlx::SqlitePool) -> Result<(), super::error::ConfigError> {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -9,9 +9,16 @@
 //!    construction time.
 //!
 //! 2. **Durable configuration store** ([`ConfigStore`]) — a SQLite-backed
-//!    persistent store for profiles, prompts, schedule entries, and encrypted
-//!    provider credentials. The store is designed for desktop application use
-//!    and manages its own schema migrations.
+//!    persistent store for profiles, prompts, schedule entries, encrypted
+//!    provider credentials, and shared runtime settings. The store is designed
+//!    for desktop application use and manages its own schema migrations.
+//!
+//!    Runtime settings include provider configuration (without credentials),
+//!    custom models, default model selection, MCP server definitions, and
+//!    skill settings. These are shared between the AgentIron desktop app and
+//!    headless/CLI consumers through typed APIs rather than direct SQLite
+//!    access. Provider credentials remain in the encrypted credential store
+//!    and are not stored in provider runtime configuration.
 //!
 //! ## Platform-default paths
 //!
@@ -571,7 +578,9 @@ mod migrations;
 
 pub use error::ConfigError;
 pub use records::{
-    CredentialRecord, ProfileInput, ProfileRecord, PromptInput, PromptRecord, ScheduleInput,
-    ScheduleRecord,
+    CredentialRecord, CustomModelInput, CustomModelRecord, DefaultModelInput, DefaultModelRecord,
+    McpServerConfigInput, McpServerConfigRecord, ProfileInput, ProfileRecord, PromptInput,
+    PromptRecord, ProviderConfigInput, ProviderConfigRecord, RuntimeSettingsSnapshot,
+    ScheduleInput, ScheduleRecord, SkillSettingsInput, SkillSettingsRecord,
 };
 pub use store::{default_config_path, ConfigStore, OpenOptions};

--- a/src/config/records.rs
+++ b/src/config/records.rs
@@ -1,5 +1,6 @@
 use chrono::{DateTime, Utc};
 use serde_json::Value;
+use std::path::PathBuf;
 
 /// A stored profile record.
 #[derive(Debug, Clone)]
@@ -62,4 +63,126 @@ pub struct CredentialRecord {
     pub credential_mode: String,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+}
+
+// ============================================================================
+// Runtime Settings Records (Issue #67)
+// ============================================================================
+
+/// A stored provider runtime configuration record.
+#[derive(Debug, Clone)]
+pub struct ProviderConfigRecord {
+    pub provider_slug: String,
+    pub display_name: String,
+    pub enabled: bool,
+    pub base_url: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Input for creating or updating a provider runtime configuration.
+#[derive(Debug, Clone)]
+pub struct ProviderConfigInput {
+    pub provider_slug: String,
+    pub display_name: String,
+    pub enabled: bool,
+    pub base_url: Option<String>,
+}
+
+/// A stored custom model record.
+#[derive(Debug, Clone)]
+pub struct CustomModelRecord {
+    pub provider_slug: String,
+    pub model_id: String,
+    pub display_name: String,
+    pub context_window: Option<u32>,
+    pub output_limit: Option<u32>,
+    pub supports_tool_calls: bool,
+    pub supports_reasoning: bool,
+    pub supports_vision: bool,
+    pub cost_input_per_million: Option<f64>,
+    pub cost_output_per_million: Option<f64>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Input for creating or updating a custom model.
+#[derive(Debug, Clone)]
+pub struct CustomModelInput {
+    pub provider_slug: String,
+    pub model_id: String,
+    pub display_name: String,
+    pub context_window: Option<u32>,
+    pub output_limit: Option<u32>,
+    pub supports_tool_calls: bool,
+    pub supports_reasoning: bool,
+    pub supports_vision: bool,
+    pub cost_input_per_million: Option<f64>,
+    pub cost_output_per_million: Option<f64>,
+}
+
+/// A stored default model selection record.
+#[derive(Debug, Clone)]
+pub struct DefaultModelRecord {
+    pub provider_slug: String,
+    pub model_id: String,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Input for setting the default model.
+#[derive(Debug, Clone)]
+pub struct DefaultModelInput {
+    pub provider_slug: String,
+    pub model_id: String,
+}
+
+/// A stored MCP server configuration record.
+#[derive(Debug, Clone)]
+pub struct McpServerConfigRecord {
+    pub id: String,
+    pub label: String,
+    pub description: Option<String>,
+    pub transport: crate::mcp::server::McpTransport,
+    pub working_dir: Option<PathBuf>,
+    pub enabled_by_default: bool,
+    pub inherited_env_vars: Vec<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Input for creating or updating an MCP server configuration.
+#[derive(Debug, Clone)]
+pub struct McpServerConfigInput {
+    pub id: String,
+    pub label: String,
+    pub description: Option<String>,
+    pub transport: crate::mcp::server::McpTransport,
+    pub working_dir: Option<PathBuf>,
+    pub enabled_by_default: bool,
+    pub inherited_env_vars: Vec<String>,
+}
+
+/// A stored skill settings record.
+#[derive(Debug, Clone)]
+pub struct SkillSettingsRecord {
+    pub trust_project_skills: bool,
+    pub additional_skill_dirs: Vec<PathBuf>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Input for setting skill settings.
+#[derive(Debug, Clone)]
+pub struct SkillSettingsInput {
+    pub trust_project_skills: bool,
+    pub additional_skill_dirs: Vec<PathBuf>,
+}
+
+/// Validated runtime settings snapshot loaded from the config store.
+#[derive(Debug, Clone)]
+pub struct RuntimeSettingsSnapshot {
+    pub provider_configs: Vec<ProviderConfigRecord>,
+    pub custom_models: Vec<CustomModelRecord>,
+    pub default_model: Option<DefaultModelRecord>,
+    pub mcp_servers: Vec<McpServerConfigRecord>,
+    pub skill_settings: SkillSettingsRecord,
 }

--- a/src/config/store.rs
+++ b/src/config/store.rs
@@ -6,9 +6,10 @@ use super::{
     migrations,
     records::*,
 };
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use sqlx::{Row, SqlitePool};
-use std::path::Path;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -533,6 +534,843 @@ impl ConfigStore {
             .acquire()
             .await
             .map_err(|e| ConfigError::Query(e.to_string()))
+    }
+
+    // ============================================================================
+    // Provider Config APIs
+    // ============================================================================
+
+    /// Store or replace a provider runtime configuration.
+    pub async fn set_provider_config(
+        &self,
+        input: &ProviderConfigInput,
+    ) -> Result<ProviderConfigRecord, ConfigError> {
+        if input.provider_slug.trim().is_empty() {
+            return Err(ConfigError::Validation(
+                "Provider slug must not be empty".to_string(),
+            ));
+        }
+        if input.display_name.trim().is_empty() {
+            return Err(ConfigError::Validation(
+                "Provider display name must not be empty".to_string(),
+            ));
+        }
+        let now = Utc::now().to_rfc3339();
+        sqlx::query(
+            r#"
+            INSERT INTO provider_configs (provider_slug, display_name, enabled, base_url, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+            ON CONFLICT(provider_slug) DO UPDATE SET
+                display_name = excluded.display_name,
+                enabled = excluded.enabled,
+                base_url = excluded.base_url,
+                updated_at = excluded.updated_at
+            "#,
+        )
+        .bind(&input.provider_slug)
+        .bind(&input.display_name)
+        .bind(input.enabled)
+        .bind(&input.base_url)
+        .bind(&now)
+        .bind(&now)
+        .execute(&self.pool)
+        .await
+        .map_err(ConfigError::from)?;
+
+        Ok(ProviderConfigRecord {
+            provider_slug: input.provider_slug.clone(),
+            display_name: input.display_name.clone(),
+            enabled: input.enabled,
+            base_url: input.base_url.clone(),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        })
+    }
+
+    /// Get a provider runtime configuration by slug.
+    pub async fn get_provider_config(
+        &self,
+        provider_slug: &str,
+    ) -> Result<Option<ProviderConfigRecord>, ConfigError> {
+        let row = sqlx::query(
+            "SELECT provider_slug, display_name, enabled, base_url, created_at, updated_at FROM provider_configs WHERE provider_slug = ?",
+        )
+        .bind(provider_slug)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(ConfigError::from)?;
+
+        match row {
+            Some(row) => Ok(Some(ProviderConfigRecord {
+                provider_slug: row.get("provider_slug"),
+                display_name: row.get("display_name"),
+                enabled: row.get::<i64, _>("enabled") != 0,
+                base_url: row.get("base_url"),
+                created_at: parse_datetime(row.get::<String, _>("created_at"))?,
+                updated_at: parse_datetime(row.get::<String, _>("updated_at"))?,
+            })),
+            None => Ok(None),
+        }
+    }
+
+    /// List all provider runtime configurations.
+    pub async fn list_provider_configs(&self) -> Result<Vec<ProviderConfigRecord>, ConfigError> {
+        let rows = sqlx::query(
+            "SELECT provider_slug, display_name, enabled, base_url, created_at, updated_at FROM provider_configs ORDER BY updated_at DESC",
+        )
+        .fetch_all(&self.pool)
+        .await
+        .map_err(ConfigError::from)?;
+
+        rows.into_iter()
+            .map(|row| {
+                Ok(ProviderConfigRecord {
+                    provider_slug: row.get("provider_slug"),
+                    display_name: row.get("display_name"),
+                    enabled: row.get::<i64, _>("enabled") != 0,
+                    base_url: row.get("base_url"),
+                    created_at: parse_datetime(row.get::<String, _>("created_at"))?,
+                    updated_at: parse_datetime(row.get::<String, _>("updated_at"))?,
+                })
+            })
+            .collect()
+    }
+
+    /// Remove a provider runtime configuration by slug.
+    pub async fn remove_provider_config(&self, provider_slug: &str) -> Result<(), ConfigError> {
+        sqlx::query("DELETE FROM provider_configs WHERE provider_slug = ?")
+            .bind(provider_slug)
+            .execute(&self.pool)
+            .await
+            .map_err(ConfigError::from)?;
+        Ok(())
+    }
+
+    // ============================================================================
+    // Custom Model APIs
+    // ============================================================================
+
+    /// Store or replace a custom model record.
+    pub async fn set_custom_model(
+        &self,
+        input: &CustomModelInput,
+    ) -> Result<CustomModelRecord, ConfigError> {
+        if input.provider_slug.trim().is_empty() {
+            return Err(ConfigError::Validation(
+                "Provider slug must not be empty".to_string(),
+            ));
+        }
+        if input.model_id.trim().is_empty() {
+            return Err(ConfigError::Validation(
+                "Model ID must not be empty".to_string(),
+            ));
+        }
+        if input.display_name.trim().is_empty() {
+            return Err(ConfigError::Validation(
+                "Display name must not be empty".to_string(),
+            ));
+        }
+        if matches!(input.context_window, Some(0)) {
+            return Err(ConfigError::Validation(
+                "Context window must be greater than 0 when set".to_string(),
+            ));
+        }
+        if matches!(input.output_limit, Some(0)) {
+            return Err(ConfigError::Validation(
+                "Output limit must be greater than 0 when set".to_string(),
+            ));
+        }
+        validate_optional_non_negative_f64(input.cost_input_per_million, "Input cost per million")?;
+        validate_optional_non_negative_f64(
+            input.cost_output_per_million,
+            "Output cost per million",
+        )?;
+        let now = Utc::now().to_rfc3339();
+        sqlx::query(
+            r#"
+            INSERT INTO custom_models (provider_slug, model_id, display_name, context_window, output_limit, supports_tool_calls, supports_reasoning, supports_vision, cost_input_per_million, cost_output_per_million, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(provider_slug, model_id) DO UPDATE SET
+                display_name = excluded.display_name,
+                context_window = excluded.context_window,
+                output_limit = excluded.output_limit,
+                supports_tool_calls = excluded.supports_tool_calls,
+                supports_reasoning = excluded.supports_reasoning,
+                supports_vision = excluded.supports_vision,
+                cost_input_per_million = excluded.cost_input_per_million,
+                cost_output_per_million = excluded.cost_output_per_million,
+                updated_at = excluded.updated_at
+            "#,
+        )
+        .bind(&input.provider_slug)
+        .bind(&input.model_id)
+        .bind(&input.display_name)
+        .bind(input.context_window.map(|v| v as i64))
+        .bind(input.output_limit.map(|v| v as i64))
+        .bind(input.supports_tool_calls)
+        .bind(input.supports_reasoning)
+        .bind(input.supports_vision)
+        .bind(input.cost_input_per_million)
+        .bind(input.cost_output_per_million)
+        .bind(&now)
+        .bind(&now)
+        .execute(&self.pool)
+        .await
+        .map_err(ConfigError::from)?;
+
+        Ok(CustomModelRecord {
+            provider_slug: input.provider_slug.clone(),
+            model_id: input.model_id.clone(),
+            display_name: input.display_name.clone(),
+            context_window: input.context_window,
+            output_limit: input.output_limit,
+            supports_tool_calls: input.supports_tool_calls,
+            supports_reasoning: input.supports_reasoning,
+            supports_vision: input.supports_vision,
+            cost_input_per_million: input.cost_input_per_million,
+            cost_output_per_million: input.cost_output_per_million,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        })
+    }
+
+    /// Get a custom model by provider slug and model ID.
+    pub async fn get_custom_model(
+        &self,
+        provider_slug: &str,
+        model_id: &str,
+    ) -> Result<Option<CustomModelRecord>, ConfigError> {
+        let row = sqlx::query(
+            "SELECT provider_slug, model_id, display_name, context_window, output_limit, supports_tool_calls, supports_reasoning, supports_vision, cost_input_per_million, cost_output_per_million, created_at, updated_at FROM custom_models WHERE provider_slug = ? AND model_id = ?",
+        )
+        .bind(provider_slug)
+        .bind(model_id)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(ConfigError::from)?;
+
+        match row {
+            Some(row) => Ok(Some(CustomModelRecord {
+                provider_slug: row.get("provider_slug"),
+                model_id: row.get("model_id"),
+                display_name: row.get("display_name"),
+                context_window: row
+                    .get::<Option<i64>, _>("context_window")
+                    .map(|v| v as u32),
+                output_limit: row.get::<Option<i64>, _>("output_limit").map(|v| v as u32),
+                supports_tool_calls: row.get::<i64, _>("supports_tool_calls") != 0,
+                supports_reasoning: row.get::<i64, _>("supports_reasoning") != 0,
+                supports_vision: row.get::<i64, _>("supports_vision") != 0,
+                cost_input_per_million: row.get("cost_input_per_million"),
+                cost_output_per_million: row.get("cost_output_per_million"),
+                created_at: parse_datetime(row.get::<String, _>("created_at"))?,
+                updated_at: parse_datetime(row.get::<String, _>("updated_at"))?,
+            })),
+            None => Ok(None),
+        }
+    }
+
+    /// List custom models, optionally filtered by provider slug.
+    pub async fn list_custom_models(
+        &self,
+        provider_slug: Option<&str>,
+    ) -> Result<Vec<CustomModelRecord>, ConfigError> {
+        let rows = if let Some(slug) = provider_slug {
+            sqlx::query(
+                "SELECT provider_slug, model_id, display_name, context_window, output_limit, supports_tool_calls, supports_reasoning, supports_vision, cost_input_per_million, cost_output_per_million, created_at, updated_at FROM custom_models WHERE provider_slug = ? ORDER BY updated_at DESC",
+            )
+            .bind(slug)
+            .fetch_all(&self.pool)
+            .await
+            .map_err(ConfigError::from)?
+        } else {
+            sqlx::query(
+                "SELECT provider_slug, model_id, display_name, context_window, output_limit, supports_tool_calls, supports_reasoning, supports_vision, cost_input_per_million, cost_output_per_million, created_at, updated_at FROM custom_models ORDER BY updated_at DESC",
+            )
+            .fetch_all(&self.pool)
+            .await
+            .map_err(ConfigError::from)?
+        };
+
+        rows.into_iter()
+            .map(|row| {
+                Ok(CustomModelRecord {
+                    provider_slug: row.get("provider_slug"),
+                    model_id: row.get("model_id"),
+                    display_name: row.get("display_name"),
+                    context_window: row
+                        .get::<Option<i64>, _>("context_window")
+                        .map(|v| v as u32),
+                    output_limit: row.get::<Option<i64>, _>("output_limit").map(|v| v as u32),
+                    supports_tool_calls: row.get::<i64, _>("supports_tool_calls") != 0,
+                    supports_reasoning: row.get::<i64, _>("supports_reasoning") != 0,
+                    supports_vision: row.get::<i64, _>("supports_vision") != 0,
+                    cost_input_per_million: row.get("cost_input_per_million"),
+                    cost_output_per_million: row.get("cost_output_per_million"),
+                    created_at: parse_datetime(row.get::<String, _>("created_at"))?,
+                    updated_at: parse_datetime(row.get::<String, _>("updated_at"))?,
+                })
+            })
+            .collect()
+    }
+
+    /// Remove a custom model by provider slug and model ID.
+    pub async fn remove_custom_model(
+        &self,
+        provider_slug: &str,
+        model_id: &str,
+    ) -> Result<(), ConfigError> {
+        sqlx::query("DELETE FROM custom_models WHERE provider_slug = ? AND model_id = ?")
+            .bind(provider_slug)
+            .bind(model_id)
+            .execute(&self.pool)
+            .await
+            .map_err(ConfigError::from)?;
+        Ok(())
+    }
+
+    // ============================================================================
+    // Default Model APIs
+    // ============================================================================
+
+    /// Set the default model selection.
+    pub async fn set_default_model(
+        &self,
+        input: &DefaultModelInput,
+    ) -> Result<DefaultModelRecord, ConfigError> {
+        if input.provider_slug.trim().is_empty() {
+            return Err(ConfigError::Validation(
+                "Provider slug must not be empty".to_string(),
+            ));
+        }
+        if input.model_id.trim().is_empty() {
+            return Err(ConfigError::Validation(
+                "Model ID must not be empty".to_string(),
+            ));
+        }
+        let now = Utc::now().to_rfc3339();
+        sqlx::query(
+            r#"
+            INSERT INTO runtime_defaults (id, provider_slug, model_id, updated_at)
+            VALUES (1, ?, ?, ?)
+            ON CONFLICT(id) DO UPDATE SET
+                provider_slug = excluded.provider_slug,
+                model_id = excluded.model_id,
+                updated_at = excluded.updated_at
+            "#,
+        )
+        .bind(&input.provider_slug)
+        .bind(&input.model_id)
+        .bind(&now)
+        .execute(&self.pool)
+        .await
+        .map_err(ConfigError::from)?;
+
+        Ok(DefaultModelRecord {
+            provider_slug: input.provider_slug.clone(),
+            model_id: input.model_id.clone(),
+            updated_at: Utc::now(),
+        })
+    }
+
+    /// Get the default model selection.
+    pub async fn get_default_model(&self) -> Result<Option<DefaultModelRecord>, ConfigError> {
+        let row = sqlx::query(
+            "SELECT provider_slug, model_id, updated_at FROM runtime_defaults WHERE id = 1",
+        )
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(ConfigError::from)?;
+
+        match row {
+            Some(row) => Ok(Some(DefaultModelRecord {
+                provider_slug: row.get("provider_slug"),
+                model_id: row.get("model_id"),
+                updated_at: parse_datetime(row.get::<String, _>("updated_at"))?,
+            })),
+            None => Ok(None),
+        }
+    }
+
+    /// Clear the default model selection.
+    pub async fn clear_default_model(&self) -> Result<(), ConfigError> {
+        sqlx::query("DELETE FROM runtime_defaults WHERE id = 1")
+            .execute(&self.pool)
+            .await
+            .map_err(ConfigError::from)?;
+        Ok(())
+    }
+
+    // ============================================================================
+    // MCP Server APIs
+    // ============================================================================
+
+    /// Store or replace an MCP server configuration.
+    pub async fn set_mcp_server(
+        &self,
+        input: &McpServerConfigInput,
+    ) -> Result<McpServerConfigRecord, ConfigError> {
+        if input.id.trim().is_empty() {
+            return Err(ConfigError::Validation(
+                "MCP server ID must not be empty".to_string(),
+            ));
+        }
+        if input.label.trim().is_empty() {
+            return Err(ConfigError::Validation(
+                "MCP server label must not be empty".to_string(),
+            ));
+        }
+        validate_mcp_server_input(input)?;
+        let (transport_kind, command, args_json, env_json, url, headers_json) =
+            serialize_mcp_transport(&input.transport)?;
+        let inherited_env_vars_json = serde_json::to_string(&input.inherited_env_vars)?;
+        let working_dir_str = input
+            .working_dir
+            .as_ref()
+            .map(|p| p.to_string_lossy().to_string());
+        let now = Utc::now().to_rfc3339();
+
+        sqlx::query(
+            r#"
+            INSERT INTO mcp_servers (id, label, description, transport_kind, command, args_json, env_json, inherited_env_vars_json, url, headers_json, working_dir, enabled_by_default, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(id) DO UPDATE SET
+                label = excluded.label,
+                description = excluded.description,
+                transport_kind = excluded.transport_kind,
+                command = excluded.command,
+                args_json = excluded.args_json,
+                env_json = excluded.env_json,
+                inherited_env_vars_json = excluded.inherited_env_vars_json,
+                url = excluded.url,
+                headers_json = excluded.headers_json,
+                working_dir = excluded.working_dir,
+                enabled_by_default = excluded.enabled_by_default,
+                updated_at = excluded.updated_at
+            "#,
+        )
+        .bind(&input.id)
+        .bind(&input.label)
+        .bind(&input.description)
+        .bind(&transport_kind)
+        .bind(&command)
+        .bind(&args_json)
+        .bind(&env_json)
+        .bind(&inherited_env_vars_json)
+        .bind(&url)
+        .bind(&headers_json)
+        .bind(&working_dir_str)
+        .bind(input.enabled_by_default)
+        .bind(&now)
+        .bind(&now)
+        .execute(&self.pool)
+        .await
+        .map_err(ConfigError::from)?;
+
+        Ok(McpServerConfigRecord {
+            id: input.id.clone(),
+            label: input.label.clone(),
+            description: input.description.clone(),
+            transport: input.transport.clone(),
+            working_dir: input.working_dir.clone(),
+            enabled_by_default: input.enabled_by_default,
+            inherited_env_vars: input.inherited_env_vars.clone(),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        })
+    }
+
+    /// Get an MCP server configuration by ID.
+    pub async fn get_mcp_server(
+        &self,
+        id: &str,
+    ) -> Result<Option<McpServerConfigRecord>, ConfigError> {
+        let row = sqlx::query(
+            "SELECT id, label, description, transport_kind, command, args_json, env_json, inherited_env_vars_json, url, headers_json, working_dir, enabled_by_default, created_at, updated_at FROM mcp_servers WHERE id = ?",
+        )
+        .bind(id)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(ConfigError::from)?;
+
+        match row {
+            Some(row) => {
+                let transport = deserialize_mcp_transport(
+                    row.get("transport_kind"),
+                    row.get("command"),
+                    row.get("args_json"),
+                    row.get("env_json"),
+                    row.get("url"),
+                    row.get("headers_json"),
+                )?;
+                let inherited_env_vars: Vec<String> =
+                    serde_json::from_str(&row.get::<String, _>("inherited_env_vars_json"))?;
+                let working_dir: Option<String> = row.get("working_dir");
+                Ok(Some(McpServerConfigRecord {
+                    id: row.get("id"),
+                    label: row.get("label"),
+                    description: row.get("description"),
+                    transport,
+                    working_dir: working_dir.map(PathBuf::from),
+                    enabled_by_default: row.get::<i64, _>("enabled_by_default") != 0,
+                    inherited_env_vars,
+                    created_at: parse_datetime(row.get::<String, _>("created_at"))?,
+                    updated_at: parse_datetime(row.get::<String, _>("updated_at"))?,
+                }))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// List all MCP server configurations.
+    pub async fn list_mcp_servers(&self) -> Result<Vec<McpServerConfigRecord>, ConfigError> {
+        let rows = sqlx::query(
+            "SELECT id, label, description, transport_kind, command, args_json, env_json, inherited_env_vars_json, url, headers_json, working_dir, enabled_by_default, created_at, updated_at FROM mcp_servers ORDER BY updated_at DESC",
+        )
+        .fetch_all(&self.pool)
+        .await
+        .map_err(ConfigError::from)?;
+
+        let mut servers = Vec::new();
+        for row in rows {
+            let transport = deserialize_mcp_transport(
+                row.get("transport_kind"),
+                row.get("command"),
+                row.get("args_json"),
+                row.get("env_json"),
+                row.get("url"),
+                row.get("headers_json"),
+            )?;
+            let inherited_env_vars: Vec<String> =
+                serde_json::from_str(&row.get::<String, _>("inherited_env_vars_json"))?;
+            let working_dir: Option<String> = row.get("working_dir");
+            servers.push(McpServerConfigRecord {
+                id: row.get("id"),
+                label: row.get("label"),
+                description: row.get("description"),
+                transport,
+                working_dir: working_dir.map(PathBuf::from),
+                enabled_by_default: row.get::<i64, _>("enabled_by_default") != 0,
+                inherited_env_vars,
+                created_at: parse_datetime(row.get::<String, _>("created_at"))?,
+                updated_at: parse_datetime(row.get::<String, _>("updated_at"))?,
+            });
+        }
+        Ok(servers)
+    }
+
+    /// Remove an MCP server configuration by ID.
+    pub async fn remove_mcp_server(&self, id: &str) -> Result<(), ConfigError> {
+        sqlx::query("DELETE FROM mcp_servers WHERE id = ?")
+            .bind(id)
+            .execute(&self.pool)
+            .await
+            .map_err(ConfigError::from)?;
+        Ok(())
+    }
+
+    // ============================================================================
+    // Skill Settings APIs
+    // ============================================================================
+
+    /// Store or replace skill settings.
+    pub async fn set_skill_settings(
+        &self,
+        input: &SkillSettingsInput,
+    ) -> Result<SkillSettingsRecord, ConfigError> {
+        validate_skill_settings_input(input)?;
+        let additional_skill_dirs_json = serde_json::to_string(&input.additional_skill_dirs)?;
+        let now = Utc::now().to_rfc3339();
+        sqlx::query(
+            r#"
+            INSERT INTO skill_settings (id, trust_project_skills, additional_skill_dirs_json, updated_at)
+            VALUES (1, ?, ?, ?)
+            ON CONFLICT(id) DO UPDATE SET
+                trust_project_skills = excluded.trust_project_skills,
+                additional_skill_dirs_json = excluded.additional_skill_dirs_json,
+                updated_at = excluded.updated_at
+            "#,
+        )
+        .bind(input.trust_project_skills)
+        .bind(&additional_skill_dirs_json)
+        .bind(&now)
+        .execute(&self.pool)
+        .await
+        .map_err(ConfigError::from)?;
+
+        Ok(SkillSettingsRecord {
+            trust_project_skills: input.trust_project_skills,
+            additional_skill_dirs: input.additional_skill_dirs.clone(),
+            updated_at: Utc::now(),
+        })
+    }
+
+    /// Get skill settings, returning defaults if not set.
+    pub async fn get_skill_settings(&self) -> Result<SkillSettingsRecord, ConfigError> {
+        let row = sqlx::query(
+            "SELECT trust_project_skills, additional_skill_dirs_json, updated_at FROM skill_settings WHERE id = 1",
+        )
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(ConfigError::from)?;
+
+        match row {
+            Some(row) => {
+                let additional_skill_dirs_json: String = row.get("additional_skill_dirs_json");
+                let additional_skill_dirs: Vec<PathBuf> =
+                    serde_json::from_str(&additional_skill_dirs_json)?;
+                Ok(SkillSettingsRecord {
+                    trust_project_skills: row.get::<i64, _>("trust_project_skills") != 0,
+                    additional_skill_dirs,
+                    updated_at: parse_datetime(row.get::<String, _>("updated_at"))?,
+                })
+            }
+            None => Ok(SkillSettingsRecord {
+                trust_project_skills: false,
+                additional_skill_dirs: Vec::new(),
+                updated_at: Utc::now(),
+            }),
+        }
+    }
+
+    // ============================================================================
+    // Runtime Settings Snapshot
+    // ============================================================================
+
+    /// Load a validated runtime settings snapshot from the config store.
+    pub async fn load_runtime_settings(&self) -> Result<RuntimeSettingsSnapshot, ConfigError> {
+        let provider_configs = self.list_provider_configs().await?;
+        let custom_models = self.list_custom_models(None).await?;
+        let default_model = self.get_default_model().await?;
+        let mcp_servers = self.list_mcp_servers().await?;
+        let skill_settings = self.get_skill_settings().await?;
+
+        // Validate cross-record consistency
+        if let Some(ref default) = default_model {
+            if default.provider_slug.trim().is_empty() {
+                return Err(ConfigError::Validation(
+                    "Default model provider slug is empty".to_string(),
+                ));
+            }
+            if default.model_id.trim().is_empty() {
+                return Err(ConfigError::Validation(
+                    "Default model ID is empty".to_string(),
+                ));
+            }
+        }
+
+        // Validate MCP server IDs are unique (defensive; DB has PK)
+        let mut seen_ids = std::collections::HashSet::new();
+        for server in &mcp_servers {
+            if !seen_ids.insert(&server.id) {
+                return Err(ConfigError::Validation(format!(
+                    "Duplicate MCP server ID: {}",
+                    server.id
+                )));
+            }
+        }
+
+        // Validate inherited_env_vars entries are names only
+        for server in &mcp_servers {
+            for var_name in &server.inherited_env_vars {
+                validate_env_var_name(var_name)?;
+            }
+        }
+
+        validate_skill_settings_input(&SkillSettingsInput {
+            trust_project_skills: skill_settings.trust_project_skills,
+            additional_skill_dirs: skill_settings.additional_skill_dirs.clone(),
+        })?;
+
+        Ok(RuntimeSettingsSnapshot {
+            provider_configs,
+            custom_models,
+            default_model,
+            mcp_servers,
+            skill_settings,
+        })
+    }
+}
+
+/// Parse an RFC3339 datetime string into a `DateTime<Utc>`.
+fn parse_datetime(s: String) -> Result<DateTime<Utc>, ConfigError> {
+    Ok(chrono::DateTime::parse_from_rfc3339(&s)
+        .map_err(|e| ConfigError::Deserialization(e.to_string()))?
+        .with_timezone(&Utc))
+}
+
+fn validate_optional_non_negative_f64(value: Option<f64>, label: &str) -> Result<(), ConfigError> {
+    if let Some(value) = value {
+        if !value.is_finite() || value < 0.0 {
+            return Err(ConfigError::Validation(format!(
+                "{} must be finite and non-negative when set",
+                label
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_env_var_name(name: &str) -> Result<(), ConfigError> {
+    if name.trim().is_empty() {
+        return Err(ConfigError::Validation(
+            "Inherited environment variable name must not be empty".to_string(),
+        ));
+    }
+    if name.contains('=') {
+        return Err(ConfigError::Validation(format!(
+            "Inherited environment variable '{}' contains '=' and is not a valid variable name",
+            name
+        )));
+    }
+    Ok(())
+}
+
+fn validate_mcp_server_input(input: &McpServerConfigInput) -> Result<(), ConfigError> {
+    use crate::mcp::server::McpTransport;
+
+    match &input.transport {
+        McpTransport::Stdio { command, .. } => {
+            if command.trim().is_empty() {
+                return Err(ConfigError::Validation(
+                    "MCP stdio command must not be empty".to_string(),
+                ));
+            }
+        }
+        McpTransport::Http { config } | McpTransport::HttpSse { config } => {
+            if config.url.trim().is_empty() {
+                return Err(ConfigError::Validation(
+                    "MCP HTTP URL must not be empty".to_string(),
+                ));
+            }
+        }
+    }
+
+    for name in &input.inherited_env_vars {
+        validate_env_var_name(name)?;
+    }
+
+    Ok(())
+}
+
+fn validate_skill_settings_input(input: &SkillSettingsInput) -> Result<(), ConfigError> {
+    for dir in &input.additional_skill_dirs {
+        if dir.as_os_str().is_empty() {
+            return Err(ConfigError::Validation(
+                "Additional skill directory must not be empty".to_string(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Serialize an MCP transport into database columns.
+fn serialize_mcp_transport(
+    transport: &crate::mcp::server::McpTransport,
+) -> Result<
+    (
+        String,
+        Option<String>,
+        Option<String>,
+        Option<String>,
+        Option<String>,
+        Option<String>,
+    ),
+    ConfigError,
+> {
+    use crate::mcp::server::McpTransport;
+    match transport {
+        McpTransport::Stdio { command, args, env } => {
+            let args_json = serde_json::to_string(args)?;
+            let env_json = serde_json::to_string(env)?;
+            Ok((
+                "stdio".to_string(),
+                Some(command.clone()),
+                Some(args_json),
+                Some(env_json),
+                None,
+                None,
+            ))
+        }
+        McpTransport::Http { config } => {
+            let headers_json = config
+                .headers
+                .as_ref()
+                .map(|h| serde_json::to_string(h))
+                .transpose()?;
+            Ok((
+                "http".to_string(),
+                None,
+                None,
+                None,
+                Some(config.url.clone()),
+                headers_json,
+            ))
+        }
+        McpTransport::HttpSse { config } => {
+            let headers_json = config
+                .headers
+                .as_ref()
+                .map(|h| serde_json::to_string(h))
+                .transpose()?;
+            Ok((
+                "http_sse".to_string(),
+                None,
+                None,
+                None,
+                Some(config.url.clone()),
+                headers_json,
+            ))
+        }
+    }
+}
+
+/// Deserialize MCP transport from database columns.
+fn deserialize_mcp_transport(
+    transport_kind: String,
+    command: Option<String>,
+    args_json: Option<String>,
+    env_json: Option<String>,
+    url: Option<String>,
+    headers_json: Option<String>,
+) -> Result<crate::mcp::server::McpTransport, ConfigError> {
+    use crate::mcp::server::{HttpConfig, McpTransport};
+    match transport_kind.as_str() {
+        "stdio" => {
+            let command = command
+                .ok_or_else(|| ConfigError::Deserialization("Missing stdio command".to_string()))?;
+            let args: Vec<String> = args_json
+                .map(|s| serde_json::from_str(&s))
+                .transpose()?
+                .unwrap_or_default();
+            let env: HashMap<String, String> = env_json
+                .map(|s| serde_json::from_str(&s))
+                .transpose()?
+                .unwrap_or_default();
+            Ok(McpTransport::Stdio { command, args, env })
+        }
+        "http" => {
+            let url =
+                url.ok_or_else(|| ConfigError::Deserialization("Missing HTTP URL".to_string()))?;
+            let headers: Option<HashMap<String, String>> =
+                headers_json.map(|s| serde_json::from_str(&s)).transpose()?;
+            Ok(McpTransport::Http {
+                config: HttpConfig { url, headers },
+            })
+        }
+        "http_sse" => {
+            let url = url
+                .ok_or_else(|| ConfigError::Deserialization("Missing HTTP+SSE URL".to_string()))?;
+            let headers: Option<HashMap<String, String>> =
+                headers_json.map(|s| serde_json::from_str(&s)).transpose()?;
+            Ok(McpTransport::HttpSse {
+                config: HttpConfig { url, headers },
+            })
+        }
+        other => Err(ConfigError::Deserialization(format!(
+            "Unknown MCP transport kind: {}",
+            other
+        ))),
     }
 }
 

--- a/src/config/store.rs
+++ b/src/config/store.rs
@@ -1264,20 +1264,19 @@ fn validate_skill_settings_input(input: &SkillSettingsInput) -> Result<(), Confi
     Ok(())
 }
 
+type SerializedMcpTransport = (
+    String,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+);
+
 /// Serialize an MCP transport into database columns.
 fn serialize_mcp_transport(
     transport: &crate::mcp::server::McpTransport,
-) -> Result<
-    (
-        String,
-        Option<String>,
-        Option<String>,
-        Option<String>,
-        Option<String>,
-        Option<String>,
-    ),
-    ConfigError,
-> {
+) -> Result<SerializedMcpTransport, ConfigError> {
     use crate::mcp::server::McpTransport;
     match transport {
         McpTransport::Stdio { command, args, env } => {
@@ -1296,7 +1295,7 @@ fn serialize_mcp_transport(
             let headers_json = config
                 .headers
                 .as_ref()
-                .map(|h| serde_json::to_string(h))
+                .map(serde_json::to_string)
                 .transpose()?;
             Ok((
                 "http".to_string(),
@@ -1311,7 +1310,7 @@ fn serialize_mcp_transport(
             let headers_json = config
                 .headers
                 .as_ref()
-                .map(|h| serde_json::to_string(h))
+                .map(serde_json::to_string)
                 .transpose()?;
             Ok((
                 "http_sse".to_string(),

--- a/src/mcp/client.rs
+++ b/src/mcp/client.rs
@@ -156,8 +156,14 @@ impl StdioMcpClient {
         };
 
         let mut cmd = Command::new(command);
+        let mut base_env = sanitized_stdio_env();
+        for var_name in &config.inherited_env_vars {
+            if let Ok(value) = std::env::var(var_name) {
+                base_env.insert(var_name.clone(), value);
+            }
+        }
         cmd.args(args)
-            .envs(sanitized_stdio_env())
+            .envs(base_env)
             .envs(env)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -85,12 +85,21 @@ pub struct McpServerConfig {
     pub id: String,
     /// Display label for this server
     pub label: String,
+    /// Optional description for this server
+    #[serde(default)]
+    pub description: Option<String>,
     /// Transport configuration
     pub transport: McpTransport,
     /// Whether this server should be enabled by default for new sessions
     pub enabled_by_default: bool,
     /// Optional working directory for stdio transports
     pub working_dir: Option<PathBuf>,
+    /// Names of parent environment variables to inherit for stdio transports.
+    /// The runtime copies the parent value for each named variable into the
+    /// subprocess environment after sanitization and before applying the
+    /// configured `env` map.
+    #[serde(default)]
+    pub inherited_env_vars: Vec<String>,
 }
 
 /// Runtime state for a configured MCP server

--- a/tests/config_store_tests.rs
+++ b/tests/config_store_tests.rs
@@ -854,7 +854,7 @@ async fn test_runtime_settings_snapshot() {
     let snapshot = store.load_runtime_settings().await.unwrap();
     assert_eq!(snapshot.provider_configs.len(), 1);
     assert!(snapshot.default_model.is_some());
-    assert_eq!(snapshot.skill_settings.trust_project_skills, false);
+    assert!(!snapshot.skill_settings.trust_project_skills);
 }
 
 #[tokio::test]

--- a/tests/config_store_tests.rs
+++ b/tests/config_store_tests.rs
@@ -938,7 +938,80 @@ async fn test_skill_settings_reject_empty_additional_dir() {
 
 #[tokio::test]
 async fn test_migrations_v1_to_v2() {
-    let store = ConfigStore::open_in_memory().await.unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("v1-config.db");
+    let pool = sqlx::sqlite::SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect_with(
+            sqlx::sqlite::SqliteConnectOptions::new()
+                .filename(&db_path)
+                .create_if_missing(true),
+        )
+        .await
+        .unwrap();
+
+    sqlx::raw_sql(
+        r#"
+        CREATE TABLE schema_version (
+            id INTEGER PRIMARY KEY CHECK (id = 1),
+            version INTEGER NOT NULL
+        );
+
+        CREATE TABLE profiles (
+            id TEXT PRIMARY KEY,
+            schema_version INTEGER NOT NULL,
+            payload TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        );
+
+        CREATE TABLE prompts (
+            id TEXT PRIMARY KEY,
+            schema_version INTEGER NOT NULL,
+            payload TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        );
+
+        CREATE TABLE schedule (
+            id TEXT PRIMARY KEY,
+            schema_version INTEGER NOT NULL,
+            payload TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        );
+
+        CREATE TABLE credentials (
+            provider_slug TEXT PRIMARY KEY,
+            credential_mode TEXT NOT NULL,
+            encrypted_payload BLOB NOT NULL,
+            nonce BLOB NOT NULL,
+            encryption_metadata TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        );
+
+        INSERT INTO schema_version (id, version) VALUES (1, 1);
+        INSERT INTO profiles (id, schema_version, payload, created_at, updated_at)
+        VALUES ('legacy-profile', 1, '{"name":"Legacy"}', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+        "#,
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+    drop(pool);
+
+    let store = open_test_store(&db_path).await;
+
+    let legacy_profile = store.get_profile("legacy-profile").await.unwrap().unwrap();
+    assert_eq!(legacy_profile.payload, json!({"name": "Legacy"}));
+
+    let mut conn = store.acquire().await.unwrap();
+    let version: i64 = sqlx::query_scalar("SELECT version FROM schema_version WHERE id = 1")
+        .fetch_one(&mut *conn)
+        .await
+        .unwrap();
+    assert_eq!(version, 2);
 
     // Verify v2 tables exist by using the new APIs
     store

--- a/tests/config_store_tests.rs
+++ b/tests/config_store_tests.rs
@@ -613,6 +613,349 @@ async fn test_durable_store_disconnect_oauth() {
 }
 
 // ============================================================================
+// Runtime Settings Tests (Issue #67)
+// ============================================================================
+
+use iron_core::config::{
+    CustomModelInput, DefaultModelInput, McpServerConfigInput, ProviderConfigInput,
+    SkillSettingsInput,
+};
+use iron_core::mcp::server::{HttpConfig, McpTransport};
+use std::collections::HashMap;
+
+#[tokio::test]
+async fn test_provider_config_crud() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+
+    let input = ProviderConfigInput {
+        provider_slug: "openai".to_string(),
+        display_name: "OpenAI".to_string(),
+        enabled: true,
+        base_url: Some("https://api.openai.com".to_string()),
+    };
+
+    let record = store.set_provider_config(&input).await.unwrap();
+    assert_eq!(record.provider_slug, "openai");
+    assert_eq!(record.display_name, "OpenAI");
+    assert!(record.enabled);
+
+    let retrieved = store.get_provider_config("openai").await.unwrap().unwrap();
+    assert_eq!(retrieved.display_name, "OpenAI");
+
+    let list = store.list_provider_configs().await.unwrap();
+    assert_eq!(list.len(), 1);
+
+    store.remove_provider_config("openai").await.unwrap();
+    assert!(store.get_provider_config("openai").await.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn test_provider_config_excludes_credentials() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+
+    // Verify provider config API does not accept credential fields
+    let input = ProviderConfigInput {
+        provider_slug: "openai".to_string(),
+        display_name: "OpenAI".to_string(),
+        enabled: true,
+        base_url: None,
+    };
+
+    let record = store.set_provider_config(&input).await.unwrap();
+    // Provider config record should not have api_key or credential fields
+    assert_eq!(record.provider_slug, "openai");
+}
+
+#[tokio::test]
+async fn test_custom_model_crud() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+
+    let input = CustomModelInput {
+        provider_slug: "openai".to_string(),
+        model_id: "gpt-4o-custom".to_string(),
+        display_name: "Custom GPT-4o".to_string(),
+        context_window: Some(128000),
+        output_limit: Some(4096),
+        supports_tool_calls: true,
+        supports_reasoning: false,
+        supports_vision: true,
+        cost_input_per_million: Some(5.0),
+        cost_output_per_million: Some(15.0),
+    };
+
+    let record = store.set_custom_model(&input).await.unwrap();
+    assert_eq!(record.model_id, "gpt-4o-custom");
+
+    let retrieved = store
+        .get_custom_model("openai", "gpt-4o-custom")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(retrieved.display_name, "Custom GPT-4o");
+    assert_eq!(retrieved.context_window, Some(128000));
+
+    let list = store.list_custom_models(None).await.unwrap();
+    assert_eq!(list.len(), 1);
+
+    let by_provider = store.list_custom_models(Some("openai")).await.unwrap();
+    assert_eq!(by_provider.len(), 1);
+
+    store
+        .remove_custom_model("openai", "gpt-4o-custom")
+        .await
+        .unwrap();
+    assert!(store
+        .get_custom_model("openai", "gpt-4o-custom")
+        .await
+        .unwrap()
+        .is_none());
+}
+
+#[tokio::test]
+async fn test_default_model_crud() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+
+    let input = DefaultModelInput {
+        provider_slug: "openai".to_string(),
+        model_id: "gpt-4o".to_string(),
+    };
+
+    let record = store.set_default_model(&input).await.unwrap();
+    assert_eq!(record.provider_slug, "openai");
+    assert_eq!(record.model_id, "gpt-4o");
+
+    let retrieved = store.get_default_model().await.unwrap().unwrap();
+    assert_eq!(retrieved.provider_slug, "openai");
+    assert_eq!(retrieved.model_id, "gpt-4o");
+
+    store.clear_default_model().await.unwrap();
+    assert!(store.get_default_model().await.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn test_mcp_server_stdio_crud() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+
+    let mut env = HashMap::new();
+    env.insert("KEY".to_string(), "value".to_string());
+
+    let input = McpServerConfigInput {
+        id: "filesystem".to_string(),
+        label: "Filesystem".to_string(),
+        description: Some("File system access".to_string()),
+        transport: McpTransport::Stdio {
+            command: "npx".to_string(),
+            args: vec!["-y", "@modelcontextprotocol/server-filesystem"]
+                .into_iter()
+                .map(String::from)
+                .collect(),
+            env,
+        },
+        working_dir: Some(std::path::PathBuf::from("/tmp")),
+        enabled_by_default: true,
+        inherited_env_vars: vec!["HOME".to_string()],
+    };
+
+    let record = store.set_mcp_server(&input).await.unwrap();
+    assert_eq!(record.id, "filesystem");
+    assert_eq!(record.inherited_env_vars, vec!["HOME"]);
+
+    let retrieved = store.get_mcp_server("filesystem").await.unwrap().unwrap();
+    assert_eq!(retrieved.label, "Filesystem");
+    assert_eq!(retrieved.inherited_env_vars, vec!["HOME"]);
+
+    let list = store.list_mcp_servers().await.unwrap();
+    assert_eq!(list.len(), 1);
+
+    store.remove_mcp_server("filesystem").await.unwrap();
+    assert!(store.get_mcp_server("filesystem").await.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn test_mcp_server_http_crud() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+
+    let input = McpServerConfigInput {
+        id: "remote".to_string(),
+        label: "Remote".to_string(),
+        description: None,
+        transport: McpTransport::Http {
+            config: HttpConfig {
+                url: "https://example.com/mcp".to_string(),
+                headers: Some(
+                    [("Authorization".to_string(), "Bearer token".to_string())]
+                        .into_iter()
+                        .collect(),
+                ),
+            },
+        },
+        working_dir: None,
+        enabled_by_default: false,
+        inherited_env_vars: vec![],
+    };
+
+    let record = store.set_mcp_server(&input).await.unwrap();
+    assert_eq!(record.id, "remote");
+
+    let retrieved = store.get_mcp_server("remote").await.unwrap().unwrap();
+    match retrieved.transport {
+        McpTransport::Http { config } => {
+            assert_eq!(config.url, "https://example.com/mcp");
+        }
+        _ => panic!("Expected HTTP transport"),
+    }
+}
+
+#[tokio::test]
+async fn test_skill_settings_defaults() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+
+    // Defaults when not set
+    let settings = store.get_skill_settings().await.unwrap();
+    assert!(!settings.trust_project_skills);
+    assert!(settings.additional_skill_dirs.is_empty());
+
+    let input = SkillSettingsInput {
+        trust_project_skills: true,
+        additional_skill_dirs: vec![std::path::PathBuf::from("/custom/skills")],
+    };
+
+    let record = store.set_skill_settings(&input).await.unwrap();
+    assert!(record.trust_project_skills);
+    assert_eq!(record.additional_skill_dirs.len(), 1);
+
+    let retrieved = store.get_skill_settings().await.unwrap();
+    assert!(retrieved.trust_project_skills);
+}
+
+#[tokio::test]
+async fn test_runtime_settings_snapshot() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+
+    // Set up some runtime settings
+    store
+        .set_provider_config(&ProviderConfigInput {
+            provider_slug: "openai".to_string(),
+            display_name: "OpenAI".to_string(),
+            enabled: true,
+            base_url: None,
+        })
+        .await
+        .unwrap();
+
+    store
+        .set_default_model(&DefaultModelInput {
+            provider_slug: "openai".to_string(),
+            model_id: "gpt-4o".to_string(),
+        })
+        .await
+        .unwrap();
+
+    let snapshot = store.load_runtime_settings().await.unwrap();
+    assert_eq!(snapshot.provider_configs.len(), 1);
+    assert!(snapshot.default_model.is_some());
+    assert_eq!(snapshot.skill_settings.trust_project_skills, false);
+}
+
+#[tokio::test]
+async fn test_inherited_env_vars_validation() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+
+    let input = McpServerConfigInput {
+        id: "bad-env".to_string(),
+        label: "Bad Env".to_string(),
+        description: None,
+        transport: McpTransport::Stdio {
+            command: "echo".to_string(),
+            args: vec![],
+            env: HashMap::new(),
+        },
+        working_dir: None,
+        enabled_by_default: true,
+        inherited_env_vars: vec!["KEY=VALUE".to_string()],
+    };
+
+    let result = store.set_mcp_server(&input).await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_custom_model_numeric_validation() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+
+    let input = CustomModelInput {
+        provider_slug: "openai".to_string(),
+        model_id: "bad-cost".to_string(),
+        display_name: "Bad Cost".to_string(),
+        context_window: Some(0),
+        output_limit: Some(4096),
+        supports_tool_calls: false,
+        supports_reasoning: false,
+        supports_vision: false,
+        cost_input_per_million: Some(-1.0),
+        cost_output_per_million: Some(0.0),
+    };
+
+    let result = store.set_custom_model(&input).await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_mcp_server_transport_validation() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+
+    let input = McpServerConfigInput {
+        id: "bad-stdio".to_string(),
+        label: "Bad Stdio".to_string(),
+        description: None,
+        transport: McpTransport::Stdio {
+            command: "".to_string(),
+            args: vec![],
+            env: HashMap::new(),
+        },
+        working_dir: None,
+        enabled_by_default: true,
+        inherited_env_vars: vec![],
+    };
+
+    let result = store.set_mcp_server(&input).await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_skill_settings_reject_empty_additional_dir() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+
+    let result = store
+        .set_skill_settings(&SkillSettingsInput {
+            trust_project_skills: false,
+            additional_skill_dirs: vec![std::path::PathBuf::new()],
+        })
+        .await;
+
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_migrations_v1_to_v2() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+
+    // Verify v2 tables exist by using the new APIs
+    store
+        .set_provider_config(&ProviderConfigInput {
+            provider_slug: "test".to_string(),
+            display_name: "Test".to_string(),
+            enabled: true,
+            base_url: None,
+        })
+        .await
+        .unwrap();
+
+    let retrieved = store.get_provider_config("test").await.unwrap();
+    assert!(retrieved.is_some());
+}
+
+// ============================================================================
 // XDG Path Verification Tests (Task 8.6)
 // ============================================================================
 

--- a/tests/mcp_e2e_tests.rs
+++ b/tests/mcp_e2e_tests.rs
@@ -129,6 +129,8 @@ async fn register_server_connects_and_discovers_tools_end_to_end() {
     agent.register_mcp_server(McpServerConfig {
         id: "stdio-server".to_string(),
         label: "Fake stdio server".to_string(),
+        description: None,
+        inherited_env_vars: vec![],
         transport: McpTransport::Stdio {
             command: script_path.to_string_lossy().into_owned(),
             args: vec![],
@@ -168,6 +170,8 @@ async fn prompt_request_includes_visible_mcp_tools() {
     agent.register_mcp_server(McpServerConfig {
         id: "stdio-server".to_string(),
         label: "Fake stdio server".to_string(),
+        description: None,
+        inherited_env_vars: vec![],
         transport: McpTransport::Stdio {
             command: script_path.to_string_lossy().into_owned(),
             args: vec![],
@@ -235,6 +239,8 @@ async fn model_issued_mcp_tool_call_executes_through_runtime() {
     agent.register_mcp_server(McpServerConfig {
         id: "stdio-server".to_string(),
         label: "Fake stdio server".to_string(),
+        description: None,
+        inherited_env_vars: vec![],
         transport: McpTransport::Stdio {
             command: script_path.to_string_lossy().into_owned(),
             args: vec![],
@@ -281,6 +287,8 @@ async fn model_issued_mcp_tool_call_respects_real_approval_flow() {
     agent.register_mcp_server(McpServerConfig {
         id: "stdio-server".to_string(),
         label: "Fake stdio server".to_string(),
+        description: None,
+        inherited_env_vars: vec![],
         transport: McpTransport::Stdio {
             command: script_path.to_string_lossy().into_owned(),
             args: vec![],
@@ -331,6 +339,8 @@ async fn model_issued_unavailable_mcp_tool_uses_precise_canonical_diagnostics() 
     agent.register_mcp_server(McpServerConfig {
         id: "stdio-server".to_string(),
         label: "Fake stdio server".to_string(),
+        description: None,
+        inherited_env_vars: vec![],
         transport: McpTransport::Stdio {
             command: script_path.to_string_lossy().into_owned(),
             args: vec![],
@@ -365,6 +375,8 @@ async fn reconnect_and_rediscover_restore_tools() {
     agent.register_mcp_server(McpServerConfig {
         id: "stdio-server".to_string(),
         label: "Fake stdio server".to_string(),
+        description: None,
+        inherited_env_vars: vec![],
         transport: McpTransport::Stdio {
             command: script_path.to_string_lossy().into_owned(),
             args: vec![],
@@ -468,6 +480,8 @@ async fn python_exec_child_call_can_reach_visible_mcp_tool() {
     agent.register_mcp_server(McpServerConfig {
         id: "stdio-server".to_string(),
         label: "Fake stdio server".to_string(),
+        description: None,
+        inherited_env_vars: vec![],
         transport: McpTransport::Stdio {
             command: script_path.to_string_lossy().into_owned(),
             args: vec![],
@@ -523,6 +537,8 @@ async fn python_exec_child_unavailable_mcp_tool_uses_precise_canonical_diagnosti
     agent.register_mcp_server(McpServerConfig {
         id: "stdio-server".to_string(),
         label: "Fake stdio server".to_string(),
+        description: None,
+        inherited_env_vars: vec![],
         transport: McpTransport::Stdio {
             command: script_path.to_string_lossy().into_owned(),
             args: vec![],

--- a/tests/mcp_integration_tests.rs
+++ b/tests/mcp_integration_tests.rs
@@ -79,6 +79,8 @@ fn test_mcp_server_registration_stores_configuration() {
     let server_config = McpServerConfig {
         id: "my-server".to_string(),
         label: "My Test Server".to_string(),
+        description: None,
+        inherited_env_vars: vec![],
         transport: McpTransport::Http {
             config: HttpConfig::new("http://localhost:8080".to_string()),
         },
@@ -107,6 +109,8 @@ fn test_mcp_server_health_transitions() {
     let server_config = McpServerConfig {
         id: "my-server".to_string(),
         label: "My Test Server".to_string(),
+        description: None,
+        inherited_env_vars: vec![],
         transport: McpTransport::Http {
             config: HttpConfig::new("http://localhost:8080".to_string()),
         },
@@ -144,6 +148,8 @@ fn test_tool_discovery_updates_registry() {
     let server_config = McpServerConfig {
         id: "my-server".to_string(),
         label: "My Test Server".to_string(),
+        description: None,
+        inherited_env_vars: vec![],
         transport: McpTransport::Http {
             config: HttpConfig::new("http://localhost:8080".to_string()),
         },
@@ -181,6 +187,8 @@ async fn test_session_tool_catalog_includes_mcp_tools_when_enabled_and_usable() 
     let server_config = McpServerConfig {
         id: "my-server".to_string(),
         label: "My Test Server".to_string(),
+        description: None,
+        inherited_env_vars: vec![],
         transport: McpTransport::Http {
             config: HttpConfig::new("http://localhost:8080".to_string()),
         },
@@ -225,6 +233,8 @@ async fn test_session_tool_catalog_excludes_disabled_mcp_servers() {
     let server_config = McpServerConfig {
         id: "disabled-server".to_string(),
         label: "Disabled Server".to_string(),
+        description: None,
+        inherited_env_vars: vec![],
         transport: McpTransport::Http {
             config: HttpConfig::new("http://localhost:8080".to_string()),
         },
@@ -267,6 +277,8 @@ async fn test_session_tool_catalog_excludes_errored_mcp_servers() {
     let server_config = McpServerConfig {
         id: "errored-server".to_string(),
         label: "Errored Server".to_string(),
+        description: None,
+        inherited_env_vars: vec![],
         transport: McpTransport::Http {
             config: HttpConfig::new("http://localhost:8080".to_string()),
         },
@@ -307,6 +319,8 @@ async fn test_session_tool_catalog_cache_invalidates_on_mcp_registry_change() {
     let server_config = McpServerConfig {
         id: "cached-server".to_string(),
         label: "Cached Server".to_string(),
+        description: None,
+        inherited_env_vars: vec![],
         transport: McpTransport::Http {
             config: HttpConfig::new("http://localhost:8080".to_string()),
         },
@@ -358,6 +372,8 @@ async fn test_session_tool_catalog_filters_consistently() {
     let enabled_config = McpServerConfig {
         id: "enabled-server".to_string(),
         label: "Enabled Server".to_string(),
+        description: None,
+        inherited_env_vars: vec![],
         transport: McpTransport::Http {
             config: HttpConfig::new("http://localhost:8081".to_string()),
         },
@@ -368,6 +384,8 @@ async fn test_session_tool_catalog_filters_consistently() {
     let disabled_config = McpServerConfig {
         id: "disabled-server".to_string(),
         label: "Disabled Server".to_string(),
+        description: None,
+        inherited_env_vars: vec![],
         transport: McpTransport::Http {
             config: HttpConfig::new("http://localhost:8082".to_string()),
         },
@@ -438,6 +456,8 @@ done
     let server_config = McpServerConfig {
         id: "my-server".to_string(),
         label: "My Server".to_string(),
+        description: None,
+        inherited_env_vars: vec![],
         transport: McpTransport::Stdio {
             command: script_path.to_string_lossy().into_owned(),
             args: vec![],
@@ -502,6 +522,8 @@ async fn test_mcp_tool_execution_requires_approval() {
     let server_config = McpServerConfig {
         id: "approval-server".to_string(),
         label: "Approval Server".to_string(),
+        description: None,
+        inherited_env_vars: vec![],
         transport: McpTransport::Http {
             config: HttpConfig::new("http://localhost:8080".to_string()),
         },
@@ -586,6 +608,8 @@ done
     let server_config = McpServerConfig {
         id: "lifecycle-server".to_string(),
         label: "Lifecycle Server".to_string(),
+        description: None,
+        inherited_env_vars: vec![],
         transport: McpTransport::Stdio {
             command: script_path.to_string_lossy().into_owned(),
             args: vec![],
@@ -642,6 +666,8 @@ async fn test_mcp_unavailable_tool_diagnostics_disabled_server() {
     let server_config = McpServerConfig {
         id: "diagnostics-server".to_string(),
         label: "Diagnostics Server".to_string(),
+        description: None,
+        inherited_env_vars: vec![],
         transport: McpTransport::Http {
             config: HttpConfig::new("http://localhost:8080".to_string()),
         },
@@ -708,6 +734,8 @@ async fn test_mcp_unavailable_tool_diagnostics_unknown_tool() {
     let server_config = McpServerConfig {
         id: "tools-server".to_string(),
         label: "Tools Server".to_string(),
+        description: None,
+        inherited_env_vars: vec![],
         transport: McpTransport::Http {
             config: HttpConfig::new("http://localhost:8080".to_string()),
         },
@@ -806,6 +834,8 @@ async fn test_mcp_runtime_default_enablement_semantics() {
     let server_config = McpServerConfig {
         id: "override-server".to_string(),
         label: "Override Server".to_string(),
+        description: None,
+        inherited_env_vars: vec![],
         transport: McpTransport::Http {
             config: HttpConfig::new("http://localhost:8080".to_string()),
         },
@@ -841,6 +871,8 @@ async fn test_mcp_runtime_default_enablement_semantics() {
     let server_config2 = McpServerConfig {
         id: "override-server2".to_string(),
         label: "Override Server 2".to_string(),
+        description: None,
+        inherited_env_vars: vec![],
         transport: McpTransport::Http {
             config: HttpConfig::new("http://localhost:8080".to_string()),
         },
@@ -1132,6 +1164,8 @@ async fn test_http_mcp_client_parses_streamable_http_sse_response() {
     let config = McpServerConfig {
         id: "streamable-http".to_string(),
         label: "Streamable HTTP".to_string(),
+        description: None,
+        inherited_env_vars: vec![],
         transport: McpTransport::Http {
             config: HttpConfig::new(format!("http://127.0.0.1:{}", port)),
         },
@@ -1168,6 +1202,8 @@ async fn test_http_mcp_client_initialize_accepts_absent_response_id() {
     let config = McpServerConfig {
         id: "http-absent-init-id".to_string(),
         label: "HTTP absent initialize id".to_string(),
+        description: None,
+        inherited_env_vars: vec![],
         transport: McpTransport::Http {
             config: HttpConfig::new(format!("http://127.0.0.1:{}", port)),
         },
@@ -1193,6 +1229,8 @@ async fn test_http_mcp_client_initialize_accepts_explicit_null_response_id() {
     let config = McpServerConfig {
         id: "http-null-init-id".to_string(),
         label: "HTTP null initialize id".to_string(),
+        description: None,
+        inherited_env_vars: vec![],
         transport: McpTransport::Http {
             config: HttpConfig::new(format!("http://127.0.0.1:{}", port)),
         },
@@ -1218,6 +1256,8 @@ async fn test_http_mcp_client_rejects_post_bootstrap_id_less_response() {
     let config = McpServerConfig {
         id: "http-post-bootstrap-idless".to_string(),
         label: "HTTP post-bootstrap id-less response".to_string(),
+        description: None,
+        inherited_env_vars: vec![],
         transport: McpTransport::Http {
             config: HttpConfig::new(format!("http://127.0.0.1:{}", port)),
         },
@@ -1253,6 +1293,8 @@ async fn test_http_mcp_client_sends_accept_header() {
     let config = McpServerConfig {
         id: "test-accept".to_string(),
         label: "Test Accept Header".to_string(),
+        description: None,
+        inherited_env_vars: vec![],
         transport: McpTransport::Http {
             config: HttpConfig::new(format!("http://127.0.0.1:{}", port)),
         },
@@ -1292,6 +1334,8 @@ async fn test_http_mcp_client_sends_custom_headers() {
     let config = McpServerConfig {
         id: "test-custom-headers".to_string(),
         label: "Test Custom Headers".to_string(),
+        description: None,
+        inherited_env_vars: vec![],
         transport: McpTransport::Http {
             config: HttpConfig {
                 url: format!("http://127.0.0.1:{}", port),

--- a/tests/mcp_outstanding_tests.rs
+++ b/tests/mcp_outstanding_tests.rs
@@ -471,6 +471,8 @@ async fn public_effective_tools_match_prompt_visible_tools() {
     agent.register_mcp_server(McpServerConfig {
         id: "stdio-server".to_string(),
         label: "Fake stdio server".to_string(),
+        description: None,
+        inherited_env_vars: vec![],
         transport: McpTransport::Stdio {
             command: script_path.to_string_lossy().into_owned(),
             args: vec![],
@@ -566,6 +568,8 @@ async fn http_sse_transport_handles_framing_and_response_correlation() {
     agent.register_mcp_server(McpServerConfig {
         id: "sse-server".to_string(),
         label: "Fake SSE server".to_string(),
+        description: None,
+        inherited_env_vars: vec![],
         transport: McpTransport::HttpSse {
             config: HttpConfig::new(fake_sse_server.url.clone()),
         },
@@ -593,6 +597,8 @@ async fn sse_tool_discovery_follows_pagination() {
     let config = McpServerConfig {
         id: "paged-sse".to_string(),
         label: "Paged SSE".to_string(),
+        description: None,
+        inherited_env_vars: vec![],
         transport: McpTransport::HttpSse {
             config: HttpConfig::new(fake_sse_server.url.clone()),
         },
@@ -627,6 +633,8 @@ async fn mcp_name_resolution_is_unambiguous_for_server_ids_with_underscores() {
     agent.register_mcp_server(McpServerConfig {
         id: "stdio_server_id".to_string(),
         label: "Underscore stdio server".to_string(),
+        description: None,
+        inherited_env_vars: vec![],
         transport: McpTransport::Stdio {
             command: script_path.to_string_lossy().into_owned(),
             args: vec![],
@@ -679,6 +687,8 @@ async fn failed_stdio_spawn_surfaces_as_server_error_without_panic() {
     agent.register_mcp_server(McpServerConfig {
         id: "nonexistent-cmd".to_string(),
         label: "Bad command".to_string(),
+        description: None,
+        inherited_env_vars: vec![],
         transport: McpTransport::Stdio {
             command: "/no/such/binary/exists_abc123".to_string(),
             args: vec![],
@@ -734,6 +744,8 @@ async fn stdio_transport_applies_working_dir_and_uses_safe_environment() {
     let config = McpServerConfig {
         id: "review-stdio".to_string(),
         label: "Review stdio".to_string(),
+        description: None,
+        inherited_env_vars: vec![],
         transport: McpTransport::Stdio {
             command: script_path.to_string_lossy().into_owned(),
             args: vec![],
@@ -805,6 +817,8 @@ async fn stdio_call_tool_preserves_server_error_details_and_correlates_responses
     let config = McpServerConfig {
         id: "review-stdio".to_string(),
         label: "Review stdio".to_string(),
+        description: None,
+        inherited_env_vars: vec![],
         transport: McpTransport::Stdio {
             command: script_path.to_string_lossy().into_owned(),
             args: vec![],
@@ -849,6 +863,8 @@ async fn sse_startup_failure_fails_fast() {
     let config = McpServerConfig {
         id: "broken-sse".to_string(),
         label: "Broken SSE".to_string(),
+        description: None,
+        inherited_env_vars: vec![],
         transport: McpTransport::HttpSse {
             config: HttpConfig::new(format!("http://{}", addr)),
         },
@@ -1044,6 +1060,8 @@ async fn concurrent_sse_requests_are_correctly_correlated() {
     agent.register_mcp_server(McpServerConfig {
         id: "concurrent-sse".to_string(),
         label: "Concurrent SSE server".to_string(),
+        description: None,
+        inherited_env_vars: vec![],
         transport: McpTransport::HttpSse {
             config: HttpConfig::new(fake_sse_server.url.clone()),
         },
@@ -1202,6 +1220,8 @@ async fn stdio_initialize_accepts_absent_response_id() {
     agent.register_mcp_server(McpServerConfig {
         id: "null-id-stdio".to_string(),
         label: "Null ID stdio server".to_string(),
+        description: None,
+        inherited_env_vars: vec![],
         transport: McpTransport::Stdio {
             command: script_path.to_string_lossy().into_owned(),
             args: vec![],
@@ -1233,6 +1253,8 @@ async fn stdio_initialize_accepts_explicit_null_response_id() {
     agent.register_mcp_server(McpServerConfig {
         id: "explicit-null-stdio".to_string(),
         label: "Explicit null ID stdio server".to_string(),
+        description: None,
+        inherited_env_vars: vec![],
         transport: McpTransport::Stdio {
             command: script_path.to_string_lossy().into_owned(),
             args: vec![],
@@ -1478,6 +1500,8 @@ async fn sse_initialize_accepts_absent_response_id() {
     agent.register_mcp_server(McpServerConfig {
         id: "null-id-sse".to_string(),
         label: "Null ID SSE server".to_string(),
+        description: None,
+        inherited_env_vars: vec![],
         transport: McpTransport::HttpSse {
             config: HttpConfig::new(fake_sse_server.url.clone()),
         },
@@ -1506,6 +1530,8 @@ async fn sse_initialize_accepts_explicit_null_response_id() {
     agent.register_mcp_server(McpServerConfig {
         id: "explicit-null-sse".to_string(),
         label: "Explicit null ID SSE server".to_string(),
+        description: None,
+        inherited_env_vars: vec![],
         transport: McpTransport::HttpSse {
             config: HttpConfig::new(fake_sse_server.url.clone()),
         },
@@ -1598,6 +1624,8 @@ async fn stdio_post_bootstrap_id_less_response_is_rejected() {
     agent.register_mcp_server(McpServerConfig {
         id: "null-id-tools-list".to_string(),
         label: "Null ID on tools/list".to_string(),
+        description: None,
+        inherited_env_vars: vec![],
         transport: McpTransport::Stdio {
             command: script_path.to_string_lossy().into_owned(),
             args: vec![],

--- a/tests/mcp_outstanding_tests.rs
+++ b/tests/mcp_outstanding_tests.rs
@@ -740,12 +740,14 @@ async fn stdio_transport_applies_working_dir_and_uses_safe_environment() {
 
     let mut env = HashMap::new();
     env.insert("EXPLICIT_ALLOWED".to_string(), "present".to_string());
+    let inherited_key = "TEST_INHERITED_ALLOWED";
+    std::env::set_var(inherited_key, "allowed-value");
 
     let config = McpServerConfig {
         id: "review-stdio".to_string(),
         label: "Review stdio".to_string(),
         description: None,
-        inherited_env_vars: vec![],
+        inherited_env_vars: vec![inherited_key.to_string()],
         transport: McpTransport::Stdio {
             command: script_path.to_string_lossy().into_owned(),
             args: vec![],
@@ -782,23 +784,11 @@ async fn stdio_transport_applies_working_dir_and_uses_safe_environment() {
 
     std::env::remove_var(sensitive_key);
 
-    // Verify that a non-sensitive inherited env var IS present in the
-    // subprocess (the hybrid approach inherits all non-sensitive vars).
-    let inherited_key = std::env::vars()
-        .map(|(key, _)| key)
-        .find(|key| key.starts_with("CARGO_"))
-        .expect("expected at least one CARGO_* env var during tests");
-
     let inherited_env = client
         .call_tool("env_tool", json!({"key": inherited_key}))
         .await
         .unwrap();
-    assert_ne!(
-        inherited_env["result"],
-        json!("<missing>"),
-        "non-sensitive inherited var '{}' should be present in subprocess",
-        inherited_key
-    );
+    assert_eq!(inherited_env["result"], json!("allowed-value"));
 
     let explicit_env = client
         .call_tool("env_tool", json!({"key": "EXPLICIT_ALLOWED"}))
@@ -807,6 +797,7 @@ async fn stdio_transport_applies_working_dir_and_uses_safe_environment() {
     assert_eq!(explicit_env["result"], json!("present"));
 
     client.close().await;
+    std::env::remove_var(inherited_key);
 }
 
 #[tokio::test]

--- a/tests/mcp_tests.rs
+++ b/tests/mcp_tests.rs
@@ -43,6 +43,8 @@ fn new_session_uses_runtime_default_enablement_enabled() {
     let server_config = McpServerConfig {
         id: "test-server".to_string(),
         label: "Test Server".to_string(),
+        description: None,
+        inherited_env_vars: vec![],
         transport: McpTransport::Http {
             config: HttpConfig::new("http://localhost:8080".to_string()),
         },
@@ -80,6 +82,8 @@ fn new_session_uses_runtime_default_enablement_disabled() {
     let server_config = McpServerConfig {
         id: "test-server".to_string(),
         label: "Test Server".to_string(),
+        description: None,
+        inherited_env_vars: vec![],
         transport: McpTransport::Http {
             config: HttpConfig::new("http://localhost:8080".to_string()),
         },
@@ -116,6 +120,8 @@ fn session_toggle_does_not_affect_another_session() {
     let server_config = McpServerConfig {
         id: "test-server".to_string(),
         label: "Test Server".to_string(),
+        description: None,
+        inherited_env_vars: vec![],
         transport: McpTransport::Http {
             config: HttpConfig::new("http://localhost:8080".to_string()),
         },
@@ -176,6 +182,8 @@ fn mcp_state_not_included_in_handoff() {
     let server_config = McpServerConfig {
         id: "test-server".to_string(),
         label: "Test Server".to_string(),
+        description: None,
+        inherited_env_vars: vec![],
         transport: McpTransport::Http {
             config: HttpConfig::new("http://localhost:8080".to_string()),
         },
@@ -242,6 +250,8 @@ async fn imported_session_adopts_destination_runtime_mcp_policy() {
     source_agent.register_mcp_server(McpServerConfig {
         id: "test-server".to_string(),
         label: "Test Server".to_string(),
+        description: None,
+        inherited_env_vars: vec![],
         transport: McpTransport::Http {
             config: HttpConfig::new("http://localhost:8080".to_string()),
         },
@@ -272,6 +282,8 @@ async fn imported_session_adopts_destination_runtime_mcp_policy() {
     destination_agent.register_mcp_server(McpServerConfig {
         id: "test-server".to_string(),
         label: "Test Server".to_string(),
+        description: None,
+        inherited_env_vars: vec![],
         transport: McpTransport::Http {
             config: HttpConfig::new("http://localhost:8080".to_string()),
         },
@@ -311,6 +323,8 @@ fn registering_new_server_materializes_runtime_default_for_existing_sessions() {
     runtime.register_mcp_server(McpServerConfig {
         id: "late-server".to_string(),
         label: "Late Server".to_string(),
+        description: None,
+        inherited_env_vars: vec![],
         transport: McpTransport::Http {
             config: HttpConfig::new("http://localhost:8080".to_string()),
         },

--- a/tests/mcp_visibility_tests.rs
+++ b/tests/mcp_visibility_tests.rs
@@ -14,6 +14,8 @@ fn create_test_registry() -> Arc<McpServerRegistry> {
     let server_config = McpServerConfig {
         id: "test-server".to_string(),
         label: "Test Server".to_string(),
+        description: None,
+        inherited_env_vars: vec![],
         transport: McpTransport::Http {
             config: HttpConfig::new("http://localhost:8080".to_string()),
         },


### PR DESCRIPTION
## Summary
- Add typed ConfigStore APIs for provider runtime config, custom models, default model selection, MCP server definitions, skill settings, and runtime settings snapshots.
- Add schema v2 migrations and validation for shared runtime settings.
- Add MCP inherited env var handling and archive/sync the OpenSpec change.

## Verification
- cargo fmt --check
- cargo check
- cargo test --test config_store_tests
- cargo test mcp::client::tests::sanitized_env
- cargo test
- openspec validate add-runtime-settings-config-store-apis --strict
- openspec validate core-config-store --strict
- openspec validate session-scoped-mcp-support --strict

Closes #67

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Durable runtime settings store (provider configs, custom models, default-model selection, MCP servers, skill settings).
  * Runtime snapshot API to load/validate consolidated runtime configuration.
  * MCP stdio env handling: sanitize parent env, support explicit inherited env var names, and merge/override configured env vars.

* **Documentation**
  * Added specs, design, proposal, and task docs for runtime settings, MCP transport rules, migrations, and validation.

* **Tests**
  * New/updated tests covering CRUD, migrations, snapshot validation, MCP env behavior, and transport scenarios.

* **Chores**
  * Database schema migration to v2 and migration coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->