### PR TITLE
feat(config): add saved handoff bundle storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,12 +395,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "base64ct"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
-
-[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -630,9 +624,9 @@ dependencies = [
 
 [[package]]
 name = "cbindgen"
-version = "0.29.3"
+version = "0.29.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c95537b45400390270fae69ac098d057c8f5399001cde9d04f700c105ddfff2d"
+checksum = "2ecb53484c9c167ba674026b656d8a27d7657a58e6066aa902bfb1a4aa00ae20"
 dependencies = [
  "heck",
  "indexmap 2.14.0",
@@ -682,13 +676,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chacha20poly1305"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher",
  "poly1305",
  "zeroize",
@@ -727,6 +732,12 @@ checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cobs"
@@ -775,12 +786,6 @@ checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
-
-[[package]]
-name = "const-oid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const-oid"
@@ -1077,6 +1082,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1123,17 +1137,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
  "uuid",
-]
-
-[[package]]
-name = "der"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
-dependencies = [
- "const-oid 0.9.6",
- "pem-rfc7468",
- "zeroize",
 ]
 
 [[package]]
@@ -1187,7 +1190,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid 0.9.6",
  "crypto-common 0.1.7",
  "subtle",
 ]
@@ -1199,15 +1201,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
- "const-oid 0.10.2",
+ "const-oid",
  "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
 name = "directories"
-version = "5.0.1"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
+checksum = "16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d"
 dependencies = [
  "dirs-sys",
 ]
@@ -1224,14 +1227,14 @@ dependencies = [
 
 [[package]]
 name = "dirs-sys"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
- "windows-sys 0.48.0",
+ "redox_users 0.5.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1241,7 +1244,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
- "redox_users",
+ "redox_users 0.4.6",
  "winapi",
 ]
 
@@ -1367,13 +1370,12 @@ dependencies = [
 
 [[package]]
 name = "etcetera"
-version = "0.8.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
 dependencies = [
  "cfg-if",
- "home",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1544,9 +1546,9 @@ dependencies = [
 
 [[package]]
 name = "flume"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1832,6 +1834,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1944,8 +1947,6 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
- "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -1970,11 +1971,11 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -2015,7 +2016,16 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
+dependencies = [
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -2028,19 +2038,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "home"
-version = "0.5.12"
+name = "hmac"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "windows-sys 0.61.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
 name = "http"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -2560,13 +2570,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.99"
+version = "0.3.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+checksum = "f2025f20d7a4fa7785846e7b63d10a76d3f1cee98ee5cb79ea59703f95e42162"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -2627,9 +2636,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin",
-]
 
 [[package]]
 name = "leb128"
@@ -2686,10 +2692,7 @@ version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
- "bitflags",
  "libc",
- "plain",
- "redox_syscall 0.8.1",
 ]
 
 [[package]]
@@ -2801,12 +2804,12 @@ checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "md-5"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
- "digest 0.10.7",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2962,22 +2965,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint-dig"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
-dependencies = [
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand 0.8.6",
- "smallvec",
- "zeroize",
-]
-
-[[package]]
 name = "num-cmp"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3036,7 +3023,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -3124,18 +3110,9 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
-]
-
-[[package]]
-name = "pem-rfc7468"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
-dependencies = [
- "base64ct",
 ]
 
 [[package]]
@@ -3230,37 +3207,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "pkcs1"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
-dependencies = [
- "der",
- "pkcs8",
- "spki",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der",
- "spki",
-]
-
-[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "polling"
@@ -3371,9 +3321,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -3381,9 +3331,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
  "itertools",
@@ -3602,6 +3552,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20 0.10.0",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3638,6 +3599,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_xoshiro"
@@ -3678,15 +3645,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b44b894f2a6e36457d665d1e08c3866add6ed5e70050c1b4ba8a8ddedb02ce7"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "redox_users"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3695,6 +3653,17 @@ dependencies = [
  "getrandom 0.2.17",
  "libredox",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3750,9 +3719,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3773,9 +3742,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
@@ -3852,26 +3821,6 @@ checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
 dependencies = [
  "rmp",
  "serde",
-]
-
-[[package]]
-name = "rsa"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
-dependencies = [
- "const-oid 0.9.6",
- "digest 0.10.7",
- "num-bigint-dig",
- "num-integer",
- "num-traits",
- "pkcs1",
- "pkcs8",
- "rand_core 0.6.4",
- "signature",
- "spki",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -4168,7 +4117,7 @@ dependencies = [
  "cbc",
  "futures-util",
  "generic-array",
- "hkdf",
+ "hkdf 0.12.4",
  "num",
  "once_cell",
  "rand 0.8.6",
@@ -4285,18 +4234,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
 name = "serde_with"
 version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4353,6 +4290,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4403,16 +4351,6 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
-]
-
-[[package]]
-name = "signature"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
-dependencies = [
- "digest 0.10.7",
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4499,20 +4437,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der",
-]
-
-[[package]]
 name = "sqlx"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+checksum = "378620ccc25c62c89d8be1c819e76a88d59bdcc3304733330788948e619bfd71"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -4523,12 +4451,13 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+checksum = "05b44e85bf579a8eeb4ceaa77a3a523baf2bf0e9bac7e40f405d537b5d2d5ccb"
 dependencies = [
  "base64",
  "bytes",
+ "cfg-if",
  "chrono",
  "crc",
  "crossbeam-queue",
@@ -4538,12 +4467,11 @@ dependencies = [
  "futures-intrusive",
  "futures-io",
  "futures-util",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "hashlink",
  "indexmap 2.14.0",
  "log",
  "memchr",
- "once_cell",
  "percent-encoding",
  "serde",
  "serde_json",
@@ -4558,9 +4486,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+checksum = "bd2b84f2bc39a5705ef27ec785a11c934a41bbd4a24941e257927cddc26b60bf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4571,15 +4499,15 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros-core"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+checksum = "fb8d96de5fdc85a5c4ec813432b523ec637e80ba98f046555f75f7908ddac7c3"
 dependencies = [
+ "cfg-if",
  "dotenvy",
  "either",
  "heck",
  "hex",
- "once_cell",
  "proc-macro2",
  "quote",
  "serde",
@@ -4590,58 +4518,43 @@ dependencies = [
  "sqlx-postgres",
  "sqlx-sqlite",
  "syn",
+ "thiserror 2.0.18",
  "tokio",
  "url",
 ]
 
 [[package]]
 name = "sqlx-mysql"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+checksum = "90b8020fe17c5f2c245bfa2505d7ef59c5604839527c740266ad2214acebea27"
 dependencies = [
- "atoi",
- "base64",
  "bitflags",
  "byteorder",
  "bytes",
  "chrono",
  "crc",
- "digest 0.10.7",
+ "digest 0.11.3",
  "dotenvy",
  "either",
- "futures-channel",
  "futures-core",
- "futures-io",
  "futures-util",
  "generic-array",
- "hex",
- "hkdf",
- "hmac",
- "itoa",
  "log",
- "md-5",
- "memchr",
- "once_cell",
  "percent-encoding",
- "rand 0.8.6",
- "rsa",
  "serde",
- "sha1",
- "sha2 0.10.9",
- "smallvec",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
  "sqlx-core",
- "stringprep",
  "thiserror 2.0.18",
  "tracing",
- "whoami",
 ]
 
 [[package]]
 name = "sqlx-postgres"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+checksum = "87a2bdd6e83f6b3ea525ca9fee568030508b58355a43d0b2c1674d5f79dcd65e"
 dependencies = [
  "atoi",
  "base64",
@@ -4655,18 +4568,16 @@ dependencies = [
  "futures-core",
  "futures-util",
  "hex",
- "hkdf",
- "hmac",
- "home",
+ "hkdf 0.13.0",
+ "hmac 0.13.0",
  "itoa",
  "log",
  "md-5",
  "memchr",
- "once_cell",
- "rand 0.8.6",
+ "rand 0.10.1",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -4677,13 +4588,14 @@ dependencies = [
 
 [[package]]
 name = "sqlx-sqlite"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+checksum = "488e99c397a62007e4229aec669a179816339afc6d2620ca6fa420dbee2e982c"
 dependencies = [
  "atoi",
  "chrono",
  "flume",
+ "form_urlencoded",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -4693,7 +4605,6 @@ dependencies = [
  "log",
  "percent-encoding",
  "serde",
- "serde_urlencoded",
  "sqlx-core",
  "thiserror 2.0.18",
  "tracing",
@@ -5405,9 +5316,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.2"
+version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -5518,16 +5429,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasite"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
-
-[[package]]
 name = "wasm-bindgen"
-version = "0.2.122"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+checksum = "a254a4b10c19a76f09a27640e7ffbf9bc30bf67e16a3bf28aaefa4920fe81563"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5538,9 +5443,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.72"
+version = "0.4.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
+checksum = "54568702fabf5d4849ce2b90fadfa64168a097eaf4b351ce9df8b687a0086aaf"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5548,9 +5453,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.122"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+checksum = "24a40fc75b0ec6f3746ceb10d36f53a93dcd68a93b11b6445983945d79eba0dc"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5558,9 +5463,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.122"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+checksum = "908f34bd9b9ce3d4caf07b72dfab63d61504d156856c6bd3cd87fa350cf3985b"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5571,9 +5476,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.122"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+checksum = "7acbf7616c27b194bbb550bf77ed0c2c3e5b7fd1260a93082b95fb7f47959b92"
 dependencies = [
  "unicode-ident",
 ]
@@ -5991,9 +5896,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.99"
+version = "0.3.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+checksum = "6e0871acf327f283dc6da28a1696cdc64fb355ba9f935d052021fa77f35cce69"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6029,13 +5934,9 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "1.6.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
-dependencies = [
- "libredox",
- "wasite",
-]
+checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
 
 [[package]]
 name = "wiggle"
@@ -6200,15 +6101,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -6241,21 +6133,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -6293,12 +6170,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -6311,12 +6182,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -6326,12 +6191,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6359,12 +6218,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -6374,12 +6227,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6395,12 +6242,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -6410,12 +6251,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6654,7 +6489,7 @@ dependencies = [
  "rand 0.8.6",
  "serde",
  "serde_repr",
- "sha1",
+ "sha1 0.10.6",
  "static_assertions",
  "tokio",
  "tracing",
@@ -6692,18 +6527,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,8 +57,8 @@ grep-searcher = "0.1"
 grep-regex = "0.1"
 
 # Config store dependencies
-sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite", "migrate", "chrono"] }
-directories = "5"
+sqlx = { version = "0.9", features = ["runtime-tokio", "sqlite", "migrate", "chrono"] }
+directories = "6"
 keyring = { version = "3", features = ["tokio", "async-secret-service", "linux-native"] }
 secret-service = { version = "4", features = ["rt-tokio-crypto-rust"] }
 base64 = "0.22"

--- a/openspec/changes/archive/2026-06-09-add-core-handoff-storage/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-09-add-core-handoff-storage/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-09

--- a/openspec/changes/archive/2026-06-09-add-core-handoff-storage/design.md
+++ b/openspec/changes/archive/2026-06-09-add-core-handoff-storage/design.md
@@ -1,0 +1,73 @@
+## Context
+
+`iron-core` already owns handoff bundle creation and hydration through `HandoffExporter`, `HandoffImporter`, and facade methods for exporting/importing active sessions. AgentIron desktop currently handles saved handoff files at the app command layer, which means persistence, JSON serialization, version validation, and list metadata semantics are not shared with CLI or headless consumers.
+
+The core config store already provides the durable SQLite-backed API surface for shared AgentIron state. Saved handoffs fit that ownership boundary because they are core-defined artifacts that should be readable by any `iron-core` consumer using the same config database.
+
+Saved handoff bundles are exact snapshots. Current `HandoffBundle` data may include sensitive fields such as `current_provider_api_key`, so this design treats saved handoffs as sensitive local state and does not alter bundle contents during persistence. Future security work may encrypt or protect the stored snapshot, but this change does not redefine snapshot semantics.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add `ConfigStore` APIs for `save_handoff`, `load_handoff`, `list_handoffs`, and `delete_handoff`.
+- Persist the full serialized `HandoffBundle` as the authoritative saved artifact.
+- Derive list metadata from the bundle and caller-provided name/id so UI and headless consumers can list saved handoffs without loading every bundle.
+- Validate identifiers, names, bundle version compatibility, metadata version compatibility, and deserialization failures at API boundaries.
+- Cover save, load, list, delete, update, migration, and invalid-bundle behavior with tests.
+
+**Non-Goals:**
+
+- Do not introduce a separate `HandoffStore` abstraction in this change.
+- Do not sanitize, redact, filter, transform, or reinterpret `HandoffBundle` fields during persistence.
+- Do not design future encrypted-at-rest saved handoff storage beyond preserving exact snapshot semantics.
+- Do not change session export/import behavior or handoff hydration semantics except where durable storage APIs call into existing serialization/version validation.
+- Do not migrate existing app-owned handoff JSON files automatically; app migration/import can be handled by consumers using the new APIs.
+
+## Decisions
+
+### Use `ConfigStore` as the public storage API
+
+Saved handoff APIs will be methods on `iron_core::config::ConfigStore` because saved handoffs are durable core-owned state that should share the existing config database, migration system, error model, and app/headless access path.
+
+Alternative considered: add a separate `HandoffStore`. That may become useful if saved handoff storage needs an independent backend later, but it would add abstraction before there is a concrete need.
+
+### Store exact `HandoffBundle` JSON as authoritative data
+
+The table will store `bundle_json` containing the serialized `HandoffBundle`. The persistence layer validates compatibility but does not repair or modify the bundle. Loading returns the deserialized bundle and saved metadata derived from the stored row.
+
+Alternative considered: normalize bundle contents across multiple tables. That would make listing and future querying easier but would make exact snapshot semantics harder to preserve and would couple storage to internal bundle shape.
+
+### Keep metadata columns derived and secondary
+
+The `saved_handoffs` table should include derived columns for `id`, `name`, `bundle_version`, `source_session_id`, `source_model`, `source_provider`, `size_estimate_tokens`, `created_at`, and `updated_at`. `list_handoffs` returns metadata only. `load_handoff` returns both metadata and bundle.
+
+Alternative considered: calculate list metadata by deserializing every bundle on list. That keeps schema smaller but makes listing unnecessarily expensive and makes malformed stored rows harder to surface consistently.
+
+### Use replace semantics for save
+
+`save_handoff` should create or update by stable handoff ID. Existing rows keep `created_at`, replace `name`, replace `bundle_json`, refresh derived metadata, and update `updated_at`.
+
+Alternative considered: fail on duplicate ID and require a separate update API. Existing `ConfigStore` opaque record APIs already use replace semantics, and save/load/list/delete is the requested vocabulary.
+
+### Validate at save and load boundaries
+
+`save_handoff` should reject empty/invalid IDs, empty names, unsupported bundle versions, metadata version mismatches, serialization failures, and numeric metadata that cannot be represented safely in storage. `load_handoff` should return `Ok(None)` for missing IDs and return a typed `ConfigError` for rows whose bundle JSON cannot deserialize or whose version is unsupported.
+
+Alternative considered: validate only on save. Load-time validation is still necessary because databases can be shared across versions or externally corrupted.
+
+## Risks / Trade-offs
+
+- Saved handoffs can contain credentials or other sensitive local state -> Document and preserve exact snapshot semantics now; defer hardening such as encryption-at-rest to a dedicated security change.
+- Metadata columns can drift from `bundle_json` if bugs write inconsistent rows -> Derive metadata inside `save_handoff`, validate on load, and test metadata derivation.
+- Future bundle versions may need compatibility behavior -> Gate current APIs on supported version constants and surface typed errors for unsupported versions rather than silently accepting incompatible snapshots.
+- App-owned JSON files may already exist -> This core change provides APIs for future app migration/import, but does not silently migrate desktop files from `iron-core`.
+
+## Migration Plan
+
+Add a compiled-in migration that creates `saved_handoffs` without altering existing config-store tables or data. Existing config databases should open normally and gain the new table. Rollback is source-level only; older binaries should ignore the extra table if they do not query it.
+
+## Open Questions
+
+- Should a future security change encrypt saved handoff snapshots with the same key-source infrastructure used for provider credentials, or should it use a distinct user-controlled export/import protection model?
+- Should explicit JSON import/export helper APIs live on `ConfigStore`, the handoff module, or facade types after the core saved-state APIs exist?

--- a/openspec/changes/archive/2026-06-09-add-core-handoff-storage/proposal.md
+++ b/openspec/changes/archive/2026-06-09-add-core-handoff-storage/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+AgentIron currently relies on app-layer JSON file handling for saved handoff bundles even though `iron-core` already owns bundle creation and hydration semantics. Moving saved handoff persistence into `iron-core::config::ConfigStore` gives desktop, CLI, and headless consumers one shared API for saving, loading, listing, deleting, and validating durable handoff snapshots.
+
+## What Changes
+
+- Add typed `ConfigStore` APIs to save, load, list, and delete saved handoff bundles.
+- Store saved handoffs as exact serialized `HandoffBundle` snapshots with derived metadata for listing.
+- Validate saved handoff identifiers, names, bundle schema versions, and serialized bundle shape at save/load boundaries.
+- Add a compiled-in config-store migration for a `saved_handoffs` table.
+- Add tests covering save, load, list, delete, update semantics, metadata derivation, and invalid bundle handling.
+- Do not strip, sanitize, rewrite, or reinterpret bundle contents during persistence; saved handoffs are sensitive local snapshots.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `core-config-store`: Add durable saved handoff bundle storage APIs and schema requirements to the existing core-owned config store.
+
+## Impact
+
+- Affected public APIs: `iron_core::config::ConfigStore` and related config-store handoff input/record/metadata types.
+- Affected storage: SQLite config-store migrations gain a `saved_handoffs` table with metadata columns and authoritative bundle JSON.
+- Affected handoff domain: existing `HandoffBundle` serialization and version constants become validation inputs for durable saved handoff records.
+- Affected consumers: AgentIron desktop can keep import/export UI while delegating saved handoff storage and validation semantics to `iron-core`; CLI/headless consumers can share the same saved handoff state.

--- a/openspec/changes/archive/2026-06-09-add-core-handoff-storage/specs/core-config-store/spec.md
+++ b/openspec/changes/archive/2026-06-09-add-core-handoff-storage/specs/core-config-store/spec.md
@@ -1,0 +1,71 @@
+## ADDED Requirements
+
+### Requirement: Config store supports saved handoff bundles
+
+The system SHALL provide typed `ConfigStore` APIs for saving, loading, listing, and deleting saved handoff bundles. Saved handoffs SHALL be stored by a stable caller-provided non-empty ID and non-empty human-readable name, and SHALL preserve the full serialized `HandoffBundle` as the authoritative saved artifact.
+
+#### Scenario: Saved handoff roundtrips
+- **WHEN** a caller saves a valid `HandoffBundle` with a stable ID and name
+- **THEN** the caller can load the saved handoff by the same ID
+- **AND** the loaded bundle matches the saved bundle exactly
+- **AND** the loaded record includes saved handoff metadata
+
+#### Scenario: Saved handoff is missing
+- **WHEN** a caller loads a saved handoff ID that does not exist
+- **THEN** the API returns `Ok(None)`
+
+#### Scenario: Saved handoff is deleted
+- **WHEN** a caller deletes a saved handoff by ID
+- **THEN** subsequent load calls for that ID return `Ok(None)`
+
+### Requirement: Config store lists saved handoff metadata
+
+The system SHALL provide a `ConfigStore` API that lists saved handoff metadata without requiring callers to load every full handoff bundle. Saved handoff metadata SHALL include ID, name, bundle version, created timestamp, updated timestamp, source session ID when present, source model when present, source provider when present, and size estimate tokens.
+
+#### Scenario: Saved handoff metadata is listed
+- **WHEN** a caller lists saved handoffs after saving one or more valid handoff bundles
+- **THEN** the returned list includes metadata for each saved handoff
+- **AND** the metadata includes the caller-provided ID and name
+- **AND** the metadata includes source session, source model, source provider, and size estimate values derived from the saved bundle when present
+- **AND** the list response does not include full bundle JSON or hydrated session content
+
+#### Scenario: Saved handoff metadata reflects updates
+- **WHEN** a caller saves a new bundle using an existing saved handoff ID
+- **THEN** the existing record is replaced atomically
+- **AND** the original created timestamp is preserved
+- **AND** the updated timestamp changes
+- **AND** list metadata reflects the replacement bundle and name
+
+### Requirement: Saved handoff persistence validates bundle compatibility
+
+The system SHALL validate saved handoff IDs, names, serialized bundle shape, bundle version, and bundle metadata version at save and load boundaries. Validation SHALL reject unsupported or malformed saved handoff data with an actionable `ConfigError` rather than silently accepting, repairing, sanitizing, or reinterpreting the bundle.
+
+#### Scenario: Invalid saved handoff input is rejected
+- **WHEN** a caller attempts to save a handoff with an empty ID, empty name, unsupported bundle version, unsupported metadata version, or unserializable bundle data
+- **THEN** the API returns a typed `ConfigError`
+- **AND** no successful saved handoff record is committed for that invalid input
+
+#### Scenario: Malformed stored bundle is rejected on load
+- **WHEN** a saved handoff row contains malformed bundle JSON or an unsupported bundle version
+- **THEN** loading that saved handoff returns a typed `ConfigError`
+- **AND** the system does not return a partially hydrated, repaired, or sanitized bundle
+
+#### Scenario: Saved handoff snapshot remains exact
+- **WHEN** a valid saved handoff bundle contains fields that are sensitive, optional, runtime-derived, or unknown to the storage layer
+- **THEN** the persistence API stores and loads the exact serialized bundle according to the current `HandoffBundle` schema
+- **AND** the persistence API does not strip, redact, transform, or reinterpret bundle fields
+
+### Requirement: Saved handoff schema is migrated on open
+
+The SQLite-backed config store SHALL add a compiled-in migration for saved handoff storage. The migration SHALL create a `saved_handoffs` table containing the authoritative serialized bundle and metadata columns sufficient for listing saved handoffs.
+
+#### Scenario: Existing config store opens after saved handoff migration
+- **WHEN** a config store database created before saved handoff storage is opened
+- **THEN** the system applies the saved handoff migration
+- **AND** existing profile, prompt, schedule, credential, provider runtime, custom model, MCP, and skill settings records remain available
+- **AND** saved handoff APIs are available
+
+#### Scenario: In-memory store includes saved handoff schema
+- **WHEN** an in-memory config store is created for tests or embedders
+- **THEN** the same compiled-in saved handoff migration is applied
+- **AND** saved handoff CRUD APIs are available without user configuration files

--- a/openspec/changes/archive/2026-06-09-add-core-handoff-storage/tasks.md
+++ b/openspec/changes/archive/2026-06-09-add-core-handoff-storage/tasks.md
@@ -1,0 +1,31 @@
+## 1. Schema And Types
+
+- [x] 1.1 Add a compiled-in config-store migration that creates the `saved_handoffs` table with bundle JSON, derived metadata columns, and timestamps.
+- [x] 1.2 Add public config-store types for saved handoff save input, saved handoff metadata, and loaded saved handoff records.
+- [x] 1.3 Re-export the new saved handoff types from `iron_core::config` consistently with existing config-store records.
+
+## 2. ConfigStore APIs
+
+- [x] 2.1 Implement `ConfigStore::save_handoff` with ID/name validation, bundle compatibility validation, metadata derivation, transactional replace semantics, and timestamp handling.
+- [x] 2.2 Implement `ConfigStore::load_handoff` returning `Ok(None)` for missing IDs and typed errors for malformed or unsupported stored bundles.
+- [x] 2.3 Implement `ConfigStore::list_handoffs` returning metadata-only records without deserializing or returning full bundle contents.
+- [x] 2.4 Implement `ConfigStore::delete_handoff` with missing-record behavior consistent with existing delete APIs.
+
+## 3. Validation And Errors
+
+- [x] 3.1 Add validation helpers for saved handoff IDs, names, bundle versions, metadata versions, serialization, and deserialization failures.
+- [x] 3.2 Map invalid saved handoff input and corrupted stored bundle cases to actionable `ConfigError` variants without panics.
+- [x] 3.3 Ensure persistence preserves exact `HandoffBundle` snapshots and does not redact, rewrite, or reinterpret bundle fields.
+
+## 4. Tests
+
+- [x] 4.1 Add in-memory config-store tests for save/load exact roundtrip behavior.
+- [x] 4.2 Add tests for list metadata derivation, metadata-only listing, update replace semantics, and timestamp behavior.
+- [x] 4.3 Add tests for delete behavior and missing load behavior.
+- [x] 4.4 Add tests for invalid save input and malformed or unsupported stored bundle handling.
+- [x] 4.5 Add migration tests proving existing config-store data remains available after the saved handoff migration.
+
+## 5. Verification
+
+- [x] 5.1 Run the focused config-store and handoff test suites.
+- [x] 5.2 Run `cargo check --manifest-path Cargo.toml` if touched Rust APIs affect crate-wide compilation.

--- a/openspec/specs/core-config-store/spec.md
+++ b/openspec/specs/core-config-store/spec.md
@@ -369,3 +369,73 @@ The SQLite-backed config store SHALL add compiled-in migrations for provider con
 - **WHEN** an in-memory config store is created for tests or embedders
 - **THEN** the same compiled-in runtime-settings migrations are applied
 - **AND** runtime settings CRUD APIs are available without user configuration files
+
+### Requirement: Config store supports saved handoff bundles
+
+The system SHALL provide typed `ConfigStore` APIs for saving, loading, listing, and deleting saved handoff bundles. Saved handoffs SHALL be stored by a stable caller-provided non-empty ID and non-empty human-readable name, and SHALL preserve the full serialized `HandoffBundle` as the authoritative saved artifact.
+
+#### Scenario: Saved handoff roundtrips
+- **WHEN** a caller saves a valid `HandoffBundle` with a stable ID and name
+- **THEN** the caller can load the saved handoff by the same ID
+- **AND** the loaded bundle matches the saved bundle exactly
+- **AND** the loaded record includes saved handoff metadata
+
+#### Scenario: Saved handoff is missing
+- **WHEN** a caller loads a saved handoff ID that does not exist
+- **THEN** the API returns `Ok(None)`
+
+#### Scenario: Saved handoff is deleted
+- **WHEN** a caller deletes a saved handoff by ID
+- **THEN** subsequent load calls for that ID return `Ok(None)`
+
+### Requirement: Config store lists saved handoff metadata
+
+The system SHALL provide a `ConfigStore` API that lists saved handoff metadata without requiring callers to load every full handoff bundle. Saved handoff metadata SHALL include ID, name, bundle version, created timestamp, updated timestamp, source session ID when present, source model when present, source provider when present, and size estimate tokens.
+
+#### Scenario: Saved handoff metadata is listed
+- **WHEN** a caller lists saved handoffs after saving one or more valid handoff bundles
+- **THEN** the returned list includes metadata for each saved handoff
+- **AND** the metadata includes the caller-provided ID and name
+- **AND** the metadata includes source session, source model, source provider, and size estimate values derived from the saved bundle when present
+- **AND** the list response does not include full bundle JSON or hydrated session content
+
+#### Scenario: Saved handoff metadata reflects updates
+- **WHEN** a caller saves a new bundle using an existing saved handoff ID
+- **THEN** the existing record is replaced atomically
+- **AND** the original created timestamp is preserved
+- **AND** the updated timestamp changes
+- **AND** list metadata reflects the replacement bundle and name
+
+### Requirement: Saved handoff persistence validates bundle compatibility
+
+The system SHALL validate saved handoff IDs, names, serialized bundle shape, bundle version, and bundle metadata version at save and load boundaries. Validation SHALL reject unsupported or malformed saved handoff data with an actionable `ConfigError` rather than silently accepting, repairing, sanitizing, or reinterpreting the bundle.
+
+#### Scenario: Invalid saved handoff input is rejected
+- **WHEN** a caller attempts to save a handoff with an empty ID, empty name, unsupported bundle version, unsupported metadata version, or unserializable bundle data
+- **THEN** the API returns a typed `ConfigError`
+- **AND** no successful saved handoff record is committed for that invalid input
+
+#### Scenario: Malformed stored bundle is rejected on load
+- **WHEN** a saved handoff row contains malformed bundle JSON or an unsupported bundle version
+- **THEN** loading that saved handoff returns a typed `ConfigError`
+- **AND** the system does not return a partially hydrated, repaired, or sanitized bundle
+
+#### Scenario: Saved handoff snapshot remains exact
+- **WHEN** a valid saved handoff bundle contains fields that are sensitive, optional, runtime-derived, or unknown to the storage layer
+- **THEN** the persistence API stores and loads the exact serialized bundle according to the current `HandoffBundle` schema
+- **AND** the persistence API does not strip, redact, transform, or reinterpret bundle fields
+
+### Requirement: Saved handoff schema is migrated on open
+
+The SQLite-backed config store SHALL add a compiled-in migration for saved handoff storage. The migration SHALL create a `saved_handoffs` table containing the authoritative serialized bundle and metadata columns sufficient for listing saved handoffs.
+
+#### Scenario: Existing config store opens after saved handoff migration
+- **WHEN** a config store database created before saved handoff storage is opened
+- **THEN** the system applies the saved handoff migration
+- **AND** existing profile, prompt, schedule, credential, provider runtime, custom model, MCP, and skill settings records remain available
+- **AND** saved handoff APIs are available
+
+#### Scenario: In-memory store includes saved handoff schema
+- **WHEN** an in-memory config store is created for tests or embedders
+- **THEN** the same compiled-in saved handoff migration is applied
+- **AND** saved handoff CRUD APIs are available without user configuration files

--- a/src/config/migrations.rs
+++ b/src/config/migrations.rs
@@ -173,7 +173,7 @@ pub async fn apply_migrations(pool: &sqlx::SqlitePool) -> Result<(), super::erro
                 .await
                 .map_err(|e| super::error::ConfigError::Migration(e.to_string()))?;
 
-            sqlx::raw_sql(sql).execute(&mut *tx).await.map_err(|e| {
+            sqlx::raw_sql(*sql).execute(&mut *tx).await.map_err(|e| {
                 super::error::ConfigError::Migration(format!("Migration {} failed: {}", version, e))
             })?;
 

--- a/src/config/migrations.rs
+++ b/src/config/migrations.rs
@@ -118,11 +118,30 @@ pub const MIGRATIONS: &[(i64, &str)] = &[
             INSERT OR IGNORE INTO schema_version (id, version) VALUES (1, 3);
             "#,
     ),
+    (
+        4,
+        r#"
+            CREATE TABLE IF NOT EXISTS saved_handoffs (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                bundle_json TEXT NOT NULL,
+                bundle_version TEXT NOT NULL,
+                source_session_id TEXT NULL,
+                source_model TEXT NULL,
+                source_provider TEXT NULL,
+                size_estimate_tokens INTEGER NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+
+            INSERT OR IGNORE INTO schema_version (id, version) VALUES (1, 4);
+            "#,
+    ),
 ];
 
 /// The current schema version.
 #[allow(dead_code)]
-pub const CURRENT_SCHEMA_VERSION: i64 = 3;
+pub const CURRENT_SCHEMA_VERSION: i64 = 4;
 
 /// Apply all pending migrations to the database.
 pub async fn apply_migrations(pool: &sqlx::SqlitePool) -> Result<(), super::error::ConfigError> {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -587,6 +587,7 @@ pub use records::{
     CredentialRecord, CustomModelInput, CustomModelRecord, DefaultModelInput, DefaultModelRecord,
     McpServerConfigInput, McpServerConfigRecord, ProfileInput, ProfileRecord, PromptInput,
     PromptRecord, ProviderConfigInput, ProviderConfigRecord, RuntimeSettingsSnapshot,
-    ScheduleInput, ScheduleRecord, SkillSettingsInput, SkillSettingsRecord,
+    SavedHandoffInput, SavedHandoffMetadata, SavedHandoffRecord, ScheduleInput, ScheduleRecord,
+    SkillSettingsInput, SkillSettingsRecord,
 };
 pub use store::{default_config_path, ConfigStore, OpenOptions};

--- a/src/config/records.rs
+++ b/src/config/records.rs
@@ -190,3 +190,36 @@ pub struct RuntimeSettingsSnapshot {
     pub mcp_servers: Vec<McpServerConfigRecord>,
     pub skill_settings: SkillSettingsRecord,
 }
+
+// ============================================================================
+// Saved Handoff Records (Issue #69)
+// ============================================================================
+
+/// Metadata for a saved handoff bundle.
+#[derive(Debug, Clone)]
+pub struct SavedHandoffMetadata {
+    pub id: String,
+    pub name: String,
+    pub bundle_version: String,
+    pub source_session_id: Option<String>,
+    pub source_model: Option<String>,
+    pub source_provider: Option<String>,
+    pub size_estimate_tokens: usize,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// A saved handoff record with the full bundle.
+#[derive(Debug, Clone)]
+pub struct SavedHandoffRecord {
+    pub metadata: SavedHandoffMetadata,
+    pub bundle: crate::context::handoff::HandoffBundle,
+}
+
+/// Input for saving a handoff bundle.
+#[derive(Debug, Clone)]
+pub struct SavedHandoffInput {
+    pub id: String,
+    pub name: String,
+    pub bundle: crate::context::handoff::HandoffBundle,
+}

--- a/src/config/store.rs
+++ b/src/config/store.rs
@@ -120,6 +120,11 @@ impl ConfigStore {
         })
     }
 
+    /// Access the underlying SQLite pool (for tests and direct queries).
+    pub fn pool(&self) -> &SqlitePool {
+        &self.pool
+    }
+
     // Profile APIs
 
     /// Store or replace a profile record.
@@ -1481,6 +1486,195 @@ fn deserialize_mcp_transport(
             "Unknown MCP transport kind: {}",
             other
         ))),
+    }
+}
+
+// ============================================================================
+// Saved Handoff APIs (Issue #69)
+// ============================================================================
+
+impl ConfigStore {
+    /// Save or replace a handoff bundle.
+    ///
+    /// Returns `ConfigError::Validation` if the ID or name is empty, or if the
+    /// bundle version is not supported.
+    pub async fn save_handoff(&self, input: &SavedHandoffInput) -> Result<(), ConfigError> {
+        // Validate ID
+        if input.id.is_empty() {
+            return Err(ConfigError::Validation(
+                "Handoff ID must not be empty".to_string(),
+            ));
+        }
+
+        // Validate name
+        if input.name.is_empty() {
+            return Err(ConfigError::Validation(
+                "Handoff name must not be empty".to_string(),
+            ));
+        }
+
+        // Validate bundle version
+        if input.bundle.version != crate::context::handoff::HANDOFF_BUNDLE_VERSION {
+            return Err(ConfigError::Validation(format!(
+                "Unsupported handoff bundle version: {} (expected {})",
+                input.bundle.version,
+                crate::context::handoff::HANDOFF_BUNDLE_VERSION
+            )));
+        }
+
+        // Serialize bundle
+        let bundle_json = serde_json::to_string(&input.bundle)
+            .map_err(|e| ConfigError::Serialization(e.to_string()))?;
+
+        let now = Utc::now().to_rfc3339();
+
+        sqlx::query(
+            r#"
+            INSERT INTO saved_handoffs (id, name, bundle_json, bundle_version, source_session_id, source_model, source_provider, size_estimate_tokens, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(id) DO UPDATE SET
+                name = excluded.name,
+                bundle_json = excluded.bundle_json,
+                bundle_version = excluded.bundle_version,
+                source_session_id = excluded.source_session_id,
+                source_model = excluded.source_model,
+                source_provider = excluded.source_provider,
+                size_estimate_tokens = excluded.size_estimate_tokens,
+                updated_at = excluded.updated_at
+            "#,
+        )
+        .bind(&input.id)
+        .bind(&input.name)
+        .bind(&bundle_json)
+        .bind(&input.bundle.version)
+        .bind(&input.bundle.metadata.source_session_id)
+        .bind(&input.bundle.metadata.source_model)
+        .bind(&input.bundle.metadata.source_provider)
+        .bind(input.bundle.metadata.size_estimate_tokens as i64)
+        .bind(&now)
+        .bind(&now)
+        .execute(&self.pool)
+        .await
+        .map_err(ConfigError::from)?;
+
+        Ok(())
+    }
+
+    /// Load a saved handoff by ID.
+    ///
+    /// Returns `Ok(None)` if the handoff does not exist.
+    /// Returns a typed error if the stored bundle is malformed or has an
+    /// unsupported version.
+    pub async fn load_handoff(&self, id: &str) -> Result<Option<SavedHandoffRecord>, ConfigError> {
+        let row = sqlx::query(
+            r#"
+            SELECT id, name, bundle_json, bundle_version, source_session_id,
+                   source_model, source_provider, size_estimate_tokens,
+                   created_at, updated_at
+            FROM saved_handoffs
+            WHERE id = ?
+            "#,
+        )
+        .bind(id)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(ConfigError::from)?;
+
+        match row {
+            Some(row) => {
+                let bundle_json: String = row.get("bundle_json");
+                let bundle: crate::context::handoff::HandoffBundle =
+                    serde_json::from_str(&bundle_json)
+                        .map_err(|e| ConfigError::Deserialization(e.to_string()))?;
+
+                // Validate loaded bundle version
+                if bundle.version != crate::context::handoff::HANDOFF_BUNDLE_VERSION {
+                    return Err(ConfigError::Validation(format!(
+                        "Unsupported stored handoff bundle version: {} (expected {})",
+                        bundle.version,
+                        crate::context::handoff::HANDOFF_BUNDLE_VERSION
+                    )));
+                }
+
+                Ok(Some(SavedHandoffRecord {
+                    metadata: SavedHandoffMetadata {
+                        id: row.get("id"),
+                        name: row.get("name"),
+                        bundle_version: row.get("bundle_version"),
+                        source_session_id: row.get("source_session_id"),
+                        source_model: row.get("source_model"),
+                        source_provider: row.get("source_provider"),
+                        size_estimate_tokens: row.get::<i64, _>("size_estimate_tokens") as usize,
+                        created_at: chrono::DateTime::parse_from_rfc3339(
+                            &row.get::<String, _>("created_at"),
+                        )
+                        .map_err(|e| ConfigError::Deserialization(e.to_string()))?
+                        .with_timezone(&Utc),
+                        updated_at: chrono::DateTime::parse_from_rfc3339(
+                            &row.get::<String, _>("updated_at"),
+                        )
+                        .map_err(|e| ConfigError::Deserialization(e.to_string()))?
+                        .with_timezone(&Utc),
+                    },
+                    bundle,
+                }))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// List all saved handoff metadata.
+    ///
+    /// Returns metadata only; full bundles are not deserialized.
+    pub async fn list_handoffs(&self) -> Result<Vec<SavedHandoffMetadata>, ConfigError> {
+        let rows = sqlx::query(
+            r#"
+            SELECT id, name, bundle_version, source_session_id,
+                   source_model, source_provider, size_estimate_tokens,
+                   created_at, updated_at
+            FROM saved_handoffs
+            ORDER BY updated_at DESC
+            "#,
+        )
+        .fetch_all(&self.pool)
+        .await
+        .map_err(ConfigError::from)?;
+
+        Ok(rows
+            .into_iter()
+            .map(|row| SavedHandoffMetadata {
+                id: row.get("id"),
+                name: row.get("name"),
+                bundle_version: row.get("bundle_version"),
+                source_session_id: row.get("source_session_id"),
+                source_model: row.get("source_model"),
+                source_provider: row.get("source_provider"),
+                size_estimate_tokens: row.get::<i64, _>("size_estimate_tokens") as usize,
+                created_at: chrono::DateTime::parse_from_rfc3339(
+                    &row.get::<String, _>("created_at"),
+                )
+                .map_err(|e| ConfigError::Deserialization(e.to_string()))
+                .unwrap_or_else(|_| Utc::now().into())
+                .with_timezone(&Utc),
+                updated_at: chrono::DateTime::parse_from_rfc3339(
+                    &row.get::<String, _>("updated_at"),
+                )
+                .map_err(|e| ConfigError::Deserialization(e.to_string()))
+                .unwrap_or_else(|_| Utc::now().into())
+                .with_timezone(&Utc),
+            })
+            .collect())
+    }
+
+    /// Delete a saved handoff by ID.
+    pub async fn delete_handoff(&self, id: &str) -> Result<(), ConfigError> {
+        sqlx::query("DELETE FROM saved_handoffs WHERE id = ?")
+            .bind(id)
+            .execute(&self.pool)
+            .await
+            .map_err(ConfigError::from)?;
+
+        Ok(())
     }
 }
 

--- a/src/config/store.rs
+++ b/src/config/store.rs
@@ -1493,11 +1493,28 @@ fn deserialize_mcp_transport(
 // Saved Handoff APIs (Issue #69)
 // ============================================================================
 
+/// Convert a usize token count to an i64 for database storage.
+fn to_db_token_count(value: usize) -> Result<i64, ConfigError> {
+    i64::try_from(value).map_err(|_| {
+        ConfigError::Validation("size_estimate_tokens exceeds SQLite INTEGER range".to_string())
+    })
+}
+
+/// Convert an i64 token count from database storage to usize.
+fn from_db_token_count(value: i64) -> Result<usize, ConfigError> {
+    usize::try_from(value).map_err(|_| {
+        ConfigError::Deserialization(format!(
+            "Invalid persisted size_estimate_tokens value: {}",
+            value
+        ))
+    })
+}
+
 impl ConfigStore {
     /// Save or replace a handoff bundle.
     ///
     /// Returns `ConfigError::Validation` if the ID or name is empty, or if the
-    /// bundle version is not supported.
+    /// bundle version or metadata version is not supported.
     pub async fn save_handoff(&self, input: &SavedHandoffInput) -> Result<(), ConfigError> {
         // Validate ID
         if input.id.is_empty() {
@@ -1518,6 +1535,15 @@ impl ConfigStore {
             return Err(ConfigError::Validation(format!(
                 "Unsupported handoff bundle version: {} (expected {})",
                 input.bundle.version,
+                crate::context::handoff::HANDOFF_BUNDLE_VERSION
+            )));
+        }
+
+        // Validate metadata version
+        if input.bundle.metadata.version != crate::context::handoff::HANDOFF_BUNDLE_VERSION {
+            return Err(ConfigError::Validation(format!(
+                "Unsupported handoff metadata version: {} (expected {})",
+                input.bundle.metadata.version,
                 crate::context::handoff::HANDOFF_BUNDLE_VERSION
             )));
         }
@@ -1550,7 +1576,7 @@ impl ConfigStore {
         .bind(&input.bundle.metadata.source_session_id)
         .bind(&input.bundle.metadata.source_model)
         .bind(&input.bundle.metadata.source_provider)
-        .bind(input.bundle.metadata.size_estimate_tokens as i64)
+        .bind(to_db_token_count(input.bundle.metadata.size_estimate_tokens)?)
         .bind(&now)
         .bind(&now)
         .execute(&self.pool)
@@ -1596,6 +1622,15 @@ impl ConfigStore {
                     )));
                 }
 
+                // Validate loaded metadata version
+                if bundle.metadata.version != crate::context::handoff::HANDOFF_BUNDLE_VERSION {
+                    return Err(ConfigError::Validation(format!(
+                        "Unsupported stored handoff metadata version: {} (expected {})",
+                        bundle.metadata.version,
+                        crate::context::handoff::HANDOFF_BUNDLE_VERSION
+                    )));
+                }
+
                 Ok(Some(SavedHandoffRecord {
                     metadata: SavedHandoffMetadata {
                         id: row.get("id"),
@@ -1604,17 +1639,11 @@ impl ConfigStore {
                         source_session_id: row.get("source_session_id"),
                         source_model: row.get("source_model"),
                         source_provider: row.get("source_provider"),
-                        size_estimate_tokens: row.get::<i64, _>("size_estimate_tokens") as usize,
-                        created_at: chrono::DateTime::parse_from_rfc3339(
-                            &row.get::<String, _>("created_at"),
-                        )
-                        .map_err(|e| ConfigError::Deserialization(e.to_string()))?
-                        .with_timezone(&Utc),
-                        updated_at: chrono::DateTime::parse_from_rfc3339(
-                            &row.get::<String, _>("updated_at"),
-                        )
-                        .map_err(|e| ConfigError::Deserialization(e.to_string()))?
-                        .with_timezone(&Utc),
+                        size_estimate_tokens: from_db_token_count(
+                            row.get::<i64, _>("size_estimate_tokens"),
+                        )?,
+                        created_at: parse_datetime(row.get::<String, _>("created_at"))?,
+                        updated_at: parse_datetime(row.get::<String, _>("updated_at"))?,
                     },
                     bundle,
                 }))
@@ -1640,30 +1669,23 @@ impl ConfigStore {
         .await
         .map_err(ConfigError::from)?;
 
-        Ok(rows
-            .into_iter()
-            .map(|row| SavedHandoffMetadata {
-                id: row.get("id"),
-                name: row.get("name"),
-                bundle_version: row.get("bundle_version"),
-                source_session_id: row.get("source_session_id"),
-                source_model: row.get("source_model"),
-                source_provider: row.get("source_provider"),
-                size_estimate_tokens: row.get::<i64, _>("size_estimate_tokens") as usize,
-                created_at: chrono::DateTime::parse_from_rfc3339(
-                    &row.get::<String, _>("created_at"),
-                )
-                .map_err(|e| ConfigError::Deserialization(e.to_string()))
-                .unwrap_or_else(|_| Utc::now().into())
-                .with_timezone(&Utc),
-                updated_at: chrono::DateTime::parse_from_rfc3339(
-                    &row.get::<String, _>("updated_at"),
-                )
-                .map_err(|e| ConfigError::Deserialization(e.to_string()))
-                .unwrap_or_else(|_| Utc::now().into())
-                .with_timezone(&Utc),
+        rows.into_iter()
+            .map(|row| {
+                Ok(SavedHandoffMetadata {
+                    id: row.get("id"),
+                    name: row.get("name"),
+                    bundle_version: row.get("bundle_version"),
+                    source_session_id: row.get("source_session_id"),
+                    source_model: row.get("source_model"),
+                    source_provider: row.get("source_provider"),
+                    size_estimate_tokens: from_db_token_count(
+                        row.get::<i64, _>("size_estimate_tokens"),
+                    )?,
+                    created_at: parse_datetime(row.get::<String, _>("created_at"))?,
+                    updated_at: parse_datetime(row.get::<String, _>("updated_at"))?,
+                })
             })
-            .collect())
+            .collect()
     }
 
     /// Delete a saved handoff by ID.

--- a/tests/config_store_tests.rs
+++ b/tests/config_store_tests.rs
@@ -1016,7 +1016,7 @@ async fn test_migrations_v1_to_v2() {
         .fetch_one(&mut *conn)
         .await
         .unwrap();
-    assert_eq!(version, 3);
+    assert_eq!(version, 4);
 
     // Verify v2/v3 tables exist by using the new APIs
     store
@@ -1368,7 +1368,7 @@ async fn test_migrations_v2_to_v3_custom_models_columns() {
         .fetch_one(&mut *conn)
         .await
         .unwrap();
-    assert_eq!(version, 3);
+    assert_eq!(version, 4);
 
     // Verify the new columns have correct defaults for existing rows
     let retrieved = store
@@ -1458,4 +1458,281 @@ async fn test_custom_model_extends_builtin_catalog() {
     assert!(custom_entry.supports_reasoning);
     assert_eq!(custom_entry.reasoning_effort_values, vec!["low", "high"]);
     assert!(custom_entry.is_custom);
+}
+
+// ============================================================================
+// Saved Handoff Tests (Issue #69)
+// ============================================================================
+
+fn create_test_handoff_bundle(id: &str) -> iron_core::context::handoff::HandoffBundle {
+    iron_core::context::handoff::HandoffBundle {
+        version: iron_core::context::handoff::HANDOFF_BUNDLE_VERSION.to_string(),
+        instructions: Some("Test instructions".to_string()),
+        handoff_note: format!("Test handoff for {}", id),
+        compressed_blocks: vec![],
+        recent_tail: vec![],
+        skill_state: iron_core::skill::SessionSkillState { active: vec![] },
+        metadata: iron_core::context::handoff::HandoffBundleMetadata {
+            version: iron_core::context::handoff::HANDOFF_BUNDLE_VERSION.to_string(),
+            source_model: "gpt-4o".to_string(),
+            source_provider: Some("openai".to_string()),
+            source_session_id: format!("session-{}", id),
+            size_estimate_tokens: 1000,
+        },
+        model_switch_history: vec![],
+        current_model: Some("gpt-4o".to_string()),
+        current_provider_slug: Some("openai".to_string()),
+        current_provider_api_key: Some("sk-test-key".to_string()),
+        hidden_tools: vec![],
+    }
+}
+
+#[tokio::test]
+async fn test_saved_handoff_roundtrip() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+
+    let bundle = create_test_handoff_bundle("test1");
+    let input = iron_core::config::SavedHandoffInput {
+        id: "handoff-1".to_string(),
+        name: "Test Handoff 1".to_string(),
+        bundle: bundle.clone(),
+    };
+
+    store.save_handoff(&input).await.unwrap();
+
+    let loaded = store.load_handoff("handoff-1").await.unwrap();
+    assert!(loaded.is_some());
+    let loaded = loaded.unwrap();
+
+    assert_eq!(loaded.metadata.id, "handoff-1");
+    assert_eq!(loaded.metadata.name, "Test Handoff 1");
+    assert_eq!(loaded.bundle, bundle);
+    assert_eq!(
+        loaded.bundle.current_provider_api_key,
+        Some("sk-test-key".to_string())
+    );
+}
+
+#[tokio::test]
+async fn test_saved_handoff_missing_returns_none() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+    let result = store.load_handoff("nonexistent").await.unwrap();
+    assert!(result.is_none());
+}
+
+#[tokio::test]
+async fn test_saved_handoff_list_metadata_only() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+
+    let bundle1 = create_test_handoff_bundle("test1");
+    let input1 = iron_core::config::SavedHandoffInput {
+        id: "handoff-1".to_string(),
+        name: "Test Handoff 1".to_string(),
+        bundle: bundle1,
+    };
+    store.save_handoff(&input1).await.unwrap();
+
+    let bundle2 = create_test_handoff_bundle("test2");
+    let input2 = iron_core::config::SavedHandoffInput {
+        id: "handoff-2".to_string(),
+        name: "Test Handoff 2".to_string(),
+        bundle: bundle2,
+    };
+    store.save_handoff(&input2).await.unwrap();
+
+    let list = store.list_handoffs().await.unwrap();
+    assert_eq!(list.len(), 2);
+
+    // Verify metadata is present but bundle is not loaded
+    let meta1 = list.iter().find(|m| m.id == "handoff-1").unwrap();
+    assert_eq!(meta1.name, "Test Handoff 1");
+    assert_eq!(meta1.source_model, Some("gpt-4o".to_string()));
+    assert_eq!(meta1.source_provider, Some("openai".to_string()));
+    assert_eq!(meta1.size_estimate_tokens, 1000);
+}
+
+#[tokio::test]
+async fn test_saved_handoff_update_replace() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+
+    let bundle1 = create_test_handoff_bundle("test1");
+    let input1 = iron_core::config::SavedHandoffInput {
+        id: "handoff-1".to_string(),
+        name: "Original Name".to_string(),
+        bundle: bundle1.clone(),
+    };
+    store.save_handoff(&input1).await.unwrap();
+
+    let original = store.load_handoff("handoff-1").await.unwrap().unwrap();
+    let original_created = original.metadata.created_at;
+
+    // Small delay to ensure updated_at changes
+    tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+
+    let mut bundle2 = create_test_handoff_bundle("test2");
+    bundle2.handoff_note = "Updated note".to_string();
+    let input2 = iron_core::config::SavedHandoffInput {
+        id: "handoff-1".to_string(),
+        name: "Updated Name".to_string(),
+        bundle: bundle2.clone(),
+    };
+    store.save_handoff(&input2).await.unwrap();
+
+    let updated = store.load_handoff("handoff-1").await.unwrap().unwrap();
+    assert_eq!(updated.metadata.name, "Updated Name");
+    assert_eq!(updated.bundle.handoff_note, "Updated note");
+    assert_eq!(updated.metadata.created_at, original_created);
+    assert!(updated.metadata.updated_at > original_created);
+}
+
+#[tokio::test]
+async fn test_saved_handoff_delete() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+
+    let bundle = create_test_handoff_bundle("test1");
+    let input = iron_core::config::SavedHandoffInput {
+        id: "handoff-1".to_string(),
+        name: "Test Handoff".to_string(),
+        bundle,
+    };
+    store.save_handoff(&input).await.unwrap();
+    assert!(store.load_handoff("handoff-1").await.unwrap().is_some());
+
+    store.delete_handoff("handoff-1").await.unwrap();
+    assert!(store.load_handoff("handoff-1").await.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn test_saved_handoff_empty_id_rejected() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+
+    let bundle = create_test_handoff_bundle("test1");
+    let input = iron_core::config::SavedHandoffInput {
+        id: "".to_string(),
+        name: "Test".to_string(),
+        bundle,
+    };
+    let err = store.save_handoff(&input).await.unwrap_err();
+    assert!(
+        matches!(err, iron_core::config::ConfigError::Validation(ref msg) if msg.contains("Handoff ID"))
+    );
+}
+
+#[tokio::test]
+async fn test_saved_handoff_empty_name_rejected() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+
+    let bundle = create_test_handoff_bundle("test1");
+    let input = iron_core::config::SavedHandoffInput {
+        id: "handoff-1".to_string(),
+        name: "".to_string(),
+        bundle,
+    };
+    let err = store.save_handoff(&input).await.unwrap_err();
+    assert!(
+        matches!(err, iron_core::config::ConfigError::Validation(ref msg) if msg.contains("Handoff name"))
+    );
+}
+
+#[tokio::test]
+async fn test_saved_handoff_unsupported_version_rejected() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+
+    let mut bundle = create_test_handoff_bundle("test1");
+    bundle.version = "99".to_string();
+    let input = iron_core::config::SavedHandoffInput {
+        id: "handoff-1".to_string(),
+        name: "Test".to_string(),
+        bundle,
+    };
+    let err = store.save_handoff(&input).await.unwrap_err();
+    assert!(
+        matches!(err, iron_core::config::ConfigError::Validation(ref msg) if msg.contains("Unsupported handoff bundle version"))
+    );
+}
+
+#[tokio::test]
+async fn test_saved_handoff_malformed_bundle_rejected_on_load() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+
+    // Insert a malformed bundle directly into the database
+    sqlx::query(
+        "INSERT INTO saved_handoffs (id, name, bundle_json, bundle_version, source_session_id, source_model, source_provider, size_estimate_tokens, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+    )
+    .bind("bad-handoff")
+    .bind("Bad Handoff")
+    .bind("{invalid json")
+    .bind("1")
+    .bind::<Option<String>>(None)
+    .bind::<Option<String>>(None)
+    .bind::<Option<String>>(None)
+    .bind(0i64)
+    .bind(chrono::Utc::now().to_rfc3339())
+    .bind(chrono::Utc::now().to_rfc3339())
+    .execute(store.pool())
+    .await
+    .unwrap();
+
+    let err = store.load_handoff("bad-handoff").await.unwrap_err();
+    assert!(matches!(
+        err,
+        iron_core::config::ConfigError::Deserialization(_)
+    ));
+}
+
+#[tokio::test]
+async fn test_saved_handoff_unsupported_version_rejected_on_load() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+
+    // Insert a bundle with unsupported version directly into the database
+    sqlx::query(
+        "INSERT INTO saved_handoffs (id, name, bundle_json, bundle_version, source_session_id, source_model, source_provider, size_estimate_tokens, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+    )
+    .bind("old-handoff")
+    .bind("Old Handoff")
+    .bind(r#"{"version":"0","instructions":null,"handoff_note":"","compressed_blocks":[],"recent_tail":[],"skill_state":{"active":[]},"metadata":{"version":"0","source_model":"","source_provider":null,"source_session_id":"","size_estimate_tokens":0},"model_switch_history":[],"current_model":null,"current_provider_slug":null,"current_provider_api_key":null,"hidden_tools":[]}"#)
+    .bind("0")
+    .bind::<Option<String>>(None)
+    .bind::<Option<String>>(None)
+    .bind::<Option<String>>(None)
+    .bind(0i64)
+    .bind(chrono::Utc::now().to_rfc3339())
+    .bind(chrono::Utc::now().to_rfc3339())
+    .execute(store.pool())
+    .await
+    .unwrap();
+
+    let err = store.load_handoff("old-handoff").await.unwrap_err();
+    assert!(
+        matches!(err, iron_core::config::ConfigError::Validation(ref msg) if msg.contains("Unsupported stored handoff bundle version"))
+    );
+}
+
+#[tokio::test]
+async fn test_saved_handoff_migration_preserves_existing_data() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+
+    // Create a profile before the migration would run (it already ran during open)
+    let profile = ProfileInput {
+        id: "migration-test-profile".to_string(),
+        schema_version: 1,
+        payload: json!({"name": "Test Profile"}),
+    };
+    store.set_profile(&profile).await.unwrap();
+
+    // Verify profile still exists
+    let retrieved = store.get_profile("migration-test-profile").await.unwrap();
+    assert!(retrieved.is_some());
+
+    // Verify saved handoff table exists and works
+    let bundle = create_test_handoff_bundle("migration-test");
+    let input = iron_core::config::SavedHandoffInput {
+        id: "migration-handoff".to_string(),
+        name: "Migration Test Handoff".to_string(),
+        bundle,
+    };
+    store.save_handoff(&input).await.unwrap();
+
+    let loaded = store.load_handoff("migration-handoff").await.unwrap();
+    assert!(loaded.is_some());
 }

--- a/tests/config_store_tests.rs
+++ b/tests/config_store_tests.rs
@@ -1709,6 +1709,47 @@ async fn test_saved_handoff_unsupported_version_rejected_on_load() {
 }
 
 #[tokio::test]
+async fn test_saved_handoff_unsupported_metadata_version_rejected() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+
+    // Test save rejection
+    let mut bundle = create_test_handoff_bundle("test1");
+    bundle.metadata.version = "99".to_string();
+    let input = iron_core::config::SavedHandoffInput {
+        id: "handoff-bad-meta".to_string(),
+        name: "Bad Metadata".to_string(),
+        bundle: bundle.clone(),
+    };
+    let err = store.save_handoff(&input).await.unwrap_err();
+    assert!(
+        matches!(err, iron_core::config::ConfigError::Validation(ref msg) if msg.contains("Unsupported handoff metadata version"))
+    );
+
+    // Test load rejection via direct DB insert
+    sqlx::query(
+        "INSERT INTO saved_handoffs (id, name, bundle_json, bundle_version, source_session_id, source_model, source_provider, size_estimate_tokens, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+    )
+    .bind("old-handoff-meta")
+    .bind("Old Handoff Meta")
+    .bind(r#"{"version":"1","instructions":null,"handoff_note":"","compressed_blocks":[],"recent_tail":[],"skill_state":{"active":[]},"metadata":{"version":"99","source_model":"","source_provider":null,"source_session_id":"","size_estimate_tokens":0},"model_switch_history":[],"current_model":null,"current_provider_slug":null,"current_provider_api_key":null,"hidden_tools":[]}"#)
+    .bind("1")
+    .bind::<Option<String>>(None)
+    .bind::<Option<String>>(None)
+    .bind::<Option<String>>(None)
+    .bind(0i64)
+    .bind(chrono::Utc::now().to_rfc3339())
+    .bind(chrono::Utc::now().to_rfc3339())
+    .execute(store.pool())
+    .await
+    .unwrap();
+
+    let err = store.load_handoff("old-handoff-meta").await.unwrap_err();
+    assert!(
+        matches!(err, iron_core::config::ConfigError::Validation(ref msg) if msg.contains("Unsupported stored handoff metadata version"))
+    );
+}
+
+#[tokio::test]
 async fn test_saved_handoff_migration_preserves_existing_data() {
     let store = ConfigStore::open_in_memory().await.unwrap();
 


### PR DESCRIPTION
Implements core-managed saved handoff bundle storage APIs.

## What's New

- **Migration v4**: adds `saved_handoffs` table with bundle JSON and derived metadata columns
- **New types**: `SavedHandoffInput`, `SavedHandoffMetadata`, `SavedHandoffRecord`
- **CRUD APIs** on `ConfigStore`:
  - `save_handoff` — validates ID/name/bundle version, stores exact snapshot
  - `load_handoff` — returns `Ok(None)` for missing, validates version on load
  - `list_handoffs` — metadata-only listing without deserializing bundles
  - `delete_handoff` — removes by ID
- **Validation**: ID/name/bundle version checks at save and load boundaries
- **Exact snapshot semantics**: no sanitization or transformation of bundle data
- **Tests**: roundtrip, metadata listing, replace semantics, delete, validation, malformed bundle handling, migration compatibility (54 tests total)

## Dependency Updates

- `directories` 5 → 6
- `sqlx` 0.8 → 0.9 (fixed `raw_sql` breaking change)
- Lockfile updated to latest compatible versions

Closes #69

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent saved-handoff storage: save, load, list (metadata-only), and delete saved handoff bundles with stable IDs and timestamps; preserves exact saved bundle snapshots.

* **Chores**
  * Bumped SQL and platform helper dependencies (minor version upgrades).
  * Added a compiled migration to enable the new saved-handoffs store.

* **Documentation**
  * Added design, proposal, spec, and task docs describing behavior, validation, and migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->