### PR TITLE
feat(config): integrate custom model registry with runtime

### DIFF
--- a/openspec/changes/archive/2026-06-09-custom-model-runtime-integration/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-09-custom-model-runtime-integration/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-09

--- a/openspec/changes/archive/2026-06-09-custom-model-runtime-integration/design.md
+++ b/openspec/changes/archive/2026-06-09-custom-model-runtime-integration/design.md
@@ -1,0 +1,113 @@
+## Context
+
+Issue #68 asks for ConfigStore-backed custom model registry APIs. The CRUD storage layer already landed via issue #67: `ConfigStore` persists `CustomModelRecord` entries keyed by `(provider_slug, model_id)`, includes validation, and loads them into `RuntimeSettingsSnapshot`. However, those records are structurally disconnected from the runtime. Two separate model metadata systems exist:
+
+1. **ConfigStore custom models** — persisted, validated, snapshot-loaded, but never consumed by runtime code.
+2. **`ModelCapabilityRegistry`** — an in-memory `HashMap<(String, String), ModelCapabilityMetadata>` used by `apply_model_switch()` for capability diffs and context adaptation. Currently populated only in tests via `RuntimeState::register_model_capability()` (line 1561 of runtime.rs), never from ConfigStore or iron-providers data.
+
+There is also no unified "effective model catalog" that merges built-in iron-providers model metadata with custom model records. The runtime resolves providers via `ProviderRegistry::default()` (runtime.rs:479, request_builder.rs:265), but this path has no awareness of custom models.
+
+```
+CURRENT STATE                          TARGET STATE
+─────────────                          ────────────
+
+iron-providers                         iron-providers
+  │                                      │
+  │ ProviderRegistry::default()          │ built-in model metadata
+  ▼                                      ▼
+resolve_managed_provider()          ┌──────────────────────┐
+  │                                 │  EffectiveModelCatalog │
+  │                                 │  built-in + custom     │
+  │                                 └──────┬───────────────┘
+ConfigStore.custom_models                   │
+  │                                         ├── RuntimeState startup
+  ▼                                         ├── ModelCapabilityRegistry
+RuntimeSettingsSnapshot                     ├── Default model validation
+  │ (dead end)                              └── Provider construction path
+  ▼
+  unused
+```
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Define a unified `EffectiveModelCatalog` that merges built-in provider model metadata with ConfigStore custom model records.
+- Bridge custom models into `ModelCapabilityRegistry` so capability diffs, context adaptation, and model switch planning use merged metadata.
+- Add provider-slug validation for custom model writes, verifying the slug matches a known built-in provider or persisted provider config.
+- Extend `CustomModelRecord`/`CustomModelInput` with optional fields needed to fully populate `ModelCapabilityMetadata` (streaming, reasoning effort values).
+- Ensure runtime startup hydrates the capability registry from the effective catalog.
+- Enable default model validation to consider both built-in and custom models.
+
+**Non-Goals:**
+
+- Changing how `ProviderRegistry` constructs provider instances. Provider construction continues to use `ProviderRegistry::default()`.
+- Adding model metadata APIs to `iron-providers`. If iron-providers does not expose a model catalog, this change defines how iron-core handles built-in metadata internally.
+- Migrating AgentIron app settings or custom model data. That is owned by AgentIron#56.
+- Persisting `ModelCapabilityRegistry` separately. It remains a runtime-only structure hydrated from ConfigStore and built-in data.
+- Replacing `ProviderPromptContext` or changing credential resolution paths.
+- Adding a user-facing model catalog browsing API for the frontend in this change.
+
+## Decisions
+
+### D1: Effective model catalog is a runtime-only merge layer, not a new SQLite table
+
+The catalog merges built-in provider knowledge with ConfigStore custom models at runtime. No new database table is needed; the catalog is built by loading built-in metadata and ConfigStore snapshot data, then merging.
+
+**Rationale**: Built-in metadata comes from code or iron-providers, not from ConfigStore. Custom models are already persisted. A runtime merge avoids schema complexity and keeps ConfigStore as the single durable source for custom entries.
+
+### D2: Custom entries extend the catalog; they do not override built-in entries with the same key
+
+If a custom model record has the same `(provider_slug, model_id)` as a built-in entry, the custom record is treated as an error or warning rather than an override. Users who need different metadata for a known model should file an iron-providers issue.
+
+**Rationale**: Allowing overrides creates silent divergence from iron-providers metadata, making debugging harder. The "extend only" model is simpler and safer. If override semantics are needed later, they can be added as an explicit opt-in.
+
+**Alternative considered**: Custom overrides same key (replaces built-in). Rejected because it hides the source of truth and makes it unclear whether behavior comes from iron-providers or ConfigStore.
+
+**Alternative considered**: Field-level overlay. Rejected for v1 because the added complexity (partial overrides, merge semantics for each field) is not justified by current use cases.
+
+### D3: Extend `CustomModelInput`/`CustomModelRecord` with optional fields to map to `ModelCapabilityMetadata`
+
+Add:
+- `supports_streaming: bool` (default true for new custom models)
+- `reasoning_effort_values: Option<Vec<String>>` (empty means not supported)
+
+Do not add `unsupported_tools` to ConfigStore; that is a runtime concern best handled by the catalog consumer, not persisted config.
+
+**Rationale**: The field mapping from `CustomModelRecord` to `ModelCapabilityMetadata` is currently lossy. Adding these fields makes the conversion complete without overcomplicating the persistence layer.
+
+### D4: Provider-slug validation uses a known-providers set, not a SQL foreign key
+
+When `set_custom_model` is called, validate that `provider_slug` matches either:
+1. A built-in provider slug known to `ProviderRegistry::default()`, or
+2. A persisted `ProviderConfigRecord` in ConfigStore.
+
+This validation is informational: it should warn or return a validation error but should not silently reject entries for providers that might be registered dynamically in the future.
+
+**Rationale**: A SQL foreign key to `provider_configs` would block custom models for built-in providers that don't have a persisted row. Rust-level validation is more flexible.
+
+### D5: Built-in model metadata comes from a compiled-in catalog in iron-core
+
+Define a `BUILTIN_MODEL_CATALOG` constant or function in iron-core that provides model metadata for known iron-providers models (context windows, capabilities, etc.). This catalog is maintained alongside iron-providers version updates.
+
+**Rationale**: iron-providers does not currently expose a model catalog API. Rather than blocking on an upstream change, iron-core can maintain its own built-in catalog that is updated when iron-providers is upgraded. If iron-providers later adds a catalog API, the built-in catalog can be replaced.
+
+**Alternative considered**: Querying iron-providers at runtime for model metadata. Rejected because iron-providers `ProviderRegistry` currently has no such API.
+
+### D6: Runtime startup hydrates `ModelCapabilityRegistry` from effective catalog
+
+`RuntimeState` initialization should call a new function that builds the effective catalog (built-in + custom) and registers all entries into `ModelCapabilityRegistry`. This replaces the current empty/test-only population.
+
+**Rationale**: This is the minimal bridge needed to make custom models functional at runtime.
+
+## Risks / Trade-offs
+
+- **[Built-in catalog drift]** → The compiled-in `BUILTIN_MODEL_CATALOG` must be updated when iron-providers adds or changes models. Mitigate by documenting the coupling and adding a note to update the catalog when iron-providers is upgraded.
+- **[Custom model without matching provider]** → Users could add custom models for providers without credentials or a persisted config. The extend-only model means these are valid additions. The runtime will fail at provider construction time if credentials are missing, which is the existing behavior.
+- **[Schema migration for new fields]** → Adding `supports_streaming` and `reasoning_effort_values` to `CustomModelRecord` requires a migration v3 for the `custom_models` table. Mitigate by making new columns nullable with sensible defaults so existing rows migrate cleanly.
+- **[iron-providers catalog API]** → If iron-providers later exposes a model catalog, the built-in catalog in iron-core becomes redundant. The effective catalog abstraction insulates consumers from this change; only the built-in data source needs updating.
+
+## Open Questions
+
+- Should provider-slug validation for custom models be a hard error (reject the write) or a soft warning (allow the write but log)? Proposal: hard error for unknown slugs, with a way to register custom providers via `set_provider_config` first.
+- What is the exact set of built-in models for the initial `BUILTIN_MODEL_CATALOG`? This depends on which providers and models iron-providers currently supports and will be determined during implementation.

--- a/openspec/changes/archive/2026-06-09-custom-model-runtime-integration/design.md
+++ b/openspec/changes/archive/2026-06-09-custom-model-runtime-integration/design.md
@@ -7,7 +7,7 @@ Issue #68 asks for ConfigStore-backed custom model registry APIs. The CRUD stora
 
 There is also no unified "effective model catalog" that merges built-in iron-providers model metadata with custom model records. The runtime resolves providers via `ProviderRegistry::default()` (runtime.rs:479, request_builder.rs:265), but this path has no awareness of custom models.
 
-```
+```text
 CURRENT STATE                          TARGET STATE
 ─────────────                          ────────────
 

--- a/openspec/changes/archive/2026-06-09-custom-model-runtime-integration/proposal.md
+++ b/openspec/changes/archive/2026-06-09-custom-model-runtime-integration/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+ConfigStore already persists custom model records with full CRUD, validation, and snapshot loading (landed via issue #67). However, those records are a dead end: `ModelCapabilityRegistry` (used for model switch planning and capability diffs) is populated only in tests, and there is no "effective model catalog" that merges built-in iron-providers knowledge with ConfigStore custom entries. Custom model metadata never reaches the runtime paths that actually resolve providers, plan model switches, or validate default model selections.
+
+## What Changes
+
+- Add an effective model catalog that merges built-in iron-providers model metadata with ConfigStore custom model records into a unified queryable view.
+- Bridge ConfigStore custom models into `ModelCapabilityRegistry` so custom model capabilities are available for model switch planning, capability comparison, and context adaptation decisions.
+- Add provider-slug validation for custom model records: verify that `provider_slug` corresponds to a known provider (built-in iron-providers or persisted provider config).
+- Extend `CustomModelRecord` fields where needed to support a complete mapping to `ModelCapabilityMetadata` (e.g., streaming support, reasoning effort values).
+- Add a `ModelCatalogProvider` or equivalent trait/type that the runtime can use to enumerate available models, look up capabilities, and validate model selections against both built-in and custom sources.
+- Ensure default model validation in the runtime settings snapshot considers the effective catalog (built-in plus custom) rather than only custom models.
+
+## Capabilities
+
+### New Capabilities
+- `effective-model-catalog`: A unified model catalog that merges built-in iron-providers model metadata with ConfigStore custom model records, providing queryable model lookup, capability metadata, and provider-scoped enumeration.
+
+### Modified Capabilities
+- `core-config-store`: Provider-slug validation for custom model records will reference the effective catalog to verify that model IDs are associated with a known provider slug.
+- `model-switching`: `ModelCapabilityRegistry` will be populated from the effective catalog so that model switch planning, capability diffs, and context adaptation use merged built-in and custom model metadata.
+
+## Impact
+
+- **Core API**: New effective model catalog types in `iron_core::config` or a new module. `ConfigStore` may gain provider-slug validation methods or accept a catalog reference.
+- **Runtime**: `RuntimeState` will hydrate `ModelCapabilityRegistry` from the effective catalog during startup or on settings change, replacing the current empty/test-only population.
+- **Model switching**: Model switch planning and capability comparison gain custom model awareness.
+- **ConfigStore validation**: Custom model writes may require a provider-slug validation step that references known providers.
+- **Schema**: Possible addition of optional fields to `CustomModelInput`/`CustomModelRecord` (e.g., `supports_streaming`, `reasoning_effort_values`) to complete the mapping to `ModelCapabilityMetadata`.
+- **Dependencies**: May require `iron-providers` to expose a model metadata API or catalog if it does not already provide one.

--- a/openspec/changes/archive/2026-06-09-custom-model-runtime-integration/specs/core-config-store/spec.md
+++ b/openspec/changes/archive/2026-06-09-custom-model-runtime-integration/specs/core-config-store/spec.md
@@ -1,0 +1,73 @@
+## MODIFIED Requirements
+
+### Requirement: Config store supports custom model records
+
+The system SHALL provide typed `ConfigStore` APIs for custom model records because custom models are shared runtime configuration required by app and headless provider/model selection. Custom model records SHALL be keyed by provider slug and model ID and SHALL include display, context window, output limit, capability, cost, streaming, reasoning effort, and store-maintained timestamp metadata.
+
+#### Scenario: Custom model roundtrips
+- **WHEN** a caller stores a custom model for a provider slug and model ID
+- **THEN** the caller can retrieve the custom model by the same provider slug and model ID
+- **AND** model metadata such as display name, context window, output limit, capabilities, costs, streaming support, and reasoning effort values roundtrips through typed fields
+
+#### Scenario: Custom models list by provider
+- **WHEN** a caller lists custom models for a provider slug
+- **THEN** the system returns only custom models associated with that provider slug
+
+#### Scenario: Starred models remain outside core config
+- **WHEN** a caller needs app-specific starred model preferences
+- **THEN** those preferences are not represented by the core custom model APIs
+- **AND** the app remains responsible for starred model persistence
+
+### Requirement: Config store exposes a runtime settings snapshot
+
+The system SHALL provide a `ConfigStore` API that loads a validated runtime settings snapshot containing provider configs, custom models, default model selection, MCP server definitions, and skill settings. The snapshot SHALL centralize cross-record validation and interpretation needed by app and headless runtime startup. Default model validation SHALL consider both built-in model metadata and custom model records from ConfigStore.
+
+#### Scenario: Headless runtime loads shared settings
+- **WHEN** a headless consumer opens the config store and loads the runtime settings snapshot
+- **THEN** it receives the same shared runtime settings available to the app through typed `iron_core::config` APIs
+- **AND** it does not read SQLite tables or app-owned settings JSON directly
+
+#### Scenario: Snapshot validates cross-record settings
+- **WHEN** persisted runtime settings contain invalid IDs, malformed transport fields, malformed JSON collections, or invalid default model fields
+- **THEN** loading the runtime settings snapshot returns an actionable `ConfigError`
+- **AND** invalid settings are not silently projected into runtime startup
+
+#### Scenario: Snapshot supports missing/default config behavior
+- **WHEN** optional runtime settings have not yet been persisted
+- **THEN** snapshot loading applies documented missing/default behavior instead of requiring callers to know table-level details
+
+#### Scenario: Snapshot validates default model against effective catalog
+- **WHEN** a default model is set to a provider/model combination
+- **THEN** validation checks the effective model catalog (built-in plus custom) rather than only custom model records
+
+## ADDED Requirements
+
+### Requirement: Config store SHALL validate custom model provider slugs against known providers
+
+When storing a custom model record, the system SHALL validate that the `provider_slug` matches either a built-in provider slug known to `ProviderRegistry::default()` or a persisted `ProviderConfigRecord`. Unknown provider slugs SHALL result in a validation error.
+
+#### Scenario: Custom model for built-in provider
+- **WHEN** a caller stores a custom model with a provider slug matching a built-in provider (e.g., `openai`, `anthropic`)
+- **THEN** validation passes
+
+#### Scenario: Custom model for persisted provider config
+- **WHEN** a caller stores a custom model with a provider slug matching a persisted `ProviderConfigRecord`
+- **THEN** validation passes
+
+#### Scenario: Custom model for unknown provider
+- **WHEN** a caller stores a custom model with a provider slug that matches neither a built-in provider nor a persisted provider config
+- **THEN** the API returns a `ConfigError` indicating the provider slug is not recognized
+
+### Requirement: Custom model schema SHALL support streaming and reasoning effort metadata
+
+The `custom_models` SQLite table and corresponding input/record types SHALL include `supports_streaming` and `reasoning_effort_values` fields. Migration v3 SHALL add these columns with defaults that preserve existing row semantics.
+
+#### Scenario: Migration v3 adds streaming column
+- **WHEN** a v2 config database is opened by the updated code
+- **THEN** migration v3 adds `supports_streaming` with a default of 1 (true)
+- **AND** existing custom model rows retain their effective behavior
+
+#### Scenario: Migration v3 adds reasoning effort values column
+- **WHEN** a v2 config database is opened by the updated code
+- **THEN** migration v3 adds `reasoning_effort_values_json` as NULL by default
+- **AND** existing custom model rows are not affected

--- a/openspec/changes/archive/2026-06-09-custom-model-runtime-integration/specs/effective-model-catalog/spec.md
+++ b/openspec/changes/archive/2026-06-09-custom-model-runtime-integration/specs/effective-model-catalog/spec.md
@@ -1,0 +1,90 @@
+## ADDED Requirements
+
+### Requirement: The runtime SHALL provide an effective model catalog merging built-in and custom model metadata
+
+The system SHALL provide an `EffectiveModelCatalog` that merges built-in provider model metadata with ConfigStore custom model records into a unified queryable view. The catalog SHALL be a runtime-only structure built by loading built-in metadata and ConfigStore snapshot data.
+
+#### Scenario: Catalog includes built-in models
+- **WHEN** the effective model catalog is built
+- **THEN** it includes model metadata from the compiled-in built-in model catalog
+- **AND** each built-in entry includes provider slug, model ID, context window, capabilities, and modality information
+
+#### Scenario: Catalog includes custom models
+- **WHEN** the effective model catalog is built and ConfigStore contains custom model records
+- **THEN** it includes all custom model entries alongside built-in entries
+- **AND** each custom entry is queryable by provider slug and model ID
+
+#### Scenario: Custom entries extend, not override, built-in entries
+- **WHEN** a custom model record has the same `(provider_slug, model_id)` as a built-in entry
+- **THEN** the catalog construction SHALL reject or flag the duplicate rather than silently overriding built-in metadata
+
+#### Scenario: Catalog lookup by provider and model
+- **WHEN** a caller queries the effective model catalog for a specific provider slug and model ID
+- **THEN** the catalog returns matching model metadata whether it is built-in or custom
+- **AND** returns `None` if no matching entry exists
+
+#### Scenario: Catalog listing by provider
+- **WHEN** a caller lists catalog entries for a specific provider slug
+- **THEN** the catalog returns all matching entries including both built-in and custom models for that provider
+
+### Requirement: The system SHALL maintain a compiled-in built-in model catalog
+
+The system SHALL include a compiled-in catalog of model metadata for known iron-providers models. This catalog SHALL be maintained alongside iron-providers version updates and SHALL include context windows, capabilities, modalities, and cost metadata for each known model.
+
+#### Scenario: Built-in catalog covers known providers
+- **WHEN** the built-in model catalog is loaded
+- **THEN** it includes model metadata for each provider and model known to the compiled iron-providers version
+- **AND** metadata includes context window, tool support, streaming support, reasoning effort support, and supported modalities
+
+#### Scenario: Built-in catalog is updated with iron-providers upgrades
+- **WHEN** iron-providers is upgraded to a new version
+- **THEN** the built-in model catalog SHOULD be reviewed and updated to reflect new or changed models
+
+### Requirement: The runtime SHALL hydrate ModelCapabilityRegistry from the effective catalog
+
+The runtime SHALL populate `ModelCapabilityRegistry` from the effective model catalog during startup or runtime settings initialization. All built-in and custom model entries SHALL be registered into the capability registry so that model switch planning, capability comparison, and context adaptation use merged metadata.
+
+#### Scenario: Runtime startup registers all catalog entries
+- **WHEN** the runtime initializes and the effective model catalog is available
+- **THEN** all catalog entries are registered into `ModelCapabilityRegistry`
+- **AND** `apply_model_switch()` can query capabilities for both built-in and custom models
+
+#### Scenario: Runtime startup without custom models
+- **WHEN** the runtime initializes and no custom models exist in ConfigStore
+- **THEN** only built-in model entries are registered into `ModelCapabilityRegistry`
+
+#### Scenario: Catalog entries map to capability metadata
+- **WHEN** a custom model entry is registered into `ModelCapabilityRegistry`
+- **THEN** the custom model's capabilities, context window, modalities, and streaming support are mapped to `ModelCapabilityMetadata` fields
+
+### Requirement: Custom model records SHALL support streaming and reasoning effort metadata
+
+`CustomModelInput` and `CustomModelRecord` SHALL include optional fields for streaming support and reasoning effort values to enable a complete mapping to `ModelCapabilityMetadata`.
+
+#### Scenario: Custom model with streaming metadata
+- **WHEN** a caller stores a custom model with `supports_streaming` set to false
+- **THEN** the runtime capability registry reflects that the model does not support streaming
+
+#### Scenario: Custom model with reasoning effort values
+- **WHEN** a caller stores a custom model with `reasoning_effort_values` set to a non-empty list
+- **THEN** the runtime capability registry reflects those reasoning effort values for capability comparison during model switches
+
+#### Scenario: Custom model with default streaming metadata
+- **WHEN** a caller stores a custom model without specifying streaming or reasoning effort
+- **THEN** streaming defaults to true and reasoning effort values default to empty
+
+### Requirement: Default model validation SHALL consider the effective catalog
+
+When validating default model selection in the runtime settings snapshot, the system SHALL check that the selected `(provider_slug, model_id)` exists in the effective model catalog (built-in plus custom), not only in the custom models table.
+
+#### Scenario: Default model is a built-in model
+- **WHEN** the default model is set to a built-in provider/model combination
+- **THEN** validation passes because the entry exists in the effective catalog
+
+#### Scenario: Default model is a custom model
+- **WHEN** the default model is set to a custom model entry
+- **THEN** validation passes because the entry exists in the effective catalog
+
+#### Scenario: Default model is unknown
+- **WHEN** the default model is set to a provider/model combination that does not exist in either built-in or custom entries
+- **THEN** validation returns an actionable error

--- a/openspec/changes/archive/2026-06-09-custom-model-runtime-integration/specs/model-switching/spec.md
+++ b/openspec/changes/archive/2026-06-09-custom-model-runtime-integration/specs/model-switching/spec.md
@@ -1,0 +1,29 @@
+## MODIFIED Requirements
+
+### Requirement: The runtime SHALL reconcile capabilities between source and target models
+
+The runtime SHALL compare the source and target model capabilities and report differences to the client. Tools, modalities, and features unsupported by the target model SHALL be hidden or disabled. Capability comparison SHALL use `ModelCapabilityRegistry` populated from the effective model catalog, covering both built-in and custom models.
+
+#### Scenario: Target supports same tools
+- **WHEN** switching to a model that supports the same tools as the current model
+- **THEN** all currently visible tools remain available
+- **AND** no capability difference report is generated
+
+#### Scenario: Target lacks some tools
+- **WHEN** switching to a model that does not support some currently visible tools
+- **THEN** unsupported tools are hidden from the effective tool catalog
+- **AND** the client receives a report listing the unavailable tools
+
+#### Scenario: Target lacks image support
+- **WHEN** switching to a model that does not support image input
+- **THEN** the runtime flags that image content may not be processable
+- **AND** the client receives a capability difference report
+
+#### Scenario: Switching between built-in and custom models
+- **WHEN** switching from a built-in model to a custom model or vice versa
+- **THEN** the capability comparison uses effective catalog metadata for both models
+- **AND** the capability diff reflects the merged built-in and custom model metadata
+
+#### Scenario: Switching to an unregistered custom model
+- **WHEN** switching to a model not present in the effective catalog
+- **THEN** the runtime rejects the switch with an error indicating the model is unknown

--- a/openspec/changes/archive/2026-06-09-custom-model-runtime-integration/tasks.md
+++ b/openspec/changes/archive/2026-06-09-custom-model-runtime-integration/tasks.md
@@ -1,0 +1,60 @@
+## 1. Built-in Model Catalog
+
+- [x] 1.1 Create `src/config/builtin_models.rs` with a `BuiltinModelEntry` struct containing provider slug, model ID, context window, tool support, streaming support, reasoning effort support and values, supported modalities, and unsupported tools.
+- [x] 1.2 Add a `builtin_model_catalog()` function returning `Vec<BuiltinModelEntry>` with metadata for known iron-providers models (OpenAI, Anthropic, Google, and other supported providers).
+- [x] 1.3 Add unit tests verifying the built-in catalog is non-empty, entries have non-empty provider slugs and model IDs, and context windows are positive.
+
+## 2. Custom Model Record Extension
+
+- [x] 2.1 Add `supports_streaming: bool` and `reasoning_effort_values: Vec<String>` fields to `CustomModelInput` in `src/config/records.rs`.
+- [x] 2.2 Add corresponding fields to `CustomModelRecord` in `src/config/records.rs`.
+- [x] 2.3 Add SQLite migration v3 to `src/config/migrations.rs` adding `supports_streaming INTEGER NOT NULL DEFAULT 1` and `reasoning_effort_values_json TEXT NULL` columns to `custom_models`.
+- [x] 2.4 Update `set_custom_model` in `src/config/store.rs` to serialize/deserialize the new fields.
+- [x] 2.5 Update `get_custom_model`, `list_custom_models`, and `load_runtime_settings` to read the new columns with backward-compatible defaults for existing rows.
+
+## 3. Provider-Slug Validation
+
+- [x] 3.1 Add a `known_provider_slugs()` function or method that returns the union of built-in provider slugs from `ProviderRegistry::default()` and persisted `ProviderConfigRecord` slugs from ConfigStore.
+- [x] 3.2 Add provider-slug validation to `set_custom_model` that checks the provider slug against `known_provider_slugs()` and returns `ConfigError` for unrecognized slugs.
+- [x] 3.3 Add tests for provider-slug validation: valid built-in slug, valid persisted slug, unknown slug rejection.
+
+## 4. Effective Model Catalog
+
+- [x] 4.1 Create `src/config/effective_catalog.rs` with an `EffectiveModelCatalog` struct containing a merged collection of model entries keyed by `(provider_slug, model_id)`.
+- [x] 4.2 Add an `EffectiveModelEntry` type that represents a unified model record with provider slug, model ID, display name, context window, output limit, capabilities (tools, streaming, reasoning effort, vision/modalities), and cost metadata.
+- [x] 4.3 Add a `build_effective_catalog(builtin: &[BuiltinModelEntry], custom: &[CustomModelRecord]) -> Result<EffectiveModelCatalog, CatalogError>` function that merges built-in and custom entries.
+- [x] 4.4 Implement extend-only semantics: if a custom entry duplicates a built-in `(provider_slug, model_id)`, return an error or warning rather than overriding.
+- [x] 4.5 Add `get(provider: &str, model: &str) -> Option<&EffectiveModelEntry>` and `list_for_provider(provider: &str) -> Vec<&EffectiveModelEntry>` query methods.
+- [x] 4.6 Add a conversion from `EffectiveModelEntry` to `ModelCapabilityMetadata` for bridging into the capability registry.
+- [x] 4.7 Add tests for catalog construction, built-in/custom merge, extend-only duplicate detection, lookup, and provider-scoped listing.
+
+## 5. Runtime Integration
+
+- [x] 5.1 Add a method or function on `RuntimeState` that builds the effective catalog from built-in metadata and `RuntimeSettingsSnapshot.custom_models`, then registers all entries into `ModelCapabilityRegistry`.
+- [x] 5.2 Call the catalog hydration method during runtime initialization so the capability registry is populated before any model switch or capability comparison can occur.
+- [x] 5.3 Update default model validation in the snapshot loader to check the effective catalog (built-in plus custom) rather than only the custom models table.
+- [x] 5.4 Add integration tests verifying that custom models registered via ConfigStore appear in `ModelCapabilityRegistry` lookups.
+- [x] 5.5 Add integration tests verifying model switch capability diffs include custom model metadata.
+
+## 6. Schema Migration Tests
+
+- [x] 6.1 Add migration tests for v2-to-v3 upgrade on the `custom_models` table, verifying new columns have correct defaults.
+- [x] 6.2 Add migration tests for opening a v3 database without re-running migration.
+- [x] 6.3 Add tests for custom model round-trips with `supports_streaming` and `reasoning_effort_values` fields.
+- [x] 6.4 Add tests for custom model round-trips where new fields use defaults (existing-row backward compatibility).
+
+## 7. Documentation and Verification
+
+- [x] 7.1 Document the effective model catalog API and its extend-only merge semantics.
+- [x] 7.2 Document the custom model record field extensions and migration v3.
+- [x] 7.3 Document provider-slug validation behavior for custom model writes.
+- [x] 7.4 Run focused config store and catalog tests.
+- [x] 7.5 Run `cargo check` on the workspace root (this is the iron-core crate; no `src-tauri/Cargo.toml` exists).
+- [x] 7.6 Run `openspec status --change custom-model-runtime-integration` or the repo-supported OpenSpec validation command.
+
+## Verification Summary
+
+- `cargo check`: passed
+- `cargo clippy --all-targets`: passed (no warnings)
+- `cargo fmt -- --check`: passed
+- `cargo test`: passed — 391 unit tests, 88 ACP runtime tests, 49 builtin tool tests, 42 config store tests, 9 config tests, 81 context management tests, 8 interop tests, 6 MCP e2e tests, 22 MCP integration tests, 15 MCP outstanding tests, 6 MCP tests, 3 MCP visibility tests, 33 prompt composition tests, 10 tool tests, 3 transport bench tests

--- a/openspec/specs/core-config-store/spec.md
+++ b/openspec/specs/core-config-store/spec.md
@@ -244,12 +244,12 @@ The system SHALL provide typed `ConfigStore` APIs for provider runtime configura
 
 ### Requirement: Config store supports custom model records
 
-The system SHALL provide typed `ConfigStore` APIs for custom model records because custom models are shared runtime configuration required by app and headless provider/model selection. Custom model records SHALL be keyed by provider slug and model ID and SHALL include display, context window, output limit, capability, cost, and store-maintained timestamp metadata.
+The system SHALL provide typed `ConfigStore` APIs for custom model records because custom models are shared runtime configuration required by app and headless provider/model selection. Custom model records SHALL be keyed by provider slug and model ID and SHALL include display, context window, output limit, capability, cost, streaming, reasoning effort, and store-maintained timestamp metadata.
 
 #### Scenario: Custom model roundtrips
 - **WHEN** a caller stores a custom model for a provider slug and model ID
 - **THEN** the caller can retrieve the custom model by the same provider slug and model ID
-- **AND** model metadata such as display name, context window, output limit, capabilities, and costs roundtrips through typed fields
+- **AND** model metadata such as display name, context window, output limit, capabilities, costs, streaming support, and reasoning effort values roundtrips through typed fields
 
 #### Scenario: Custom models list by provider
 - **WHEN** a caller lists custom models for a provider slug
@@ -259,6 +259,36 @@ The system SHALL provide typed `ConfigStore` APIs for custom model records becau
 - **WHEN** a caller needs app-specific starred model preferences
 - **THEN** those preferences are not represented by the core custom model APIs
 - **AND** the app remains responsible for starred model persistence
+
+### Requirement: Config store SHALL validate custom model provider slugs against known providers
+
+When storing a custom model record, the system SHALL validate that the `provider_slug` matches either a built-in provider slug known to `ProviderRegistry::default()` or a persisted `ProviderConfigRecord`. Unknown provider slugs SHALL result in a validation error.
+
+#### Scenario: Custom model for built-in provider
+- **WHEN** a caller stores a custom model with a provider slug matching a built-in provider (e.g., `openai`, `anthropic`)
+- **THEN** validation passes
+
+#### Scenario: Custom model for persisted provider config
+- **WHEN** a caller stores a custom model with a provider slug matching a persisted `ProviderConfigRecord`
+- **THEN** validation passes
+
+#### Scenario: Custom model for unknown provider
+- **WHEN** a caller stores a custom model with a provider slug that matches neither a built-in provider nor a persisted provider config
+- **THEN** the API returns a `ConfigError` indicating the provider slug is not recognized
+
+### Requirement: Custom model schema SHALL support streaming and reasoning effort metadata
+
+The `custom_models` SQLite table and corresponding input/record types SHALL include `supports_streaming` and `reasoning_effort_values` fields. Migration v3 SHALL add these columns with defaults that preserve existing row semantics.
+
+#### Scenario: Migration v3 adds streaming column
+- **WHEN** a v2 config database is opened by the updated code
+- **THEN** migration v3 adds `supports_streaming` with a default of 1 (true)
+- **AND** existing custom model rows retain their effective behavior
+
+#### Scenario: Migration v3 adds reasoning effort values column
+- **WHEN** a v2 config database is opened by the updated code
+- **THEN** migration v3 adds `reasoning_effort_values_json` as NULL by default
+- **AND** existing custom model rows are not affected
 
 ### Requirement: Config store supports typed default model selection
 
@@ -306,7 +336,7 @@ The system SHALL provide typed `ConfigStore` APIs for skill settings used by run
 
 ### Requirement: Config store exposes a runtime settings snapshot
 
-The system SHALL provide a `ConfigStore` API that loads a validated runtime settings snapshot containing provider configs, custom models, default model selection, MCP server definitions, and skill settings. The snapshot SHALL centralize cross-record validation and interpretation needed by app and headless runtime startup.
+The system SHALL provide a `ConfigStore` API that loads a validated runtime settings snapshot containing provider configs, custom models, default model selection, MCP server definitions, and skill settings. The snapshot SHALL centralize cross-record validation and interpretation needed by app and headless runtime startup. Default model validation SHALL consider both built-in model metadata and custom model records from ConfigStore.
 
 #### Scenario: Headless runtime loads shared settings
 - **WHEN** a headless consumer opens the config store and loads the runtime settings snapshot
@@ -321,6 +351,10 @@ The system SHALL provide a `ConfigStore` API that loads a validated runtime sett
 #### Scenario: Snapshot supports missing/default config behavior
 - **WHEN** optional runtime settings have not yet been persisted
 - **THEN** snapshot loading applies documented missing/default behavior instead of requiring callers to know table-level details
+
+#### Scenario: Snapshot validates default model against effective catalog
+- **WHEN** a default model is set to a provider/model combination
+- **THEN** validation checks the effective model catalog (built-in plus custom) rather than only custom model records
 
 ### Requirement: Runtime settings schema is migrated on open
 

--- a/openspec/specs/effective-model-catalog/spec.md
+++ b/openspec/specs/effective-model-catalog/spec.md
@@ -1,0 +1,94 @@
+## Purpose
+
+Define the runtime model catalog that merges built-in provider model metadata with ConfigStore custom model records for capability lookup, default model validation, and model-switch planning.
+
+## Requirements
+
+### Requirement: The runtime SHALL provide an effective model catalog merging built-in and custom model metadata
+
+The system SHALL provide an `EffectiveModelCatalog` that merges built-in provider model metadata with ConfigStore custom model records into a unified queryable view. The catalog SHALL be a runtime-only structure built by loading built-in metadata and ConfigStore snapshot data.
+
+#### Scenario: Catalog includes built-in models
+- **WHEN** the effective model catalog is built
+- **THEN** it includes model metadata from the compiled-in built-in model catalog
+- **AND** each built-in entry includes provider slug, model ID, context window, capabilities, and modality information
+
+#### Scenario: Catalog includes custom models
+- **WHEN** the effective model catalog is built and ConfigStore contains custom model records
+- **THEN** it includes all custom model entries alongside built-in entries
+- **AND** each custom entry is queryable by provider slug and model ID
+
+#### Scenario: Custom entries extend, not override, built-in entries
+- **WHEN** a custom model record has the same `(provider_slug, model_id)` as a built-in entry
+- **THEN** the catalog construction SHALL reject or flag the duplicate rather than silently overriding built-in metadata
+
+#### Scenario: Catalog lookup by provider and model
+- **WHEN** a caller queries the effective model catalog for a specific provider slug and model ID
+- **THEN** the catalog returns matching model metadata whether it is built-in or custom
+- **AND** returns `None` if no matching entry exists
+
+#### Scenario: Catalog listing by provider
+- **WHEN** a caller lists catalog entries for a specific provider slug
+- **THEN** the catalog returns all matching entries including both built-in and custom models for that provider
+
+### Requirement: The system SHALL maintain a compiled-in built-in model catalog
+
+The system SHALL include a compiled-in catalog of model metadata for known iron-providers models. This catalog SHALL be maintained alongside iron-providers version updates and SHALL include context windows, capabilities, modalities, and cost metadata for each known model.
+
+#### Scenario: Built-in catalog covers known providers
+- **WHEN** the built-in model catalog is loaded
+- **THEN** it includes model metadata for each provider and model known to the compiled iron-providers version
+- **AND** metadata includes context window, tool support, streaming support, reasoning effort support, and supported modalities
+
+#### Scenario: Built-in catalog is updated with iron-providers upgrades
+- **WHEN** iron-providers is upgraded to a new version
+- **THEN** the built-in model catalog SHOULD be reviewed and updated to reflect new or changed models
+
+### Requirement: The runtime SHALL hydrate ModelCapabilityRegistry from the effective catalog
+
+The runtime SHALL populate `ModelCapabilityRegistry` from the effective model catalog during startup or runtime settings initialization. All built-in and custom model entries SHALL be registered into the capability registry so that model switch planning, capability comparison, and context adaptation use merged metadata.
+
+#### Scenario: Runtime startup registers all catalog entries
+- **WHEN** the runtime initializes and the effective model catalog is available
+- **THEN** all catalog entries are registered into `ModelCapabilityRegistry`
+- **AND** `apply_model_switch()` can query capabilities for both built-in and custom models
+
+#### Scenario: Runtime startup without custom models
+- **WHEN** the runtime initializes and no custom models exist in ConfigStore
+- **THEN** only built-in model entries are registered into `ModelCapabilityRegistry`
+
+#### Scenario: Catalog entries map to capability metadata
+- **WHEN** a custom model entry is registered into `ModelCapabilityRegistry`
+- **THEN** the custom model's capabilities, context window, modalities, and streaming support are mapped to `ModelCapabilityMetadata` fields
+
+### Requirement: Custom model records SHALL support streaming and reasoning effort metadata
+
+`CustomModelInput` and `CustomModelRecord` SHALL include optional fields for streaming support and reasoning effort values to enable a complete mapping to `ModelCapabilityMetadata`.
+
+#### Scenario: Custom model with streaming metadata
+- **WHEN** a caller stores a custom model with `supports_streaming` set to false
+- **THEN** the runtime capability registry reflects that the model does not support streaming
+
+#### Scenario: Custom model with reasoning effort values
+- **WHEN** a caller stores a custom model with `reasoning_effort_values` set to a non-empty list
+- **THEN** the runtime capability registry reflects those reasoning effort values for capability comparison during model switches
+
+#### Scenario: Custom model with default streaming metadata
+- **WHEN** a caller stores a custom model without specifying streaming or reasoning effort
+- **THEN** streaming defaults to true and reasoning effort values default to empty
+
+### Requirement: Default model validation SHALL consider the effective catalog
+
+When validating default model selection in the runtime settings snapshot, the system SHALL check that the selected `(provider_slug, model_id)` exists in the effective model catalog (built-in plus custom), not only in the custom models table.
+
+#### Scenario: Default model is a built-in model
+- **WHEN** the default model is set to a built-in provider/model combination
+- **THEN** validation passes because the entry exists in the effective catalog
+
+#### Scenario: Default model is a custom model
+- **WHEN** the default model is set to a custom model entry
+- **THEN** validation passes because the entry exists in the effective catalog
+
+#### Scenario: Default model is unknown
+- **WHEN** the default model is set to a provider/model combination that does not exist in either built-in or custom entries
+- **THEN** validation returns an actionable error

--- a/openspec/specs/model-switching/spec.md
+++ b/openspec/specs/model-switching/spec.md
@@ -51,7 +51,7 @@ When switching to a model with a smaller context window than the current context
 - **AND** the user is advised to start a new session or manually compact context
 
 ### Requirement: The runtime SHALL reconcile capabilities between source and target models
-The runtime SHALL compare the source and target model capabilities and report differences to the client. Tools, modalities, and features unsupported by the target model SHALL be hidden or disabled.
+The runtime SHALL compare the source and target model capabilities and report differences to the client. Tools, modalities, and features unsupported by the target model SHALL be hidden or disabled. Capability comparison SHALL use `ModelCapabilityRegistry` populated from the effective model catalog, covering both built-in and custom models.
 
 #### Scenario: Target supports same tools
 - **WHEN** switching to a model that supports the same tools as the current model
@@ -67,6 +67,15 @@ The runtime SHALL compare the source and target model capabilities and report di
 - **WHEN** switching to a model that does not support image input
 - **THEN** the runtime flags that image content may not be processable
 - **AND** the client receives a capability difference report
+
+#### Scenario: Switching between built-in and custom models
+- **WHEN** switching from a built-in model to a custom model or vice versa
+- **THEN** the capability comparison uses effective catalog metadata for both models
+- **AND** the capability diff reflects the merged built-in and custom model metadata
+
+#### Scenario: Switching to an unregistered custom model
+- **WHEN** switching to a model not present in the effective catalog
+- **THEN** the runtime rejects the switch with an error indicating the model is unknown
 
 ### Requirement: Model switches SHALL be recorded per-turn in session metadata
 Each user and assistant turn SHALL record the model used for that turn. The session metadata SHALL track the current model and maintain a history of model switches.

--- a/src/config/builtin_models.rs
+++ b/src/config/builtin_models.rs
@@ -1,0 +1,254 @@
+//! Compiled-in model metadata for known iron-providers models.
+//!
+//! This catalog is maintained alongside the iron-providers version used by
+//! iron-core. When iron-providers is upgraded, this catalog should be reviewed
+//! and updated to reflect new or changed models.
+
+/// Metadata for a single built-in model entry.
+#[derive(Debug, Clone, PartialEq)]
+pub struct BuiltinModelEntry {
+    /// Provider slug (e.g., "openai", "anthropic").
+    pub provider_slug: String,
+    /// Model identifier passed to the provider API.
+    pub model_id: String,
+    /// Human-readable display name.
+    pub display_name: String,
+    /// Context window in tokens, if known.
+    pub context_window: Option<usize>,
+    /// Maximum output tokens, if known.
+    pub output_limit: Option<u32>,
+    /// Whether the model supports tool calls.
+    pub supports_tool_calls: bool,
+    /// Whether the model supports reasoning / reasoning effort.
+    pub supports_reasoning: bool,
+    /// Supported reasoning effort values, if applicable.
+    pub reasoning_effort_values: Vec<String>,
+    /// Whether the model supports vision / image input.
+    pub supports_vision: bool,
+    /// Whether the model supports streaming responses.
+    pub supports_streaming: bool,
+    /// Modalities supported by this model (e.g., "text", "image").
+    pub supported_modalities: Vec<String>,
+    /// Tools known to be unsupported by this model.
+    pub unsupported_tools: Vec<String>,
+}
+
+impl BuiltinModelEntry {
+    /// Create a new built-in model entry with sensible defaults.
+    pub fn new(provider_slug: impl Into<String>, model_id: impl Into<String>) -> Self {
+        Self {
+            provider_slug: provider_slug.into(),
+            model_id: model_id.into(),
+            display_name: String::new(),
+            context_window: None,
+            output_limit: None,
+            supports_tool_calls: false,
+            supports_reasoning: false,
+            reasoning_effort_values: Vec::new(),
+            supports_vision: false,
+            supports_streaming: true,
+            supported_modalities: vec!["text".to_string()],
+            unsupported_tools: Vec::new(),
+        }
+    }
+
+    /// Set the display name.
+    pub fn with_display_name(mut self, name: impl Into<String>) -> Self {
+        self.display_name = name.into();
+        self
+    }
+
+    /// Set the context window.
+    pub fn with_context_window(mut self, window: usize) -> Self {
+        self.context_window = Some(window);
+        self
+    }
+
+    /// Set the output limit.
+    pub fn with_output_limit(mut self, limit: u32) -> Self {
+        self.output_limit = Some(limit);
+        self
+    }
+
+    /// Enable tool call support.
+    pub fn with_tools(mut self) -> Self {
+        self.supports_tool_calls = true;
+        self
+    }
+
+    /// Enable reasoning support with optional accepted values.
+    pub fn with_reasoning(mut self, values: Vec<impl Into<String>>) -> Self {
+        self.supports_reasoning = !values.is_empty();
+        self.reasoning_effort_values = values.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Enable vision / image input support.
+    pub fn with_vision(mut self) -> Self {
+        self.supports_vision = true;
+        if !self.supported_modalities.contains(&"image".to_string()) {
+            self.supported_modalities.push("image".to_string());
+        }
+        self
+    }
+
+    /// Disable streaming support.
+    pub fn without_streaming(mut self) -> Self {
+        self.supports_streaming = false;
+        self
+    }
+
+    /// Set supported modalities.
+    pub fn with_modalities(mut self, modalities: Vec<impl Into<String>>) -> Self {
+        self.supported_modalities = modalities.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Set unsupported tools.
+    pub fn with_unsupported_tools(mut self, tools: Vec<impl Into<String>>) -> Self {
+        self.unsupported_tools = tools.into_iter().map(Into::into).collect();
+        self
+    }
+}
+
+/// Return the compiled-in catalog of known iron-providers models.
+///
+/// This catalog should be kept in sync with the iron-providers version used
+/// by iron-core. When adding a new provider or model, update this list and
+/// add a corresponding entry to the test suite.
+pub fn builtin_model_catalog() -> Vec<BuiltinModelEntry> {
+    vec![
+        // OpenAI
+        BuiltinModelEntry::new("openai", "gpt-4o")
+            .with_display_name("GPT-4o")
+            .with_context_window(128_000)
+            .with_output_limit(16_384)
+            .with_tools()
+            .with_vision(),
+        BuiltinModelEntry::new("openai", "gpt-4o-mini")
+            .with_display_name("GPT-4o Mini")
+            .with_context_window(128_000)
+            .with_output_limit(16_384)
+            .with_tools()
+            .with_vision(),
+        BuiltinModelEntry::new("openai", "o3-mini")
+            .with_display_name("o3-mini")
+            .with_context_window(200_000)
+            .with_output_limit(100_000)
+            .with_tools()
+            .with_reasoning(vec!["low", "medium", "high"]),
+        BuiltinModelEntry::new("openai", "o1")
+            .with_display_name("o1")
+            .with_context_window(200_000)
+            .with_output_limit(100_000)
+            .with_tools()
+            .with_reasoning(vec!["low", "medium", "high"]),
+        BuiltinModelEntry::new("openai", "o1-mini")
+            .with_display_name("o1-mini")
+            .with_context_window(128_000)
+            .with_output_limit(65_536)
+            .with_tools()
+            .with_reasoning(vec!["low", "medium", "high"]),
+        // Anthropic
+        BuiltinModelEntry::new("anthropic", "claude-3-7-sonnet-20250219")
+            .with_display_name("Claude 3.7 Sonnet")
+            .with_context_window(200_000)
+            .with_output_limit(8_192)
+            .with_tools()
+            .with_vision(),
+        BuiltinModelEntry::new("anthropic", "claude-3-5-sonnet-20241022")
+            .with_display_name("Claude 3.5 Sonnet")
+            .with_context_window(200_000)
+            .with_output_limit(8_192)
+            .with_tools()
+            .with_vision(),
+        BuiltinModelEntry::new("anthropic", "claude-3-5-haiku-20241022")
+            .with_display_name("Claude 3.5 Haiku")
+            .with_context_window(200_000)
+            .with_output_limit(8_192)
+            .with_tools(),
+        BuiltinModelEntry::new("anthropic", "claude-3-opus-20240229")
+            .with_display_name("Claude 3 Opus")
+            .with_context_window(200_000)
+            .with_output_limit(4_096)
+            .with_tools()
+            .with_vision(),
+        // Google
+        BuiltinModelEntry::new("google", "gemini-2.0-flash-001")
+            .with_display_name("Gemini 2.0 Flash")
+            .with_context_window(1_048_576)
+            .with_output_limit(8_192)
+            .with_tools()
+            .with_vision(),
+        BuiltinModelEntry::new("google", "gemini-1.5-pro-002")
+            .with_display_name("Gemini 1.5 Pro")
+            .with_context_window(2_097_152)
+            .with_output_limit(8_192)
+            .with_tools()
+            .with_vision(),
+        BuiltinModelEntry::new("google", "gemini-1.5-flash-002")
+            .with_display_name("Gemini 1.5 Flash")
+            .with_context_window(1_048_576)
+            .with_output_limit(8_192)
+            .with_tools()
+            .with_vision(),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_builtin_catalog_is_non_empty() {
+        let catalog = builtin_model_catalog();
+        assert!(
+            !catalog.is_empty(),
+            "Built-in model catalog must not be empty"
+        );
+    }
+
+    #[test]
+    fn test_builtin_entries_have_non_empty_ids() {
+        for entry in builtin_model_catalog() {
+            assert!(
+                !entry.provider_slug.trim().is_empty(),
+                "Built-in entry must have a non-empty provider slug"
+            );
+            assert!(
+                !entry.model_id.trim().is_empty(),
+                "Built-in entry must have a non-empty model ID"
+            );
+            assert!(
+                !entry.display_name.trim().is_empty(),
+                "Built-in entry must have a non-empty display name"
+            );
+        }
+    }
+
+    #[test]
+    fn test_builtin_entries_have_positive_context_window_when_set() {
+        for entry in builtin_model_catalog() {
+            if let Some(window) = entry.context_window {
+                assert!(
+                    window > 0,
+                    "Built-in entry ({}, {}) must have a positive context window",
+                    entry.provider_slug,
+                    entry.model_id
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_builtin_entries_have_text_modality() {
+        for entry in builtin_model_catalog() {
+            assert!(
+                entry.supported_modalities.contains(&"text".to_string()),
+                "Built-in entry ({}, {}) must support text modality",
+                entry.provider_slug,
+                entry.model_id
+            );
+        }
+    }
+}

--- a/src/config/builtin_models.rs
+++ b/src/config/builtin_models.rs
@@ -76,10 +76,18 @@ impl BuiltinModelEntry {
         self
     }
 
-    /// Enable reasoning support with optional accepted values.
+    /// Enable reasoning support with accepted effort values.
+    ///
+    /// An empty vector is rejected because reasoning support requires
+    /// at least one valid effort level.
     pub fn with_reasoning(mut self, values: Vec<impl Into<String>>) -> Self {
-        self.supports_reasoning = !values.is_empty();
-        self.reasoning_effort_values = values.into_iter().map(Into::into).collect();
+        let effort_values: Vec<String> = values.into_iter().map(Into::into).collect();
+        assert!(
+            !effort_values.is_empty(),
+            "with_reasoning requires at least one effort value"
+        );
+        self.supports_reasoning = true;
+        self.reasoning_effort_values = effort_values;
         self
     }
 

--- a/src/config/effective_catalog.rs
+++ b/src/config/effective_catalog.rs
@@ -1,0 +1,315 @@
+//! Effective model catalog that merges built-in and custom model metadata.
+
+use super::builtin_models::BuiltinModelEntry;
+use super::records::CustomModelRecord;
+use crate::context::model_switch::ModelCapabilityMetadata;
+use std::collections::HashMap;
+
+/// Errors that can occur when building or querying the effective model catalog.
+#[derive(Debug, thiserror::Error, Clone, PartialEq)]
+pub enum CatalogError {
+    #[error("Custom model duplicates built-in entry: ({0}, {1})")]
+    DuplicateBuiltIn(String, String),
+}
+
+/// A unified model entry in the effective catalog.
+#[derive(Debug, Clone, PartialEq)]
+pub struct EffectiveModelEntry {
+    /// Provider slug.
+    pub provider_slug: String,
+    /// Model identifier.
+    pub model_id: String,
+    /// Human-readable display name.
+    pub display_name: String,
+    /// Context window in tokens, if known.
+    pub context_window: Option<usize>,
+    /// Maximum output tokens, if known.
+    pub output_limit: Option<u32>,
+    /// Whether the model supports tool calls.
+    pub supports_tool_calls: bool,
+    /// Whether the model supports reasoning / reasoning effort.
+    pub supports_reasoning: bool,
+    /// Supported reasoning effort values, if applicable.
+    pub reasoning_effort_values: Vec<String>,
+    /// Whether the model supports vision / image input.
+    pub supports_vision: bool,
+    /// Whether the model supports streaming responses.
+    pub supports_streaming: bool,
+    /// Modalities supported by this model.
+    pub supported_modalities: Vec<String>,
+    /// Tools known to be unsupported by this model.
+    pub unsupported_tools: Vec<String>,
+    /// Input cost per million tokens, if known.
+    pub cost_input_per_million: Option<f64>,
+    /// Output cost per million tokens, if known.
+    pub cost_output_per_million: Option<f64>,
+    /// Whether this entry originated from a custom model record.
+    pub is_custom: bool,
+}
+
+impl EffectiveModelEntry {
+    /// Return the context window as a `usize`, defaulting to 0 when unknown.
+    ///
+    /// This is convenient for consumers that require a concrete window size.
+    pub fn context_window_or_zero(&self) -> usize {
+        self.context_window.unwrap_or(0)
+    }
+}
+
+/// A unified model catalog that merges built-in provider metadata with
+/// ConfigStore custom model records.
+#[derive(Debug, Clone, Default)]
+pub struct EffectiveModelCatalog {
+    models: HashMap<(String, String), EffectiveModelEntry>,
+}
+
+impl EffectiveModelCatalog {
+    /// Create an empty catalog.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Look up a model by provider slug and model ID.
+    pub fn get(&self, provider: &str, model: &str) -> Option<&EffectiveModelEntry> {
+        self.models.get(&(provider.to_string(), model.to_string()))
+    }
+
+    /// List all models for a given provider slug.
+    pub fn list_for_provider(&self, provider: &str) -> Vec<&EffectiveModelEntry> {
+        self.models
+            .values()
+            .filter(|entry| entry.provider_slug == provider)
+            .collect()
+    }
+
+    /// Return all entries in the catalog.
+    pub fn all_entries(&self) -> Vec<&EffectiveModelEntry> {
+        self.models.values().collect()
+    }
+
+    /// Return true if the catalog contains the given provider/model key.
+    pub fn contains(&self, provider: &str, model: &str) -> bool {
+        self.models
+            .contains_key(&(provider.to_string(), model.to_string()))
+    }
+
+    /// Register a built-in entry into the catalog.
+    fn register_builtin(&mut self, entry: &BuiltinModelEntry) {
+        let key = (entry.provider_slug.clone(), entry.model_id.clone());
+        self.models.insert(
+            key,
+            EffectiveModelEntry {
+                provider_slug: entry.provider_slug.clone(),
+                model_id: entry.model_id.clone(),
+                display_name: entry.display_name.clone(),
+                context_window: entry.context_window,
+                output_limit: entry.output_limit,
+                supports_tool_calls: entry.supports_tool_calls,
+                supports_reasoning: entry.supports_reasoning,
+                reasoning_effort_values: entry.reasoning_effort_values.clone(),
+                supports_vision: entry.supports_vision,
+                supports_streaming: entry.supports_streaming,
+                supported_modalities: entry.supported_modalities.clone(),
+                unsupported_tools: entry.unsupported_tools.clone(),
+                cost_input_per_million: None,
+                cost_output_per_million: None,
+                is_custom: false,
+            },
+        );
+    }
+
+    /// Register a custom entry into the catalog.
+    fn register_custom(&mut self, entry: &CustomModelRecord) {
+        let mut modalities = vec!["text".to_string()];
+        if entry.supports_vision && !modalities.contains(&"image".to_string()) {
+            modalities.push("image".to_string());
+        }
+
+        let key = (entry.provider_slug.clone(), entry.model_id.clone());
+        self.models.insert(
+            key,
+            EffectiveModelEntry {
+                provider_slug: entry.provider_slug.clone(),
+                model_id: entry.model_id.clone(),
+                display_name: entry.display_name.clone(),
+                context_window: entry.context_window.map(|v| v as usize),
+                output_limit: entry.output_limit,
+                supports_tool_calls: entry.supports_tool_calls,
+                supports_reasoning: entry.supports_reasoning
+                    || !entry.reasoning_effort_values.is_empty(),
+                reasoning_effort_values: entry.reasoning_effort_values.clone(),
+                supports_vision: entry.supports_vision,
+                supports_streaming: entry.supports_streaming,
+                supported_modalities: modalities,
+                unsupported_tools: Vec::new(),
+                cost_input_per_million: entry.cost_input_per_million,
+                cost_output_per_million: entry.cost_output_per_million,
+                is_custom: true,
+            },
+        );
+    }
+}
+
+/// Build an effective model catalog from built-in and custom model records.
+///
+/// Custom entries extend the catalog. If a custom entry has the same
+/// `(provider_slug, model_id)` as a built-in entry, a
+/// `CatalogError::DuplicateBuiltIn` error is returned.
+pub fn build_effective_catalog(
+    builtin: &[BuiltinModelEntry],
+    custom: &[CustomModelRecord],
+) -> Result<EffectiveModelCatalog, CatalogError> {
+    let mut catalog = EffectiveModelCatalog::new();
+
+    for entry in builtin {
+        catalog.register_builtin(entry);
+    }
+
+    for entry in custom {
+        if catalog.contains(&entry.provider_slug, &entry.model_id) {
+            return Err(CatalogError::DuplicateBuiltIn(
+                entry.provider_slug.clone(),
+                entry.model_id.clone(),
+            ));
+        }
+        catalog.register_custom(entry);
+    }
+
+    Ok(catalog)
+}
+
+impl From<&EffectiveModelEntry> for ModelCapabilityMetadata {
+    fn from(entry: &EffectiveModelEntry) -> Self {
+        Self {
+            model: entry.model_id.clone(),
+            provider: entry.provider_slug.clone(),
+            context_window: entry.context_window.unwrap_or(0),
+            supports_tools: entry.supports_tool_calls,
+            supports_streaming: entry.supports_streaming,
+            supports_reasoning_effort: entry.supports_reasoning,
+            reasoning_effort_values: entry.reasoning_effort_values.clone(),
+            supported_modalities: entry.supported_modalities.clone(),
+            unsupported_tools: entry.unsupported_tools.clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::builtin_models::BuiltinModelEntry;
+    use super::*;
+    use chrono::Utc;
+
+    fn custom_model_record(provider_slug: &str, model_id: &str) -> CustomModelRecord {
+        CustomModelRecord {
+            provider_slug: provider_slug.to_string(),
+            model_id: model_id.to_string(),
+            display_name: format!("Custom {}", model_id),
+            context_window: Some(100_000),
+            output_limit: Some(4_096),
+            supports_tool_calls: true,
+            supports_reasoning: false,
+            supports_vision: true,
+            supports_streaming: true,
+            reasoning_effort_values: Vec::new(),
+            cost_input_per_million: None,
+            cost_output_per_million: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn test_catalog_merge_built_in_and_custom() {
+        let builtin = vec![BuiltinModelEntry::new("openai", "gpt-4o")
+            .with_display_name("GPT-4o")
+            .with_context_window(128_000)
+            .with_tools()
+            .with_vision()];
+        let custom = vec![custom_model_record("custom-provider", "custom-model")];
+
+        let catalog = build_effective_catalog(&builtin, &custom).unwrap();
+        assert!(catalog.get("openai", "gpt-4o").is_some());
+        assert!(catalog.get("custom-provider", "custom-model").is_some());
+    }
+
+    #[test]
+    fn test_catalog_rejects_duplicate_built_in() {
+        let builtin = vec![BuiltinModelEntry::new("openai", "gpt-4o")
+            .with_display_name("GPT-4o")
+            .with_context_window(128_000)
+            .with_tools()];
+        let custom = vec![custom_model_record("openai", "gpt-4o")];
+
+        let result = build_effective_catalog(&builtin, &custom);
+        assert!(matches!(
+            result,
+            Err(CatalogError::DuplicateBuiltIn(ref p, ref m)) if p == "openai" && m == "gpt-4o"
+        ));
+    }
+
+    #[test]
+    fn test_catalog_lookup_and_list_by_provider() {
+        let builtin = vec![
+            BuiltinModelEntry::new("openai", "gpt-4o").with_context_window(128_000),
+            BuiltinModelEntry::new("openai", "gpt-4o-mini").with_context_window(128_000),
+            BuiltinModelEntry::new("anthropic", "claude-3-5-sonnet-20241022")
+                .with_context_window(200_000),
+        ];
+        let custom = vec![custom_model_record("openai", "custom-openai")];
+
+        let catalog = build_effective_catalog(&builtin, &custom).unwrap();
+
+        let openai_models = catalog.list_for_provider("openai");
+        assert_eq!(openai_models.len(), 3);
+
+        let anthropic_models = catalog.list_for_provider("anthropic");
+        assert_eq!(anthropic_models.len(), 1);
+
+        assert!(catalog.get("openai", "gpt-4o").is_some());
+        assert!(catalog.get("openai", "nonexistent").is_none());
+    }
+
+    #[test]
+    fn test_catalog_converts_to_capability_metadata() {
+        let builtin = vec![BuiltinModelEntry::new("openai", "gpt-4o")
+            .with_context_window(128_000)
+            .with_tools()
+            .with_vision()];
+        let catalog = build_effective_catalog(&builtin, &[]).unwrap();
+        let entry = catalog.get("openai", "gpt-4o").unwrap();
+        let meta: ModelCapabilityMetadata = entry.into();
+
+        assert_eq!(meta.model, "gpt-4o");
+        assert_eq!(meta.provider, "openai");
+        assert_eq!(meta.context_window, 128_000);
+        assert!(meta.supports_tools);
+        assert!(meta.supports_streaming);
+        assert!(meta.supported_modalities.contains(&"image".to_string()));
+    }
+
+    #[test]
+    fn test_custom_entry_inherits_modalities_from_vision_flag() {
+        let custom = vec![CustomModelRecord {
+            provider_slug: "custom".to_string(),
+            model_id: "vision-model".to_string(),
+            display_name: "Vision".to_string(),
+            context_window: Some(100_000),
+            output_limit: Some(4_096),
+            supports_tool_calls: true,
+            supports_reasoning: false,
+            supports_vision: true,
+            supports_streaming: true,
+            reasoning_effort_values: Vec::new(),
+            cost_input_per_million: None,
+            cost_output_per_million: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }];
+
+        let catalog = build_effective_catalog(&[], &custom).unwrap();
+        let entry = catalog.get("custom", "vision-model").unwrap();
+        assert!(entry.supported_modalities.contains(&"text".to_string()));
+        assert!(entry.supported_modalities.contains(&"image".to_string()));
+    }
+}

--- a/src/config/effective_catalog.rs
+++ b/src/config/effective_catalog.rs
@@ -121,7 +121,7 @@ impl EffectiveModelCatalog {
     /// Register a custom entry into the catalog.
     fn register_custom(&mut self, entry: &CustomModelRecord) {
         let mut modalities = vec!["text".to_string()];
-        if entry.supports_vision && !modalities.contains(&"image".to_string()) {
+        if entry.supports_vision {
             modalities.push("image".to_string());
         }
 

--- a/src/config/error.rs
+++ b/src/config/error.rs
@@ -58,6 +58,10 @@ pub enum ConfigError {
     /// Input validation failed.
     #[error("Validation error: {0}")]
     Validation(String),
+
+    /// Effective model catalog error.
+    #[error("Model catalog error: {0}")]
+    Catalog(String),
 }
 
 impl From<sqlx::Error> for ConfigError {
@@ -95,5 +99,11 @@ impl From<serde_json::Error> for ConfigError {
                 ConfigError::Deserialization(err.to_string())
             }
         }
+    }
+}
+
+impl From<super::effective_catalog::CatalogError> for ConfigError {
+    fn from(err: super::effective_catalog::CatalogError) -> Self {
+        ConfigError::Catalog(err.to_string())
     }
 }

--- a/src/config/migrations.rs
+++ b/src/config/migrations.rs
@@ -109,11 +109,20 @@ pub const MIGRATIONS: &[(i64, &str)] = &[
             INSERT OR IGNORE INTO schema_version (id, version) VALUES (1, 2);
             "#,
     ),
+    (
+        3,
+        r#"
+            ALTER TABLE custom_models ADD COLUMN supports_streaming INTEGER NOT NULL DEFAULT 1;
+            ALTER TABLE custom_models ADD COLUMN reasoning_effort_values_json TEXT NULL;
+
+            INSERT OR IGNORE INTO schema_version (id, version) VALUES (1, 3);
+            "#,
+    ),
 ];
 
 /// The current schema version.
 #[allow(dead_code)]
-pub const CURRENT_SCHEMA_VERSION: i64 = 2;
+pub const CURRENT_SCHEMA_VERSION: i64 = 3;
 
 /// Apply all pending migrations to the database.
 pub async fn apply_migrations(pool: &sqlx::SqlitePool) -> Result<(), super::error::ConfigError> {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -567,6 +567,8 @@ impl SkillConfig {
 }
 
 // Durable config store submodules
+pub mod builtin_models;
+pub mod effective_catalog;
 pub mod error;
 pub mod records;
 pub mod store;
@@ -576,6 +578,10 @@ mod db;
 mod key_source;
 mod migrations;
 
+pub use builtin_models::{builtin_model_catalog, BuiltinModelEntry};
+pub use effective_catalog::{
+    build_effective_catalog, CatalogError, EffectiveModelCatalog, EffectiveModelEntry,
+};
 pub use error::ConfigError;
 pub use records::{
     CredentialRecord, CustomModelInput, CustomModelRecord, DefaultModelInput, DefaultModelRecord,

--- a/src/config/records.rs
+++ b/src/config/records.rs
@@ -100,6 +100,8 @@ pub struct CustomModelRecord {
     pub supports_tool_calls: bool,
     pub supports_reasoning: bool,
     pub supports_vision: bool,
+    pub supports_streaming: bool,
+    pub reasoning_effort_values: Vec<String>,
     pub cost_input_per_million: Option<f64>,
     pub cost_output_per_million: Option<f64>,
     pub created_at: DateTime<Utc>,
@@ -117,6 +119,8 @@ pub struct CustomModelInput {
     pub supports_tool_calls: bool,
     pub supports_reasoning: bool,
     pub supports_vision: bool,
+    pub supports_streaming: bool,
+    pub reasoning_effort_values: Vec<String>,
     pub cost_input_per_million: Option<f64>,
     pub cost_output_per_million: Option<f64>,
 }

--- a/src/config/store.rs
+++ b/src/config/store.rs
@@ -646,6 +646,26 @@ impl ConfigStore {
         Ok(())
     }
 
+    /// Return the union of built-in provider slugs and persisted provider config slugs.
+    pub async fn known_provider_slugs(
+        &self,
+    ) -> Result<std::collections::HashSet<String>, ConfigError> {
+        let mut slugs = std::collections::HashSet::new();
+
+        // Built-in providers from iron-providers
+        let registry = iron_providers::ProviderRegistry::default();
+        for slug in registry.slugs() {
+            slugs.insert(slug.to_string());
+        }
+
+        // Persisted provider configs
+        for config in self.list_provider_configs().await? {
+            slugs.insert(config.provider_slug);
+        }
+
+        Ok(slugs)
+    }
+
     // ============================================================================
     // Custom Model APIs
     // ============================================================================
@@ -685,11 +705,22 @@ impl ConfigStore {
             input.cost_output_per_million,
             "Output cost per million",
         )?;
+
+        // Validate provider slug is known (built-in or persisted provider config)
+        let known_slugs = self.known_provider_slugs().await?;
+        if !known_slugs.contains(&input.provider_slug) {
+            return Err(ConfigError::Validation(format!(
+                "Provider slug '{}' is not recognized. Add a provider config first or use a built-in provider slug.",
+                input.provider_slug
+            )));
+        }
+
+        let reasoning_json = serde_json::to_string(&input.reasoning_effort_values)?;
         let now = Utc::now().to_rfc3339();
         sqlx::query(
             r#"
-            INSERT INTO custom_models (provider_slug, model_id, display_name, context_window, output_limit, supports_tool_calls, supports_reasoning, supports_vision, cost_input_per_million, cost_output_per_million, created_at, updated_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO custom_models (provider_slug, model_id, display_name, context_window, output_limit, supports_tool_calls, supports_reasoning, supports_vision, supports_streaming, reasoning_effort_values_json, cost_input_per_million, cost_output_per_million, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(provider_slug, model_id) DO UPDATE SET
                 display_name = excluded.display_name,
                 context_window = excluded.context_window,
@@ -697,6 +728,8 @@ impl ConfigStore {
                 supports_tool_calls = excluded.supports_tool_calls,
                 supports_reasoning = excluded.supports_reasoning,
                 supports_vision = excluded.supports_vision,
+                supports_streaming = excluded.supports_streaming,
+                reasoning_effort_values_json = excluded.reasoning_effort_values_json,
                 cost_input_per_million = excluded.cost_input_per_million,
                 cost_output_per_million = excluded.cost_output_per_million,
                 updated_at = excluded.updated_at
@@ -710,6 +743,8 @@ impl ConfigStore {
         .bind(input.supports_tool_calls)
         .bind(input.supports_reasoning)
         .bind(input.supports_vision)
+        .bind(input.supports_streaming)
+        .bind(reasoning_json)
         .bind(input.cost_input_per_million)
         .bind(input.cost_output_per_million)
         .bind(&now)
@@ -727,6 +762,8 @@ impl ConfigStore {
             supports_tool_calls: input.supports_tool_calls,
             supports_reasoning: input.supports_reasoning,
             supports_vision: input.supports_vision,
+            supports_streaming: input.supports_streaming,
+            reasoning_effort_values: input.reasoning_effort_values.clone(),
             cost_input_per_million: input.cost_input_per_million,
             cost_output_per_million: input.cost_output_per_million,
             created_at: Utc::now(),
@@ -741,7 +778,7 @@ impl ConfigStore {
         model_id: &str,
     ) -> Result<Option<CustomModelRecord>, ConfigError> {
         let row = sqlx::query(
-            "SELECT provider_slug, model_id, display_name, context_window, output_limit, supports_tool_calls, supports_reasoning, supports_vision, cost_input_per_million, cost_output_per_million, created_at, updated_at FROM custom_models WHERE provider_slug = ? AND model_id = ?",
+            "SELECT provider_slug, model_id, display_name, context_window, output_limit, supports_tool_calls, supports_reasoning, supports_vision, supports_streaming, reasoning_effort_values_json, cost_input_per_million, cost_output_per_million, created_at, updated_at FROM custom_models WHERE provider_slug = ? AND model_id = ?",
         )
         .bind(provider_slug)
         .bind(model_id)
@@ -761,6 +798,10 @@ impl ConfigStore {
                 supports_tool_calls: row.get::<i64, _>("supports_tool_calls") != 0,
                 supports_reasoning: row.get::<i64, _>("supports_reasoning") != 0,
                 supports_vision: row.get::<i64, _>("supports_vision") != 0,
+                supports_streaming: row.get::<i64, _>("supports_streaming") != 0,
+                reasoning_effort_values: parse_reasoning_effort_values(
+                    row.get::<Option<String>, _>("reasoning_effort_values_json"),
+                )?,
                 cost_input_per_million: row.get("cost_input_per_million"),
                 cost_output_per_million: row.get("cost_output_per_million"),
                 created_at: parse_datetime(row.get::<String, _>("created_at"))?,
@@ -777,7 +818,7 @@ impl ConfigStore {
     ) -> Result<Vec<CustomModelRecord>, ConfigError> {
         let rows = if let Some(slug) = provider_slug {
             sqlx::query(
-                "SELECT provider_slug, model_id, display_name, context_window, output_limit, supports_tool_calls, supports_reasoning, supports_vision, cost_input_per_million, cost_output_per_million, created_at, updated_at FROM custom_models WHERE provider_slug = ? ORDER BY updated_at DESC",
+                "SELECT provider_slug, model_id, display_name, context_window, output_limit, supports_tool_calls, supports_reasoning, supports_vision, supports_streaming, reasoning_effort_values_json, cost_input_per_million, cost_output_per_million, created_at, updated_at FROM custom_models WHERE provider_slug = ? ORDER BY updated_at DESC",
             )
             .bind(slug)
             .fetch_all(&self.pool)
@@ -785,7 +826,7 @@ impl ConfigStore {
             .map_err(ConfigError::from)?
         } else {
             sqlx::query(
-                "SELECT provider_slug, model_id, display_name, context_window, output_limit, supports_tool_calls, supports_reasoning, supports_vision, cost_input_per_million, cost_output_per_million, created_at, updated_at FROM custom_models ORDER BY updated_at DESC",
+                "SELECT provider_slug, model_id, display_name, context_window, output_limit, supports_tool_calls, supports_reasoning, supports_vision, supports_streaming, reasoning_effort_values_json, cost_input_per_million, cost_output_per_million, created_at, updated_at FROM custom_models ORDER BY updated_at DESC",
             )
             .fetch_all(&self.pool)
             .await
@@ -805,6 +846,10 @@ impl ConfigStore {
                     supports_tool_calls: row.get::<i64, _>("supports_tool_calls") != 0,
                     supports_reasoning: row.get::<i64, _>("supports_reasoning") != 0,
                     supports_vision: row.get::<i64, _>("supports_vision") != 0,
+                    supports_streaming: row.get::<i64, _>("supports_streaming") != 0,
+                    reasoning_effort_values: parse_reasoning_effort_values(
+                        row.get::<Option<String>, _>("reasoning_effort_values_json"),
+                    )?,
                     cost_input_per_million: row.get("cost_input_per_million"),
                     cost_output_per_million: row.get("cost_output_per_million"),
                     created_at: parse_datetime(row.get::<String, _>("created_at"))?,
@@ -848,6 +893,20 @@ impl ConfigStore {
                 "Model ID must not be empty".to_string(),
             ));
         }
+
+        // Validate that the requested default model exists in the effective catalog.
+        let custom_models = self.list_custom_models(None).await?;
+        let catalog = super::effective_catalog::build_effective_catalog(
+            &super::builtin_models::builtin_model_catalog(),
+            &custom_models,
+        )?;
+        if !catalog.contains(&input.provider_slug, &input.model_id) {
+            return Err(ConfigError::Validation(format!(
+                "Default model ({} / {}) is not present in the model catalog",
+                input.provider_slug, input.model_id
+            )));
+        }
+
         let now = Utc::now().to_rfc3339();
         sqlx::query(
             r#"
@@ -1157,6 +1216,18 @@ impl ConfigStore {
                     "Default model ID is empty".to_string(),
                 ));
             }
+
+            // Validate default model exists in effective catalog (built-in + custom)
+            let catalog = super::effective_catalog::build_effective_catalog(
+                &super::builtin_models::builtin_model_catalog(),
+                &custom_models,
+            )?;
+            if !catalog.contains(&default.provider_slug, &default.model_id) {
+                return Err(ConfigError::Validation(format!(
+                    "Default model ({} / {}) is not present in the model catalog",
+                    default.provider_slug, default.model_id
+                )));
+            }
         }
 
         // Validate MCP server IDs are unique (defensive; DB has PK)
@@ -1197,6 +1268,17 @@ fn parse_datetime(s: String) -> Result<DateTime<Utc>, ConfigError> {
     Ok(chrono::DateTime::parse_from_rfc3339(&s)
         .map_err(|e| ConfigError::Deserialization(e.to_string()))?
         .with_timezone(&Utc))
+}
+
+/// Parse reasoning effort values JSON. NULL or empty string defaults to empty Vec.
+fn parse_reasoning_effort_values(json: Option<String>) -> Result<Vec<String>, ConfigError> {
+    match json {
+        None => Ok(Vec::new()),
+        Some(s) if s.trim().is_empty() => Ok(Vec::new()),
+        Some(s) => serde_json::from_str(&s).map_err(|e| {
+            ConfigError::Deserialization(format!("Invalid reasoning_effort_values JSON: {}", e))
+        }),
+    }
 }
 
 fn validate_optional_non_negative_f64(value: Option<f64>, label: &str) -> Result<(), ConfigError> {

--- a/src/config/store.rs
+++ b/src/config/store.rs
@@ -804,14 +804,8 @@ impl ConfigStore {
                 provider_slug: row.get("provider_slug"),
                 model_id: row.get("model_id"),
                 display_name: row.get("display_name"),
-                context_window: row.get::<Option<i64>, _>("context_window").and_then(|v| {
-                    if v < 0 {
-                        None
-                    } else {
-                        Some(v as u32)
-                    }
-                }),
-                output_limit: row.get::<Option<i64>, _>("output_limit").map(|v| v as u32),
+                context_window: normalize_optional_u32(row.get::<Option<i64>, _>("context_window")),
+                output_limit: normalize_optional_u32(row.get::<Option<i64>, _>("output_limit")),
                 supports_tool_calls: row.get::<i64, _>("supports_tool_calls") != 0,
                 supports_reasoning: row.get::<i64, _>("supports_reasoning") != 0,
                 supports_vision: row.get::<i64, _>("supports_vision") != 0,
@@ -856,14 +850,10 @@ impl ConfigStore {
                     provider_slug: row.get("provider_slug"),
                     model_id: row.get("model_id"),
                     display_name: row.get("display_name"),
-                    context_window: row.get::<Option<i64>, _>("context_window").and_then(|v| {
-                        if v < 0 {
-                            None
-                        } else {
-                            Some(v as u32)
-                        }
-                    }),
-                    output_limit: row.get::<Option<i64>, _>("output_limit").map(|v| v as u32),
+                    context_window: normalize_optional_u32(
+                        row.get::<Option<i64>, _>("context_window"),
+                    ),
+                    output_limit: normalize_optional_u32(row.get::<Option<i64>, _>("output_limit")),
                     supports_tool_calls: row.get::<i64, _>("supports_tool_calls") != 0,
                     supports_reasoning: row.get::<i64, _>("supports_reasoning") != 0,
                     supports_vision: row.get::<i64, _>("supports_vision") != 0,
@@ -1225,6 +1215,18 @@ impl ConfigStore {
         let mcp_servers = self.list_mcp_servers().await?;
         let skill_settings = self.get_skill_settings().await?;
 
+        // Validate all persisted custom models reference known provider slugs.
+        let known_provider_slugs = self.known_provider_slugs().await?;
+        if let Some(model) = custom_models
+            .iter()
+            .find(|model| !known_provider_slugs.contains(&model.provider_slug))
+        {
+            return Err(ConfigError::Validation(format!(
+                "Custom model ({} / {}) references an unknown provider slug",
+                model.provider_slug, model.model_id
+            )));
+        }
+
         // Validate cross-record consistency
         if let Some(ref default) = default_model {
             if default.provider_slug.trim().is_empty() {
@@ -1289,6 +1291,12 @@ fn parse_datetime(s: String) -> Result<DateTime<Utc>, ConfigError> {
     Ok(chrono::DateTime::parse_from_rfc3339(&s)
         .map_err(|e| ConfigError::Deserialization(e.to_string()))?
         .with_timezone(&Utc))
+}
+
+/// Normalize an optional i64 value from the database to Option<u32>,
+/// treating negative values as None to avoid wraparound.
+fn normalize_optional_u32(value: Option<i64>) -> Option<u32> {
+    value.and_then(|v| if v < 0 { None } else { Some(v as u32) })
 }
 
 /// Parse reasoning effort values JSON. NULL or empty string defaults to empty Vec.

--- a/src/config/store.rs
+++ b/src/config/store.rs
@@ -715,6 +715,19 @@ impl ConfigStore {
             )));
         }
 
+        // Enforce extend-only semantics: custom models must not shadow built-ins.
+        let empty_custom_models: Vec<CustomModelRecord> = Vec::new();
+        let builtin_catalog = super::effective_catalog::build_effective_catalog(
+            &super::builtin_models::builtin_model_catalog(),
+            &empty_custom_models,
+        )?;
+        if builtin_catalog.contains(&input.provider_slug, &input.model_id) {
+            return Err(ConfigError::Validation(format!(
+                "Custom model ({} / {}) conflicts with a built-in model id",
+                input.provider_slug, input.model_id
+            )));
+        }
+
         let reasoning_json = serde_json::to_string(&input.reasoning_effort_values)?;
         let now = Utc::now().to_rfc3339();
         sqlx::query(
@@ -791,9 +804,13 @@ impl ConfigStore {
                 provider_slug: row.get("provider_slug"),
                 model_id: row.get("model_id"),
                 display_name: row.get("display_name"),
-                context_window: row
-                    .get::<Option<i64>, _>("context_window")
-                    .map(|v| v as u32),
+                context_window: row.get::<Option<i64>, _>("context_window").and_then(|v| {
+                    if v < 0 {
+                        None
+                    } else {
+                        Some(v as u32)
+                    }
+                }),
                 output_limit: row.get::<Option<i64>, _>("output_limit").map(|v| v as u32),
                 supports_tool_calls: row.get::<i64, _>("supports_tool_calls") != 0,
                 supports_reasoning: row.get::<i64, _>("supports_reasoning") != 0,
@@ -839,9 +856,13 @@ impl ConfigStore {
                     provider_slug: row.get("provider_slug"),
                     model_id: row.get("model_id"),
                     display_name: row.get("display_name"),
-                    context_window: row
-                        .get::<Option<i64>, _>("context_window")
-                        .map(|v| v as u32),
+                    context_window: row.get::<Option<i64>, _>("context_window").and_then(|v| {
+                        if v < 0 {
+                            None
+                        } else {
+                            Some(v as u32)
+                        }
+                    }),
                     output_limit: row.get::<Option<i64>, _>("output_limit").map(|v| v as u32),
                     supports_tool_calls: row.get::<i64, _>("supports_tool_calls") != 0,
                     supports_reasoning: row.get::<i64, _>("supports_reasoning") != 0,

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1613,6 +1613,7 @@ impl IronRuntime {
         let catalog = build_effective_catalog(&builtin_model_catalog(), &settings.custom_models)?;
 
         let mut registry = self.inner.model_capability_registry.write();
+        *registry = crate::context::model_switch::ModelCapabilityRegistry::new();
         for entry in catalog.all_entries() {
             let metadata = crate::context::model_switch::ModelCapabilityMetadata::from(entry);
             registry.register(metadata);

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -240,6 +240,7 @@ impl IronRuntime {
         }
 
         this.register_compress_tool();
+        this.hydrate_builtin_model_capability_registry();
 
         // Emit runtime configuration debug event (new())
         let config_event = crate::debug::redact_config(&this.inner.config);
@@ -350,6 +351,7 @@ impl IronRuntime {
         }
 
         this.register_compress_tool();
+        this.hydrate_builtin_model_capability_registry();
 
         // Emit runtime configuration debug event
         let config_event = crate::debug::redact_config(&this.inner.config);
@@ -1293,6 +1295,12 @@ impl IronRuntime {
             .get(source_provider_id, source_model_id)
             .cloned();
         let target_caps = cap_registry.get(target_provider_id, &to_model).cloned();
+        if target_caps.is_none() {
+            return Err(RuntimeError::Connection(format!(
+                "Unknown target model '{}/{}': not present in the model capability registry",
+                target_provider_id, to_model
+            )));
+        }
         drop(cap_registry);
 
         let plan = crate::context::model_switch::ModelSwitchPlanner::create_plan_with_capabilities(
@@ -1566,6 +1574,61 @@ impl IronRuntime {
             .model_capability_registry
             .write()
             .register(metadata);
+    }
+
+    /// Hydrate the model capability registry with compiled-in built-in model metadata.
+    fn hydrate_builtin_model_capability_registry(&self) {
+        use crate::config::builtin_models::builtin_model_catalog;
+
+        let mut registry = self.inner.model_capability_registry.write();
+        for entry in builtin_model_catalog() {
+            let metadata = crate::context::model_switch::ModelCapabilityMetadata {
+                model: entry.model_id,
+                provider: entry.provider_slug,
+                context_window: entry.context_window.unwrap_or(0),
+                supports_tools: entry.supports_tool_calls,
+                supports_streaming: entry.supports_streaming,
+                supports_reasoning_effort: entry.supports_reasoning,
+                reasoning_effort_values: entry.reasoning_effort_values,
+                supported_modalities: entry.supported_modalities,
+                unsupported_tools: entry.unsupported_tools,
+            };
+            registry.register(metadata);
+        }
+    }
+
+    /// Hydrate the model capability registry from a runtime settings snapshot.
+    ///
+    /// This builds the effective model catalog from built-in provider metadata
+    /// and ConfigStore custom model records, then registers every entry into
+    /// the in-memory capability registry so that model switches and capability
+    /// diffs can reason about both built-in and custom models.
+    pub fn hydrate_model_capability_registry(
+        &self,
+        settings: &crate::config::RuntimeSettingsSnapshot,
+    ) -> Result<(), crate::config::ConfigError> {
+        use crate::config::builtin_models::builtin_model_catalog;
+        use crate::config::effective_catalog::build_effective_catalog;
+
+        let catalog = build_effective_catalog(&builtin_model_catalog(), &settings.custom_models)?;
+
+        let mut registry = self.inner.model_capability_registry.write();
+        for entry in catalog.all_entries() {
+            let metadata = crate::context::model_switch::ModelCapabilityMetadata::from(entry);
+            registry.register(metadata);
+        }
+
+        Ok(())
+    }
+
+    /// Return a read lock on the model capability registry.
+    ///
+    /// Exposed primarily for tests and diagnostics.
+    pub fn model_capability_registry(
+        &self,
+    ) -> parking_lot::RwLockReadGuard<'_, crate::context::model_switch::ModelCapabilityRegistry>
+    {
+        self.inner.model_capability_registry.read()
     }
 
     pub fn cancel_active_prompt(&self, session_id: SessionId) -> bool {
@@ -2678,5 +2741,148 @@ mod tests {
         assert_eq!(config.allowed_roots, session_roots);
         // Other fields should be preserved from base
         assert_eq!(config.max_output_bytes, base_config.max_output_bytes);
+    }
+
+    // ============================================================================
+    // Model capability registry hydration tests (issue #68)
+    // ============================================================================
+
+    #[test]
+    fn runtime_startup_registers_builtin_model_capabilities() {
+        let runtime = IronRuntime::new(Config::default(), MockProvider);
+
+        let registry = runtime.model_capability_registry();
+        assert!(registry.get("openai", "gpt-4o").is_some());
+        assert!(registry
+            .get("anthropic", "claude-3-7-sonnet-20250219")
+            .is_some());
+    }
+
+    #[test]
+    fn hydrate_model_capability_registry_loads_builtin_models() {
+        let runtime = IronRuntime::new(Config::default(), MockProvider);
+        let settings = crate::config::RuntimeSettingsSnapshot {
+            provider_configs: vec![],
+            custom_models: vec![],
+            default_model: None,
+            mcp_servers: vec![],
+            skill_settings: crate::config::SkillSettingsRecord {
+                trust_project_skills: false,
+                additional_skill_dirs: vec![],
+                updated_at: chrono::Utc::now(),
+            },
+        };
+
+        runtime
+            .hydrate_model_capability_registry(&settings)
+            .unwrap();
+
+        let registry = runtime.model_capability_registry();
+        assert!(
+            registry.get("openai", "gpt-4o").is_some(),
+            "Built-in openai/gpt-4o should be registered"
+        );
+        assert!(
+            registry
+                .get("anthropic", "claude-3-7-sonnet-20250219")
+                .is_some(),
+            "Built-in anthropic/sonnet should be registered"
+        );
+    }
+
+    #[test]
+    fn hydrate_model_capability_registry_loads_custom_models() {
+        use chrono::Utc;
+
+        let runtime = IronRuntime::new(Config::default(), MockProvider);
+        let settings = crate::config::RuntimeSettingsSnapshot {
+            provider_configs: vec![],
+            custom_models: vec![crate::config::CustomModelRecord {
+                provider_slug: "openai".to_string(),
+                model_id: "custom-model".to_string(),
+                display_name: "Custom Model".to_string(),
+                context_window: Some(256_000),
+                output_limit: Some(8_192),
+                supports_tool_calls: true,
+                supports_reasoning: true,
+                supports_vision: true,
+                supports_streaming: false,
+                reasoning_effort_values: vec!["low".to_string(), "high".to_string()],
+                cost_input_per_million: Some(5.0),
+                cost_output_per_million: Some(15.0),
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
+            }],
+            default_model: None,
+            mcp_servers: vec![],
+            skill_settings: crate::config::SkillSettingsRecord {
+                trust_project_skills: false,
+                additional_skill_dirs: vec![],
+                updated_at: chrono::Utc::now(),
+            },
+        };
+
+        runtime
+            .hydrate_model_capability_registry(&settings)
+            .unwrap();
+
+        let registry = runtime.model_capability_registry();
+        let custom = registry.get("openai", "custom-model").unwrap();
+        assert_eq!(custom.context_window, 256_000);
+        assert!(custom.supports_tools);
+        assert!(!custom.supports_streaming);
+        assert!(custom.supports_reasoning_effort);
+        assert_eq!(custom.reasoning_effort_values, vec!["low", "high"]);
+    }
+
+    #[test]
+    fn hydrate_model_capability_registry_enables_capability_diffs() {
+        use chrono::Utc;
+
+        let runtime = IronRuntime::new(Config::default(), MockProvider);
+        let settings = crate::config::RuntimeSettingsSnapshot {
+            provider_configs: vec![],
+            custom_models: vec![crate::config::CustomModelRecord {
+                provider_slug: "custom-provider".to_string(),
+                model_id: "custom-model".to_string(),
+                display_name: "Custom".to_string(),
+                context_window: Some(50_000),
+                output_limit: Some(4_096),
+                supports_tool_calls: false,
+                supports_reasoning: false,
+                supports_vision: false,
+                supports_streaming: true,
+                reasoning_effort_values: vec![],
+                cost_input_per_million: None,
+                cost_output_per_million: None,
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
+            }],
+            default_model: None,
+            mcp_servers: vec![],
+            skill_settings: crate::config::SkillSettingsRecord {
+                trust_project_skills: false,
+                additional_skill_dirs: vec![],
+                updated_at: chrono::Utc::now(),
+            },
+        };
+
+        runtime
+            .hydrate_model_capability_registry(&settings)
+            .unwrap();
+
+        let registry = runtime.model_capability_registry();
+        let diff = registry
+            .compare("openai", "gpt-4o", "custom-provider", "custom-model")
+            .expect("Both models should be present in the hydrated registry");
+
+        assert!(
+            diff.window_shrink.is_some(),
+            "Expected window shrink from 128k to 50k"
+        );
+        assert!(
+            !diff.tools_supported,
+            "Expected custom model to be marked as lacking tool support"
+        );
     }
 }

--- a/tests/config_store_tests.rs
+++ b/tests/config_store_tests.rs
@@ -617,7 +617,8 @@ async fn test_durable_store_disconnect_oauth() {
 // ============================================================================
 
 use iron_core::config::{
-    CustomModelInput, DefaultModelInput, McpServerConfigInput, ProviderConfigInput,
+    build_effective_catalog, builtin_model_catalog, CatalogError, CustomModelInput,
+    CustomModelRecord, DefaultModelInput, McpServerConfigInput, ProviderConfigInput,
     SkillSettingsInput,
 };
 use iron_core::mcp::server::{HttpConfig, McpTransport};
@@ -679,6 +680,8 @@ async fn test_custom_model_crud() {
         supports_tool_calls: true,
         supports_reasoning: false,
         supports_vision: true,
+        supports_streaming: true,
+        reasoning_effort_values: vec![],
         cost_input_per_million: Some(5.0),
         cost_output_per_million: Some(15.0),
     };
@@ -892,6 +895,8 @@ async fn test_custom_model_numeric_validation() {
         supports_tool_calls: false,
         supports_reasoning: false,
         supports_vision: false,
+        supports_streaming: true,
+        reasoning_effort_values: vec![],
         cost_input_per_million: Some(-1.0),
         cost_output_per_million: Some(0.0),
     };
@@ -1011,9 +1016,9 @@ async fn test_migrations_v1_to_v2() {
         .fetch_one(&mut *conn)
         .await
         .unwrap();
-    assert_eq!(version, 2);
+    assert_eq!(version, 3);
 
-    // Verify v2 tables exist by using the new APIs
+    // Verify v2/v3 tables exist by using the new APIs
     store
         .set_provider_config(&ProviderConfigInput {
             provider_slug: "test".to_string(),
@@ -1082,4 +1087,349 @@ mod linux_path_tests {
             None => std::env::remove_var("HOME"),
         }
     }
+}
+
+// ============================================================================
+// Custom Model Runtime Integration Tests
+// ============================================================================
+
+#[tokio::test]
+async fn test_provider_slug_validation() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+
+    // Unknown provider slug should be rejected
+    let input = CustomModelInput {
+        provider_slug: "unknown-provider".to_string(),
+        model_id: "some-model".to_string(),
+        display_name: "Some Model".to_string(),
+        context_window: Some(100_000),
+        output_limit: Some(4_096),
+        supports_tool_calls: false,
+        supports_reasoning: false,
+        supports_vision: false,
+        supports_streaming: true,
+        reasoning_effort_values: vec![],
+        cost_input_per_million: None,
+        cost_output_per_million: None,
+    };
+    let err = store.set_custom_model(&input).await.unwrap_err();
+    assert!(
+        matches!(err, iron_core::config::ConfigError::Validation(ref msg) if msg.contains("unknown-provider")),
+        "Expected validation error for unknown provider slug, got {:?}",
+        err
+    );
+
+    // Built-in provider slug should be accepted
+    let builtin_input = CustomModelInput {
+        provider_slug: "openai".to_string(),
+        model_id: "custom-openai-model".to_string(),
+        display_name: "Custom OpenAI Model".to_string(),
+        context_window: Some(100_000),
+        output_limit: Some(4_096),
+        supports_tool_calls: true,
+        supports_reasoning: false,
+        supports_vision: true,
+        supports_streaming: true,
+        reasoning_effort_values: vec![],
+        cost_input_per_million: None,
+        cost_output_per_million: None,
+    };
+    store.set_custom_model(&builtin_input).await.unwrap();
+
+    // Persisted provider slug should also be accepted
+    store
+        .set_provider_config(&ProviderConfigInput {
+            provider_slug: "custom-persisted".to_string(),
+            display_name: "Custom Persisted Provider".to_string(),
+            enabled: true,
+            base_url: Some("https://example.com".to_string()),
+        })
+        .await
+        .unwrap();
+
+    let persisted_input = CustomModelInput {
+        provider_slug: "custom-persisted".to_string(),
+        model_id: "custom-persisted-model".to_string(),
+        display_name: "Custom Persisted Model".to_string(),
+        context_window: Some(100_000),
+        output_limit: Some(4_096),
+        supports_tool_calls: false,
+        supports_reasoning: false,
+        supports_vision: false,
+        supports_streaming: true,
+        reasoning_effort_values: vec![],
+        cost_input_per_million: None,
+        cost_output_per_million: None,
+    };
+    store.set_custom_model(&persisted_input).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_custom_model_streaming_and_reasoning_roundtrip() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+
+    let input = CustomModelInput {
+        provider_slug: "openai".to_string(),
+        model_id: "reasoning-model".to_string(),
+        display_name: "Reasoning Model".to_string(),
+        context_window: Some(200_000),
+        output_limit: Some(8_192),
+        supports_tool_calls: true,
+        supports_reasoning: true,
+        supports_vision: false,
+        supports_streaming: false,
+        reasoning_effort_values: vec!["low".to_string(), "medium".to_string(), "high".to_string()],
+        cost_input_per_million: Some(3.0),
+        cost_output_per_million: Some(12.0),
+    };
+
+    let record = store.set_custom_model(&input).await.unwrap();
+    assert!(!record.supports_streaming);
+    assert_eq!(
+        record.reasoning_effort_values,
+        vec!["low", "medium", "high"]
+    );
+
+    let retrieved = store
+        .get_custom_model("openai", "reasoning-model")
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(!retrieved.supports_streaming);
+    assert_eq!(
+        retrieved.reasoning_effort_values,
+        vec!["low", "medium", "high"]
+    );
+
+    let listed = store.list_custom_models(None).await.unwrap();
+    assert_eq!(listed.len(), 1);
+    assert!(!listed[0].supports_streaming);
+    assert_eq!(
+        listed[0].reasoning_effort_values,
+        vec!["low", "medium", "high"]
+    );
+}
+
+#[tokio::test]
+async fn test_custom_model_backward_compatible_defaults() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+
+    // Simulate a v2-era insert without the new columns by using raw SQL
+    let mut conn = store.acquire().await.unwrap();
+    sqlx::query(
+        r#"
+        INSERT INTO custom_models (provider_slug, model_id, display_name, context_window, output_limit, supports_tool_calls, supports_reasoning, supports_vision, cost_input_per_million, cost_output_per_million, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        "#,
+    )
+    .bind("openai")
+    .bind("legacy-model")
+    .bind("Legacy Model")
+    .bind(100_000_i64)
+    .bind(4_096_i64)
+    .bind(true)
+    .bind(false)
+    .bind(false)
+    .bind(None::<f64>)
+    .bind(None::<f64>)
+    .bind("2026-01-01T00:00:00Z")
+    .bind("2026-01-01T00:00:00Z")
+    .execute(&mut *conn)
+    .await
+    .unwrap();
+    drop(conn);
+
+    // Reading should default supports_streaming to true and reasoning_effort_values to empty
+    let retrieved = store
+        .get_custom_model("openai", "legacy-model")
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(retrieved.supports_streaming);
+    assert!(retrieved.reasoning_effort_values.is_empty());
+}
+
+#[tokio::test]
+async fn test_default_model_validation_against_effective_catalog() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+
+    // Setting default to a non-existent model should fail validation
+    let result = store
+        .set_default_model(&DefaultModelInput {
+            provider_slug: "openai".to_string(),
+            model_id: "nonexistent-model".to_string(),
+        })
+        .await;
+    assert!(
+        result.is_err(),
+        "Expected validation error for unknown default model"
+    );
+    let err = result.unwrap_err();
+    assert!(
+        matches!(err, iron_core::config::ConfigError::Validation(ref msg) if msg.contains("nonexistent-model")),
+        "Expected validation error mentioning model, got {:?}",
+        err
+    );
+
+    // Setting default to a built-in model should succeed
+    store
+        .set_default_model(&DefaultModelInput {
+            provider_slug: "openai".to_string(),
+            model_id: "gpt-4o".to_string(),
+        })
+        .await
+        .unwrap();
+
+    // Setting default to a custom model should succeed
+    store
+        .set_custom_model(&CustomModelInput {
+            provider_slug: "openai".to_string(),
+            model_id: "custom-openai-model".to_string(),
+            display_name: "Custom Model".to_string(),
+            context_window: Some(100_000),
+            output_limit: Some(4_096),
+            supports_tool_calls: true,
+            supports_reasoning: false,
+            supports_vision: false,
+            supports_streaming: true,
+            reasoning_effort_values: vec![],
+            cost_input_per_million: None,
+            cost_output_per_million: None,
+        })
+        .await
+        .unwrap();
+
+    store
+        .set_default_model(&DefaultModelInput {
+            provider_slug: "openai".to_string(),
+            model_id: "custom-openai-model".to_string(),
+        })
+        .await
+        .unwrap();
+
+    let snapshot = store.load_runtime_settings().await.unwrap();
+    assert!(snapshot.default_model.is_some());
+    assert_eq!(
+        snapshot.default_model.unwrap().model_id,
+        "custom-openai-model"
+    );
+}
+
+#[tokio::test]
+async fn test_migrations_v2_to_v3_custom_models_columns() {
+    use sqlx::sqlite::SqlitePoolOptions;
+
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("test_v2_to_v3.db");
+
+    // Create a raw v2 database
+    let pool = SqlitePoolOptions::new()
+        .connect(&format!("sqlite://{}?mode=rwc", db_path.display()))
+        .await
+        .unwrap();
+
+    sqlx::raw_sql(
+        r#"
+        CREATE TABLE schema_version (
+            id INTEGER PRIMARY KEY CHECK (id = 1),
+            version INTEGER NOT NULL
+        );
+
+        CREATE TABLE custom_models (
+            provider_slug TEXT NOT NULL,
+            model_id TEXT NOT NULL,
+            display_name TEXT NOT NULL,
+            context_window INTEGER NULL,
+            output_limit INTEGER NULL,
+            supports_tool_calls INTEGER NOT NULL DEFAULT 0,
+            supports_reasoning INTEGER NOT NULL DEFAULT 0,
+            supports_vision INTEGER NOT NULL DEFAULT 0,
+            cost_input_per_million REAL NULL,
+            cost_output_per_million REAL NULL,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            PRIMARY KEY (provider_slug, model_id)
+        );
+
+        INSERT INTO schema_version (id, version) VALUES (1, 2);
+        INSERT INTO custom_models (provider_slug, model_id, display_name, context_window, output_limit, supports_tool_calls, supports_reasoning, supports_vision, cost_input_per_million, cost_output_per_million, created_at, updated_at)
+        VALUES ('openai', 'legacy-model', 'Legacy Model', 100000, 4096, 1, 0, 0, NULL, NULL, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+        "#,
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+    drop(pool);
+
+    let store = open_test_store(&db_path).await;
+
+    let mut conn = store.acquire().await.unwrap();
+    let version: i64 = sqlx::query_scalar("SELECT version FROM schema_version WHERE id = 1")
+        .fetch_one(&mut *conn)
+        .await
+        .unwrap();
+    assert_eq!(version, 3);
+
+    // Verify the new columns have correct defaults for existing rows
+    let retrieved = store
+        .get_custom_model("openai", "legacy-model")
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(retrieved.supports_streaming);
+    assert!(retrieved.reasoning_effort_values.is_empty());
+}
+
+#[tokio::test]
+async fn test_effective_model_catalog_rejects_duplicate_builtin() {
+    let custom = vec![CustomModelRecord {
+        provider_slug: "openai".to_string(),
+        model_id: "gpt-4o".to_string(),
+        display_name: "Duplicate GPT-4o".to_string(),
+        context_window: Some(100_000),
+        output_limit: Some(4_096),
+        supports_tool_calls: true,
+        supports_reasoning: false,
+        supports_vision: false,
+        supports_streaming: true,
+        reasoning_effort_values: vec![],
+        cost_input_per_million: None,
+        cost_output_per_million: None,
+        created_at: chrono::Utc::now(),
+        updated_at: chrono::Utc::now(),
+    }];
+
+    let result = build_effective_catalog(&builtin_model_catalog(), &custom);
+    assert!(matches!(
+        result,
+        Err(CatalogError::DuplicateBuiltIn(ref p, ref m)) if p == "openai" && m == "gpt-4o"
+    ));
+}
+
+#[tokio::test]
+async fn test_custom_model_extends_builtin_catalog() {
+    let custom = vec![CustomModelRecord {
+        provider_slug: "openai".to_string(),
+        model_id: "custom-gpt-4o".to_string(),
+        display_name: "Custom GPT-4o".to_string(),
+        context_window: Some(256_000),
+        output_limit: Some(8_192),
+        supports_tool_calls: true,
+        supports_reasoning: true,
+        supports_vision: true,
+        supports_streaming: true,
+        reasoning_effort_values: vec!["low".to_string(), "high".to_string()],
+        cost_input_per_million: Some(5.0),
+        cost_output_per_million: Some(15.0),
+        created_at: chrono::Utc::now(),
+        updated_at: chrono::Utc::now(),
+    }];
+
+    let catalog = build_effective_catalog(&builtin_model_catalog(), &custom).unwrap();
+    assert!(catalog.get("openai", "gpt-4o").is_some());
+    let custom_entry = catalog.get("openai", "custom-gpt-4o").unwrap();
+    assert_eq!(custom_entry.context_window, Some(256_000));
+    assert!(custom_entry.supports_reasoning);
+    assert_eq!(custom_entry.reasoning_effort_values, vec!["low", "high"]);
+    assert!(custom_entry.is_custom);
 }

--- a/tests/config_store_tests.rs
+++ b/tests/config_store_tests.rs
@@ -1407,6 +1407,32 @@ async fn test_effective_model_catalog_rejects_duplicate_builtin() {
 }
 
 #[tokio::test]
+async fn test_set_custom_model_rejects_duplicate_builtin() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = open_test_store(dir.path().join("test.db")).await;
+
+    let input = iron_core::config::CustomModelInput {
+        provider_slug: "openai".to_string(),
+        model_id: "gpt-4o".to_string(),
+        display_name: "Duplicate GPT-4o".to_string(),
+        context_window: Some(100_000),
+        output_limit: Some(4_096),
+        supports_tool_calls: true,
+        supports_reasoning: false,
+        supports_vision: false,
+        supports_streaming: true,
+        reasoning_effort_values: vec![],
+        cost_input_per_million: None,
+        cost_output_per_million: None,
+    };
+
+    let result = store.set_custom_model(&input).await;
+    assert!(
+        matches!(result, Err(iron_core::config::ConfigError::Validation(ref msg)) if msg.contains("conflicts with a built-in model"))
+    );
+}
+
+#[tokio::test]
 async fn test_custom_model_extends_builtin_catalog() {
     let custom = vec![CustomModelRecord {
         provider_slug: "openai".to_string(),

--- a/tests/context_management_tests.rs
+++ b/tests/context_management_tests.rs
@@ -1974,7 +1974,7 @@ fn model_switch_active_session_queues_switch() {
         // While prompt is active, try to switch model
         let request = ModelSwitchRequest::Managed {
             provider_slug: "anthropic".into(),
-            model: "claude-3-sonnet".into(),
+            model: "claude-3-7-sonnet-20250219".into(),
             api_key: None,
         };
 
@@ -2165,7 +2165,9 @@ fn model_switch_smaller_window_triggers_compaction() {
 
 #[test]
 fn model_switch_too_small_window_rejected() {
-    use iron_core::{Config, ContextManagementConfig, IronAgent, ModelSwitchRequest};
+    use iron_core::{
+        Config, ContextManagementConfig, IronAgent, ModelCapabilityMetadata, ModelSwitchRequest,
+    };
     use iron_providers::ProviderEvent;
 
     run_local(async {
@@ -2184,6 +2186,20 @@ fn model_switch_too_small_window_rejected() {
         let agent = IronAgent::new(config, provider);
         let conn = agent.connect();
         let session = conn.create_session().unwrap();
+
+        agent
+            .runtime()
+            .register_model_capability(ModelCapabilityMetadata {
+                model: "tiny-model".into(),
+                provider: "openai".into(),
+                context_window: 10,
+                supports_tools: true,
+                supports_streaming: true,
+                supports_reasoning_effort: false,
+                reasoning_effort_values: Vec::new(),
+                supported_modalities: vec!["text".into()],
+                unsupported_tools: Vec::new(),
+            });
 
         // Establish conversation with long messages
         let _ = session.prompt("This is a very long user message with substantial content that will generate many tokens when estimated using the length-based heuristic, ensuring the total exceeds the minimal tail threshold").await;
@@ -2204,6 +2220,32 @@ fn model_switch_too_small_window_rejected() {
         assert!(
             err.contains("Context too large") || err.contains("too large"),
             "Error should indicate context is too large: {}",
+            err
+        );
+    });
+}
+
+#[test]
+fn model_switch_unknown_target_model_rejected() {
+    use iron_core::{Config, IronAgent, ModelSwitchRequest};
+
+    run_local(async {
+        let agent = IronAgent::new(Config::new(), MockProvider::with_infer_responses(vec![]));
+        let conn = agent.connect();
+        let session = conn.create_session().unwrap();
+
+        let request = ModelSwitchRequest::Managed {
+            provider_slug: "openai".into(),
+            model: "not-registered-model".into(),
+            api_key: None,
+        };
+
+        let result = session.switch_model(request);
+        assert!(result.is_err(), "Unknown target model should be rejected");
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("Unknown target model") && err.contains("openai/not-registered-model"),
+            "Error should identify the unknown target model: {}",
             err
         );
     });


### PR DESCRIPTION
## Summary
- add built-in and effective model catalogs for merging provider model metadata with ConfigStore custom models
- extend custom model records with streaming and reasoning effort metadata plus schema migration v3
- validate provider slugs and default models against the effective catalog
- hydrate runtime model capabilities from catalog metadata and reject switches to unknown target models
- sync and archive the `custom-model-runtime-integration` OpenSpec change

## Verification
- `cargo fmt -- --check`
- `cargo check`
- `cargo clippy --all-targets`
- `cargo test`
- `openspec status --change custom-model-runtime-integration` before archive

Closes #68

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Custom models now include streaming support and configurable reasoning-effort values.
  * Runtime builds a merged catalog of built-in + custom models used for default-model validation and model switching.
  * Built-in model metadata is registered at runtime so built-in models are recognized without custom records.

* **Bug Fixes**
  * Switching to unknown or conflicting models now fails with clear “unknown model” or capability-difference errors (unsupported tools/modalities).

* **Chores**
  * Storage schema updated to support the new custom-model fields and preserve backward compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->