### PR TITLE
Add agent profile provider resolution

### DIFF
--- a/openspec/changes/agent-profiles-provider-resolution/.openspec.yaml
+++ b/openspec/changes/agent-profiles-provider-resolution/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-11

--- a/openspec/changes/agent-profiles-provider-resolution/design.md
+++ b/openspec/changes/agent-profiles-provider-resolution/design.md
@@ -1,0 +1,155 @@
+## Context
+
+`ConfigStore` already provides opaque profile records with stable IDs and versioned JSON payloads, but `iron-core` does not yet define the typed profile payload or expose runtime APIs for registering profiles. These records are the natural durable handles for agent identities: the record ID is the stable generated profile ID, while the typed payload describes the user-facing name, provider/model preference, behavioral boundaries, approval posture, and profile-specific `identity_prompt` text.
+
+`IronRuntime` already owns optional managed-provider credential resolution through `CredentialResolver` and exposes `resolve_managed_provider(&ProviderPromptContext)`, so profile-to-provider resolution can reuse the existing provider-safe credential path rather than creating a second provider-construction flow. Profiles should not expose API keys or other credential secret material; they select a provider slug and model, and iron-core resolves auth from its broader credential state. In identity terms, provider resolution is one step in preparing an agent identity for execution; execution, delegation, and enforcement are still later work. The long-term model is that every agent execution uses a profile, falling back to the built-in protected `default` profile whenever a caller does not select one explicitly.
+
+Issues 59 and 60 are implemented together because provider resolution depends on the `AgentProfile` data model and the same tests need typed profile payloads, profile registration, and managed credential resolution.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Define `AgentProfile`, `AgentProfileId`, `AgentProfileEntry`, a profile provider context enum, profile load report/diagnostic types, and related filter/`AgentApproval` enums as public, serializable Rust types for durable agent identities.
+- Treat ConfigStore profile record IDs as stable generated profile IDs, separate from user-facing profile names.
+- Defer profile ID generation helpers while validating caller-supplied IDs.
+- Add profile identity registration APIs on `IronAgent` with unique-name validation, deterministic list behavior, and explicit unregister semantics.
+- Load typed profiles from ConfigStore profile records while preserving the existing opaque storage contract and reporting per-profile diagnostics.
+- Establish that unspecified profile selection resolves to the built-in protected `default` profile rather than a separate non-profile execution path.
+- Add profile-to-provider resolution on `IronRuntime` by delegating to the existing credential resolver and provider registry flow.
+- Add plumbing for an `ApprovalStrategy::AutoApprove` variant without changing runtime tool-approval behavior beyond making the policy representable.
+
+**Non-Goals:**
+
+- Executing sub-agents or implementing `delegate_task` behavior.
+- Enforcing `ToolFilter` or `SkillFilter` during prompt execution.
+- Defining identity rename, aliasing, ownership, sharing, or migration semantics beyond stable profile IDs.
+- Persisting or exposing per-profile API keys or credential secret material.
+- Adding profile-scoped memory, history, or session affinity.
+- Defining stored-prompt, schedule, or CLI profile-selection behavior.
+- Migrating existing profile data beyond decoding the new schema version from ConfigStore records.
+
+## Decisions
+
+### Keep profile storage opaque in ConfigStore
+
+ConfigStore continues to store profile records as versioned JSON payloads. `IronAgent::load_profiles` is responsible for reading profile IDs, fetching records, validating `schema_version`, deserializing `AgentProfile`, and registering successfully decoded profiles.
+
+Alternative considered: replacing ConfigStore profile records with typed SQL columns. This would prematurely specialize IC-1's generic profile storage and make later profile schema revisions more expensive.
+
+### Use a profile-specific provider context enum
+
+`AgentProfile` should not embed `ProviderPromptContext` because that type includes prompt-time API-key override state. Instead, this change should introduce a profile-specific provider context enum with a `RuntimeDefault` variant and a managed provider/model variant. `RuntimeDefault` preserves compatibility with existing injected-provider construction paths, while managed profiles carry provider slug and model only. Managed provider resolution can derive a `ProviderPromptContext` internally with no API key override so credentials resolve from iron-core credential state.
+
+Suggested shape:
+
+```rust
+pub enum AgentProfileProvider {
+    RuntimeDefault,
+    Managed {
+        provider_slug: ProviderSlug,
+        model: String,
+    },
+}
+```
+
+Alternative considered: reusing `ProviderPromptContext` and requiring `api_key: None` for profiles. That preserves the issue's original shape but leaks an auth override field into a durable identity API and makes accidental secret persistence possible.
+
+`RuntimeDefault` should not be restricted to the built-in default profile. User profiles may use `RuntimeDefault` when they want different identity/tool/skill/approval policy while continuing to use the runtime's current injected/default provider path.
+
+### Separate stable profile IDs from user-facing names
+
+The ConfigStore profile record ID is the stable generated profile ID for this slice. The typed `AgentProfile` payload includes a user-facing `name` that can be shown in UI and changed later without changing references. Registration and loading bind the payload to the supplied ID. Future stored prompts, delegate-task calls, and CLI selections can reference the stable profile ID without depending on display names or serialized payload internals. Public APIs should use an `AgentProfileId` newtype rather than a plain `String` to avoid confusing stable IDs with user-facing names.
+
+Alternative considered: using the user-provided name as the stable identity handle. That is simpler but makes rename semantics difficult and forces display naming choices to become durable API references.
+
+### Defer profile ID generation helpers
+
+This slice should validate caller-supplied profile IDs rather than defining a durable creation API or generated ID format. Non-default profile IDs should be non-empty after trimming, contain no control characters, and not equal `default` using ASCII case-insensitive comparison. A future profile-management API can add helpers such as `AgentProfileId::new()` or `ConfigStore::create_profile(profile) -> AgentProfileId` once creation, import/export, and rename semantics are designed.
+
+Alternative considered: requiring a generated format such as `prof_<ulid>` now. That would be reasonable long-term, but it expands this proposal into profile creation semantics that are not needed for registration, loading, or provider resolution.
+
+### Return explicit profile entries and load diagnostics
+
+`list_profiles` should return `Vec<AgentProfileEntry>` where each entry includes the stable profile ID and full `AgentProfile`. Profiles contain no credential secret material, so returning full profile values is acceptable. `load_profiles` should return `ProfileLoadReport` with loaded entries and skipped diagnostics for ConfigStore records only. The built-in default profile appears in `list_profiles` but should not appear in a `load_profiles` loaded list unless it came from ConfigStore, which reserved-default validation prevents. Diagnostics should include the profile ID, the parsed name when available, and an issue enum such as unsupported schema version, invalid payload, invalid name, reserved default, duplicate name, or missing listed record.
+
+Alternative considered: returning tuples, maps, or only profile summaries. Explicit entry/report types are clearer public API, leave room for metadata later, and avoid leaking internal registry representation.
+
+### Store registered profiles on IronAgent
+
+`IronAgent` should expose a thread-safe identity profile registry keyed by stable profile ID, initialized by every constructor. Registration APIs can be synchronous because they only mutate in-memory state. `load_profiles` remains async because ConfigStore access is async. The registry should also reject duplicate user-facing names within the loaded/registered profile set so users can safely select profiles by name when a frontend or CLI chooses to support that path. For this slice, the registry lives behind the facade while ConfigStore remains the durable source of truth; runtime execution APIs can later decide how selected identities flow into sessions, delegation, and policy enforcement.
+
+Alternative considered: storing profiles directly in `IronRuntime`. That may become appropriate once runtime execution selects and enforces identities, but doing it now would expand runtime responsibilities before delegate-task behavior, prompt selection, and policy enforcement are designed.
+
+### Validate profile names minimally
+
+Profile names are user-facing labels, so this change should avoid imposing slug-style syntax. Names should be accepted as arbitrary user text after rejecting empty or all-whitespace names and control characters. Duplicate detection should use the stored name exactly after trimming leading and trailing whitespace, except that `default` is a case-insensitive protected name reserved for the built-in profile. Richer case-insensitive or locale-aware uniqueness for non-reserved names can be added by frontends or a later profile-management change if needed.
+
+Alternative considered: requiring slug-safe names. That would simplify CLI lookup but would make display names less natural and is unnecessary because stable profile IDs already provide machine-safe references.
+
+### Normalize profile names by trimming
+
+Registration and loading should trim leading and trailing whitespace before storing the profile name. If the trimmed name is empty or contains control characters, the profile is invalid. Duplicate-name checks use the trimmed stored name exactly. The core should not perform case folding or Unicode normalization in this slice.
+
+Alternative considered: rejecting names that require trimming. That is stricter but unnecessarily hostile for user-facing labels, especially because stable profile IDs carry the machine reference semantics.
+
+### Protect the built-in default profile
+
+The registry should always include a built-in profile with ID `default` and name `default`. It uses the current default provider/model, `ToolFilter::Inherit`, `SkillFilter::Inherit`, `AgentApproval::PerTool`, and a short generic identity prompt such as `You are a helpful software engineering agent.` The `default` ID and name are protected case-insensitively, so user registration and ConfigStore loading cannot replace, shadow, or duplicate the built-in profile with `default`, `Default`, or any other ASCII case variant.
+
+The built-in default profile should use `AgentProfileProvider::RuntimeDefault` rather than requiring `Config.provider_name` to be set. This keeps existing `IronRuntime::new(config, provider)` and `IronAgent::new(config, provider)` injected-provider construction paths usable while still ensuring execution has a selected profile.
+
+Alternative considered: storing the default profile as a normal ConfigStore profile. That would make user customization simpler later, but it risks losing the fallback invariant in this slice and introduces default-profile creation/migration questions that are not needed yet.
+
+### Use schema version 1 for typed AgentProfile payloads
+
+`load_profiles` should accept the first typed profile schema version and report unsupported versions, invalid payloads, invalid names, reserved default conflicts, and duplicate names as per-profile diagnostics. The stable profile ID comes from the ConfigStore record ID, not from duplicated payload state. Valid profiles should still load when other records are invalid so one misconfigured profile does not disable the full profile set. To make duplicate-name behavior deterministic, records should be processed by stable profile ID in ascending order, and the first valid trimmed name wins after existing registry entries, including the built-in default profile, have already reserved their names.
+
+Alternative considered: failing the full load on the first invalid profile. That is simpler but creates poor desktop and CLI behavior because one stale or hand-edited record would hide every other valid profile.
+
+### Treat load_profiles as additive merge
+
+`load_profiles` should merge ConfigStore profiles into the existing in-memory registry. Loaded records replace existing profiles with the same non-reserved profile ID when validation succeeds, but loading does not remove in-memory profiles that are absent from ConfigStore. Existing registry entries win duplicate-name conflicts against newly loaded records, and rejected replacements leave the previous profile unchanged.
+
+Each profile record should validate fully before mutating the registry. If a replacement record has an invalid ID, invalid name, reserved default conflict, duplicate name owned by another profile ID, unsupported schema, or invalid payload, the existing profile for that ID remains unchanged and the load report records a diagnostic.
+
+Alternative considered: making `load_profiles` synchronize the registry exactly to ConfigStore. That would make deletion propagation easier but could unexpectedly remove manually registered profiles or the built-in default profile.
+
+### Use profiles for all agent execution
+
+Profile selection should always produce an `AgentProfile`. When a caller does not explicitly request a profile, the system should use the built-in `default` profile instead of branching through legacy non-profile configuration. This keeps primary agents and sub-agents on the same conceptual path: select profile, resolve provider, apply identity/tool/skill/approval policy, execute.
+
+Alternative considered: treating profiles as optional overrides on top of existing runtime behavior. That would preserve compatibility in the short term but would create special cases that future delegation and CLI flows would need to duplicate.
+
+### Use identity_prompt as the profile identity layer
+
+`identity_prompt` is the profile's model-facing identity instruction layer, not an append-only extension of the default profile's prompt. Custom profiles provide their own identity prompt. If a custom profile leaves `identity_prompt` absent or blank after trimming, profile selection should fall back to the default profile's generic identity prompt for execution so every selected profile has a usable identity layer.
+
+Alternative considered: always appending custom prompts to the default identity prompt. That would make custom identities harder to reason about and would force the default persona into specialized profiles even when the author wants a different identity.
+
+### Reuse existing provider resolution
+
+`IronRuntime::resolve_profile_provider(&AgentProfile)` should branch on the profile provider context. `RuntimeDefault` uses the runtime's existing injected/default provider path. `Managed` builds a managed provider prompt context from provider slug and model, with no profile-supplied API key, then calls the existing managed-provider resolution path. This preserves current injected-provider compatibility, OAuth refresh behavior, provider-safe credential material, and provider registry support checks while keeping provider construction independent from identity registry ownership.
+
+Because the runtime default provider is already owned by the runtime and managed providers are constructed on demand, this API should not be constrained to `Result<Box<dyn Provider>>` for every profile. It should return or otherwise expose a resolved provider abstraction capable of representing both the runtime-owned provider reference/handle and an owned managed provider. One possible shape is an enum with a runtime-default variant wrapping a cloned `Arc<dyn Provider>` and a managed variant wrapping `Box<dyn Provider>`.
+
+Alternative considered: exposing `CredentialResolver` directly to callers for profile resolution. That would require callers to duplicate provider registry construction and error mapping already owned by `IronRuntime`.
+
+### Treat AutoApprove as representational plumbing
+
+`AgentApproval` should represent profile-level approval policy with `PerTool`, `AutoApprove`, and `ReadOnly` variants. `ApprovalStrategy::AutoApprove` should become a distinct public variant for profile policy plumbing, but this change should not make existing tool execution skip approvals in new places. Runtime approval behavior for delegated execution is deferred to delegate-task work.
+
+Alternative considered: keeping the issue's original `SubAgentApproval` name. Because all agents are profile-backed, `AgentApproval` better describes both primary-agent and delegated-agent profiles.
+
+## Risks / Trade-offs
+
+- Profile payload schema may need revision once delegate-task execution, profile-scoped prompts, or profile-scoped memory are implemented. Mitigation: use explicit schema versions and keep ConfigStore storage opaque.
+- Treating profile IDs as durable identity handles makes creation and import/export semantics important later. Mitigation: use ConfigStore record IDs as stable generated IDs now and keep user-facing names separate.
+- Duplicate profile names can occur in existing or hand-edited stores. Mitigation: load valid non-duplicate profiles and return diagnostics for skipped duplicates.
+- Exact name matching may allow visually similar names that differ by case or Unicode normalization. Mitigation: keep core validation minimal for now and let frontends apply stricter UX rules if needed.
+- Default-profile customization may require a future decision about whether the built-in default can be replaced by a persisted user-selected default. Mitigation: protect the built-in `default` profile for this slice and defer customization.
+- A profile-specific provider context diverges from the original issue wording. Mitigation: it preserves the intended provider/model selection while avoiding an API-key field in durable identity data and retaining runtime-default injected-provider compatibility.
+- Deferring ID generation means callers can choose arbitrary valid IDs. Mitigation: validate IDs now and leave generated formats to future profile-management APIs.
+- Keeping profile registration on `IronAgent` means `IronRuntime` cannot list identities directly. Mitigation: IC-3 only requires resolving a supplied profile; future execution APIs can move or share the registry if runtime ownership becomes necessary.
+- `ToolFilter` and `SkillFilter` are representational before enforcement exists. Mitigation: document enforcement as out of scope and add tests only for serialization/registration until execution work lands.
+- `AutoApprove` can be confused with existing no-approval behavior. Mitigation: add the variant without broad behavior changes and test existing approval strategy semantics remain stable.

--- a/openspec/changes/agent-profiles-provider-resolution/proposal.md
+++ b/openspec/changes/agent-profiles-provider-resolution/proposal.md
@@ -1,0 +1,42 @@
+## Why
+
+AgentIron needs agent profiles as durable agent identities, not just reusable launch configuration. Profiles define who an agent is allowed to act as, which provider/model it prefers, which tools and skills bound its behavior, which identity prompt augments its system prompt, and which approval posture applies when that identity is used for primary-agent or sub-agent execution.
+
+All agent execution should flow through a profile. When a caller does not explicitly select a profile, AgentIron should use the built-in protected `default` profile instead of maintaining a separate non-profile execution path.
+
+Provider resolution should be part of the same proposal because it directly depends on the profile data model and is required before profile identities can execute prompts or delegated tasks.
+
+## What Changes
+
+- Add public agent profile domain types for stable profile IDs, profile entries, profile loading diagnostics, profile provider context, user-facing name, tool filtering, skill filtering, agent approval policy, and optional `identity_prompt`.
+- Represent profile provider selection with a profile-specific enum that supports the protected runtime default provider path and managed provider/model selection without API keys.
+- Treat ConfigStore profile record IDs as stable generated profile IDs used by registration, loading, and future profile references.
+- Defer profile ID generation helpers; callers and ConfigStore record creators supply validated, non-reserved profile IDs for this slice.
+- Keep profile names as user-facing, renameable labels that must be unique within the loaded/registered profile set.
+- Keep credential secret material out of profile APIs; profiles select provider slug and model, while auth remains owned by iron-core credential state.
+- Add built-in default-profile semantics so unspecified profile selection resolves to the protected `default` `AgentProfile`.
+- Protect `default` as a case-insensitive reserved profile ID/name that user profiles cannot overwrite.
+- Add `IronAgent` APIs to register, unregister, list, and load named profiles from the core config store.
+- Define durable profile loading from existing ConfigStore profile records without changing the opaque storage contract established by IC-1, including deterministic profile-ID-sorted best-effort loading diagnostics for invalid or duplicate profiles and atomic per-profile validation.
+- Add `AgentApproval` profile policy and an `ApprovalStrategy::AutoApprove` variant as plumbing only; runtime auto-approval behavior remains out of scope for this change.
+- Add profile provider resolution that supports both runtime-default provider references and managed provider construction using the existing credential resolution path and the profile's provider context.
+- Surface actionable provider-resolution errors for unknown providers, missing credentials, unsupported credential modes, and expired or revoked OAuth credentials.
+- Add unit coverage for profile registration, durable profile loading, and profile-to-provider resolution with mock credential stores.
+
+## Capabilities
+
+### New Capabilities
+
+- `agent-profiles`: Durable agent identity profile definitions with stable IDs, unique user-facing names, protected built-in default-profile semantics, runtime registration APIs, ConfigStore loading diagnostics, approval-policy plumbing, and profile-to-provider resolution.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- **Public API**: new `AgentProfile`, `AgentProfileId`, `AgentProfileEntry`, profile provider context enum, resolved profile provider abstraction, profile loading report/diagnostics, `ToolFilter`, `SkillFilter`, `AgentApproval`, and `IronAgent` profile-management methods; new `IronRuntime::resolve_profile_provider` helper.
+- **Provider orchestration**: profile resolution reuses existing `CredentialResolver` behavior and provider-safe credential boundaries.
+- **Config store integration**: profile records remain stored through ConfigStore's opaque profile API, with record IDs serving as stable generated profile IDs and domain decoding performed by profile-loading code.
+- **Approval plumbing**: `ApprovalStrategy::AutoApprove` becomes representable but does not change tool execution policy until delegate-task/runtime behavior is implemented later.
+- **Future work**: this proposal unblocks provider resolution, delegate-task execution, stored prompts, CLI/headless profile selection, and future references to durable agent identities while avoiding a separate non-profile execution path.

--- a/openspec/changes/agent-profiles-provider-resolution/specs/agent-profiles/spec.md
+++ b/openspec/changes/agent-profiles-provider-resolution/specs/agent-profiles/spec.md
@@ -1,0 +1,297 @@
+## ADDED Requirements
+
+### Requirement: Core SHALL define typed agent identity profiles
+
+The system SHALL provide public `AgentProfile`, `AgentProfileId`, `AgentProfileEntry`, a profile provider context enum, profile load report/diagnostic types, `ToolFilter`, `SkillFilter`, and `AgentApproval` types that can represent the user-facing name, provider selection, managed provider/model selection, tool availability policy, skill availability policy, agent approval policy, and optional `identity_prompt` for an agent identity profile.
+
+#### Scenario: Profile captures provider and model selection
+- **WHEN** a caller constructs an `AgentProfile`
+- **THEN** the profile includes a profile provider context that can represent either the runtime default provider path or a managed provider slug and model
+- **AND** the profile can also carry a user-facing name, tool filtering, skill filtering, approval policy, and optional `identity_prompt`
+
+#### Scenario: Runtime default provider is representable
+- **WHEN** a caller or the built-in default profile needs to use the runtime's injected/default provider path
+- **THEN** the profile provider context can represent `RuntimeDefault` without requiring a provider slug
+
+#### Scenario: User profile can use runtime default provider
+- **WHEN** a user-defined profile needs custom identity, tool, skill, or approval policy while keeping the runtime's current provider path
+- **THEN** the profile provider context can use `RuntimeDefault`
+- **AND** the profile remains distinct from the protected built-in default profile by stable ID and user-facing name
+
+#### Scenario: Managed provider is representable
+- **WHEN** a caller configures a user profile for managed provider resolution
+- **THEN** the profile provider context can represent provider slug and model
+- **AND** does not include an API-key field
+
+#### Scenario: Profile entry pairs ID with profile
+- **WHEN** a caller lists or loads profiles
+- **THEN** each successfully registered profile can be represented as an `AgentProfileEntry` containing the stable `AgentProfileId` and the full `AgentProfile`
+
+#### Scenario: Profile context omits API keys
+- **WHEN** a caller constructs or loads an `AgentProfile`
+- **THEN** the profile API does not expose an API-key field
+- **AND** the profile cannot persist per-profile credential secret material through its provider/model context
+
+#### Scenario: Tool filter variants are representable
+- **WHEN** a caller configures tool filtering for a profile
+- **THEN** the system can represent inherited tools, an allowlist of tool names, or a denylist of tool names
+
+#### Scenario: Skill filter variants are representable
+- **WHEN** a caller configures skill filtering for a profile
+- **THEN** the system can represent no skills, an allowlist of skill names, or inherited skills
+
+#### Scenario: Agent approval variants are representable
+- **WHEN** a caller configures approval policy for a profile
+- **THEN** the system can represent per-tool approval, auto-approval, or read-only execution policy
+
+### Requirement: Core SHALL separate profile IDs from user-facing names
+
+The system SHALL use ConfigStore profile record IDs and in-memory registration IDs as stable generated profile IDs for agent identities. The typed `AgentProfile` payload SHALL include a user-facing profile name that is distinct from the stable profile ID.
+
+#### Scenario: ConfigStore ID is stable profile ID
+- **WHEN** `IronAgent::load_profiles` loads a profile record from ConfigStore
+- **THEN** the profile record ID is used as the registered stable profile ID
+- **AND** the `AgentProfile` payload provides the user-facing profile name
+
+#### Scenario: Registered ID names in-memory identity
+- **WHEN** a caller registers an `AgentProfile` directly with `IronAgent`
+- **THEN** the supplied registration ID is used as the stable in-memory profile ID
+- **AND** the profile payload's name remains the user-facing label
+
+#### Scenario: Profile ID is validated
+- **WHEN** a caller registers or loads a non-default profile ID
+- **THEN** the profile ID must be non-empty after trimming, contain no control characters, and not equal `default` using ASCII case-insensitive comparison
+- **AND** invalid profile IDs are rejected or reported without mutating existing profiles
+
+#### Scenario: Profile ID generation is caller-owned for this slice
+- **WHEN** a caller creates a new durable profile record
+- **THEN** this change does not require a core-generated ID format or creation helper
+- **AND** the caller supplies a valid non-reserved profile ID
+
+#### Scenario: Profile names are unique labels
+- **WHEN** a caller registers or loads a profile
+- **THEN** the profile name must not duplicate another registered profile name after trimming leading and trailing whitespace
+- **AND** duplicate names are rejected or reported without changing the stable profile IDs of existing profiles
+
+#### Scenario: Default name is protected
+- **WHEN** a caller registers or loads a user profile with profile ID or profile name equal to `default` using ASCII case-insensitive comparison
+- **THEN** the profile is rejected or reported as reserved
+- **AND** the built-in default profile remains unchanged
+
+#### Scenario: Profile name is normalized
+- **WHEN** a caller registers or loads a profile with leading or trailing whitespace in the profile name
+- **THEN** the stored profile name is the trimmed name
+- **AND** duplicate-name checks use the trimmed stored name exactly
+
+#### Scenario: Invalid profile name is rejected
+- **WHEN** a caller registers or loads a profile with an empty, all-whitespace, or control-character-containing name
+- **THEN** the profile is rejected or reported as invalid
+- **AND** the invalid name is not registered as a selectable profile label
+
+#### Scenario: Identity rename semantics are deferred
+- **WHEN** a caller needs to rename, alias, share, or migrate an agent identity handle
+- **THEN** this change does not define those semantics
+- **AND** callers must create, replace, or delete profile records through existing ConfigStore/profile APIs until a future identity-management change defines richer behavior
+
+### Requirement: Core SHALL keep profile auth in credential state
+
+The system SHALL NOT persist or expose per-profile API keys or credential secret material as part of `AgentProfile`. Provider resolution for a profile SHALL use the profile's provider slug and model together with iron-core's existing credential state.
+
+#### Scenario: Profile resolves provider without profile API key
+- **WHEN** `IronRuntime::resolve_profile_provider` resolves a profile provider
+- **THEN** managed profile resolution derives a managed provider context from the profile provider slug and model without a profile-supplied API key
+- **AND** credentials for managed profiles are resolved from iron-core's credential resolver and credential stores
+
+#### Scenario: Prompt-time API key remains separate
+- **WHEN** prompt APIs support an app-supplied API key override
+- **THEN** that prompt-time override remains separate from durable profile identity APIs
+- **AND** it is not stored in `AgentProfile`
+
+### Requirement: Core SHALL expose in-memory agent identity registration
+
+The system SHALL provide `IronAgent` APIs to register, unregister, and list `AgentProfile` identity values by stable profile ID for the lifetime of the agent instance.
+
+#### Scenario: Default profile is always registered
+- **WHEN** an `IronAgent` is constructed
+- **THEN** its profile registry includes the built-in profile with ID `default` and name `default`
+- **AND** list operations include that built-in profile entry
+
+#### Scenario: Profile is registered
+- **WHEN** a caller registers a profile with a valid stable profile ID and unique profile name
+- **THEN** `IronAgent` stores that profile under the supplied profile ID
+- **AND** a later list operation includes an `AgentProfileEntry` with that profile ID, profile name, and profile value
+
+#### Scenario: Profile is replaced
+- **WHEN** a caller registers a profile ID that is already registered
+- **THEN** the new profile replaces the previous profile for that ID if its name remains unique within the registry
+
+#### Scenario: Invalid replacement leaves existing profile unchanged
+- **WHEN** a caller attempts to replace an existing profile ID with an invalid profile
+- **THEN** the replacement is rejected
+- **AND** the previous profile for that ID remains registered unchanged
+
+#### Scenario: Replacement cannot duplicate another profile name
+- **WHEN** a caller replaces a registered profile with a profile name already used by a different profile ID
+- **THEN** the replacement is rejected
+- **AND** the previously registered profile for the replaced ID remains unchanged
+
+#### Scenario: Default profile cannot be replaced
+- **WHEN** a caller registers a profile using the protected `default` profile ID or name with any ASCII case variant
+- **THEN** the registration is rejected
+- **AND** the built-in default profile remains unchanged
+
+#### Scenario: Profile is unregistered
+- **WHEN** a caller unregisters a registered profile ID
+- **THEN** `IronAgent` removes that profile from the in-memory registry
+- **AND** a later list operation no longer includes that profile
+
+#### Scenario: Unregistering a missing profile is explicit
+- **WHEN** a caller unregisters a profile ID that is not registered
+- **THEN** the API reports that no profile was removed without mutating other profiles
+
+#### Scenario: Unregistering frees profile name
+- **WHEN** a caller unregisters a profile ID whose profile name is registered
+- **THEN** a later registration using that same profile name for another profile ID can succeed if no other registered profile uses the name
+
+### Requirement: Core SHALL load typed agent identities from ConfigStore
+
+The system SHALL provide `IronAgent::load_profiles` to read ConfigStore profile records, decode supported typed `AgentProfile` payloads, register valid agent identities by ConfigStore record ID, and return a `ProfileLoadReport` with loaded profile entries and per-profile diagnostics for invalid, reserved, or duplicate records.
+
+#### Scenario: Stored profile loads successfully
+- **WHEN** ConfigStore contains a profile record with a supported typed profile schema version and valid profile payload
+- **THEN** `IronAgent::load_profiles` deserializes the payload into an `AgentProfile`
+- **AND** registers it under the profile record ID as the stable profile ID
+
+#### Scenario: Invalid stored profile is skipped
+- **WHEN** ConfigStore contains one valid profile record and one invalid profile record
+- **THEN** `IronAgent::load_profiles` registers the valid profile
+- **AND** reports a diagnostic for the invalid profile
+- **AND** does not fail the entire load because of the invalid profile payload
+
+#### Scenario: Load report includes loaded and skipped profiles
+- **WHEN** `IronAgent::load_profiles` completes with valid and skipped profile records
+- **THEN** the returned load report includes loaded `AgentProfileEntry` values for registered profiles
+- **AND** includes diagnostics for skipped profile records with their profile ID, parsed name when available, and issue category
+
+#### Scenario: Load report excludes built-in default
+- **WHEN** `IronAgent::load_profiles` returns a load report
+- **THEN** the report describes ConfigStore profile records that were loaded or skipped
+- **AND** does not include the built-in default profile as a loaded ConfigStore profile
+
+#### Scenario: Unsupported profile schema is skipped
+- **WHEN** ConfigStore contains a profile record with an unsupported profile schema version
+- **THEN** `IronAgent::load_profiles` reports an actionable diagnostic identifying the unsupported profile record
+- **AND** does not silently register that invalid profile
+
+#### Scenario: Invalid profile payload is skipped
+- **WHEN** ConfigStore contains a profile record whose payload cannot be decoded as an `AgentProfile`
+- **THEN** `IronAgent::load_profiles` reports an actionable diagnostic identifying the invalid profile record
+- **AND** does not silently register that invalid profile
+
+#### Scenario: Duplicate loaded profile name is skipped
+- **WHEN** ConfigStore contains multiple valid profile records with duplicate user-facing names
+- **THEN** `IronAgent::load_profiles` processes records by stable profile ID in ascending order
+- **AND** registers the first valid profile for that trimmed name
+- **AND** reports diagnostics for skipped duplicate profiles
+
+#### Scenario: Existing registry entry wins duplicate loaded name
+- **WHEN** the in-memory registry already contains a profile name
+- **AND** ConfigStore contains a different profile ID with the same trimmed profile name
+- **THEN** `IronAgent::load_profiles` keeps the existing registry entry
+- **AND** reports a duplicate-name diagnostic for the loaded profile
+
+#### Scenario: Reserved default loaded profile is skipped
+- **WHEN** ConfigStore contains a profile record with profile ID or profile name equal to `default` using ASCII case-insensitive comparison
+- **THEN** `IronAgent::load_profiles` skips that stored profile
+- **AND** reports a reserved-default diagnostic
+- **AND** the built-in default profile remains unchanged
+
+#### Scenario: Profile loading is additive
+- **WHEN** `IronAgent::load_profiles` loads profiles from ConfigStore
+- **THEN** valid loaded profiles are merged into the existing in-memory registry
+- **AND** existing in-memory profiles absent from ConfigStore remain registered
+
+#### Scenario: Invalid loaded replacement leaves existing profile unchanged
+- **WHEN** the in-memory registry contains a profile ID
+- **AND** ConfigStore contains a record for the same profile ID that fails validation
+- **THEN** `IronAgent::load_profiles` reports a diagnostic for the stored record
+- **AND** the existing in-memory profile remains registered unchanged
+
+#### Scenario: Fatal store failure aborts profile loading
+- **WHEN** ConfigStore cannot list or read profile records because of a storage failure
+- **THEN** `IronAgent::load_profiles` returns a fatal error for the store operation
+- **AND** does not report the failure as a per-profile payload diagnostic
+
+### Requirement: Core SHALL expose profile-to-provider resolution
+
+The system SHALL provide profile provider resolution that resolves the selected profile's provider context. The resolution result SHALL be able to represent both the runtime-owned default provider path and an owned managed provider constructed through credential resolution.
+
+#### Scenario: Managed profile provider resolves successfully
+- **WHEN** a profile references a known provider and model with usable credentials
+- **THEN** `IronRuntime::resolve_profile_provider` returns a resolved managed provider constructed through the provider registry
+- **AND** credential resolution uses iron-core credential state and OAuth refresh behavior without a profile-supplied API key
+
+#### Scenario: Runtime default provider resolves through existing provider
+- **WHEN** profile provider resolution is requested for a profile using the runtime default provider context
+- **THEN** the runtime uses a resolved provider representation for its existing injected/default provider path
+- **AND** does not require a managed provider slug or credential resolver for that profile
+
+#### Scenario: Resolver is not configured
+- **WHEN** profile provider resolution is requested on a runtime without a configured credential resolver
+- **THEN** the call returns a typed provider-auth error instead of panicking
+
+#### Scenario: Provider resolution fails actionably
+- **WHEN** a profile references an unknown provider, missing credential, unsupported credential mode, expired credential, or revoked OAuth credential
+- **THEN** `IronRuntime::resolve_profile_provider` returns an actionable provider-auth error from the existing credential/provider resolution surface
+
+### Requirement: Core SHALL support default profile selection
+
+The system SHALL model all agent execution as profile-backed execution. When a caller does not explicitly specify a profile, profile selection SHALL resolve to the built-in protected `default` `AgentProfile` rather than bypassing profile semantics.
+
+#### Scenario: Built-in default profile exists
+- **WHEN** the profile registry is initialized
+- **THEN** it includes a built-in profile with ID `default` and name `default`
+- **AND** that profile uses the runtime default provider context, inherited tools, inherited skills, per-tool approval, and a short generic identity prompt
+
+#### Scenario: Explicit profile is selected
+- **WHEN** a caller requests execution with a specific profile ID
+- **THEN** the system uses the selected `AgentProfile` for provider/model selection and future identity policy application
+
+#### Scenario: Default profile is selected
+- **WHEN** a caller requests execution without a specific profile ID
+- **THEN** the system resolves execution to the built-in `default` `AgentProfile`
+- **AND** provider/model selection still flows through profile-to-provider resolution
+
+#### Scenario: Non-profile execution path is avoided
+- **WHEN** primary-agent or sub-agent execution is prepared
+- **THEN** the system has an `AgentProfile` available before provider resolution
+- **AND** execution does not require a separate special-case path for missing profile configuration
+
+### Requirement: Core SHALL use identity prompts as profile identity layers
+
+The system SHALL treat `identity_prompt` as the selected profile's model-facing identity instruction layer. A custom profile's non-blank `identity_prompt` SHALL replace the default profile's identity prompt for that selected profile rather than appending to it.
+
+#### Scenario: Custom identity prompt is used
+- **WHEN** a selected non-default profile has a non-blank `identity_prompt`
+- **THEN** that prompt is the profile identity prompt used for execution preparation
+- **AND** the default profile's identity prompt is not implicitly appended
+
+#### Scenario: Blank identity prompt falls back to default
+- **WHEN** a selected non-default profile has no `identity_prompt` or has an identity prompt that is blank after trimming
+- **THEN** execution preparation uses the built-in default profile's identity prompt as the fallback identity prompt
+
+#### Scenario: Default identity prompt is generic
+- **WHEN** the built-in default profile is created
+- **THEN** it has a short generic identity prompt suitable for general software engineering assistance
+
+### Requirement: Core SHALL add AutoApprove approval plumbing
+
+The system SHALL expose an `ApprovalStrategy::AutoApprove` variant so profile approval policy can be represented distinctly from existing approval strategies.
+
+#### Scenario: AutoApprove is representable
+- **WHEN** code maps or stores an auto-approval profile policy
+- **THEN** the policy can be represented with `ApprovalStrategy::AutoApprove`
+
+#### Scenario: Existing approval behavior remains stable
+- **WHEN** runtime tool approval checks use existing `Always`, `Never`, or `PerTool` strategies
+- **THEN** their approval decisions remain unchanged by the addition of `AutoApprove`

--- a/openspec/changes/agent-profiles-provider-resolution/tasks.md
+++ b/openspec/changes/agent-profiles-provider-resolution/tasks.md
@@ -1,0 +1,52 @@
+## 1. Profile Domain Types
+
+- [x] 1.1 Add public `AgentProfile`, `AgentProfileId`, `AgentProfileEntry`, profile provider context enum, `ToolFilter`, `SkillFilter`, and `AgentApproval` types with serde support and derives consistent with adjacent public config/domain types, framed as agent identity profile types.
+- [x] 1.2 Add profile schema-version constants or validation helpers for ConfigStore typed profile payload decoding.
+- [x] 1.3 Add `ApprovalStrategy::AutoApprove` and update approval-strategy matches without changing existing `Always`, `Never`, or `PerTool` behavior.
+- [x] 1.4 Re-export the new profile types from the appropriate public module boundary.
+- [x] 1.5 Document that profile record IDs are stable generated profile IDs while `AgentProfile.name` is the user-facing unique label.
+- [x] 1.6 Ensure profile provider/model context does not expose or serialize API keys or credential secret material.
+- [x] 1.7 Add `identity_prompt: Option<String>` to `AgentProfile` for profile-specific model-facing identity instructions, with blank values falling back to the default profile identity prompt during profile selection/execution preparation.
+- [x] 1.8 Add `ProfileLoadReport`, `ProfileLoadDiagnostic`, and profile load issue types for best-effort loading feedback.
+- [x] 1.9 Validate non-default `AgentProfileId` values as caller-supplied IDs with no generation helper in this slice.
+- [x] 1.10 Add a resolved profile provider abstraction that can represent both the runtime default provider path and an owned managed provider.
+
+## 2. IronAgent Identity Profile Registry
+
+- [x] 2.1 Add an in-memory identity profile registry to `IronAgent` initialized by every constructor.
+- [x] 2.2 Implement `IronAgent::register_profile(id, profile)` with replacement semantics for existing stable profile IDs.
+- [x] 2.3 Validate user-facing profile names by trimming leading/trailing whitespace before storage, rejecting empty or control-character-containing names, and enforcing uniqueness on the trimmed stored name.
+- [x] 2.4 Implement `IronAgent::unregister_profile(id)` with explicit missing-profile reporting.
+- [x] 2.5 Implement `IronAgent::list_profiles()` with deterministic ordering and entries that include stable profile ID, user-facing name, and profile value.
+- [x] 2.6 Ensure replacing an existing profile ID rejects duplicate names owned by other profile IDs and leaves the previous profile unchanged on rejection.
+- [x] 2.7 Add the built-in protected `default` profile to every registry, reject user registration of profile ID/name `default` using ASCII case-insensitive comparison, and ensure it cannot be unregistered or replaced.
+- [x] 2.8 Ensure registration validates the full replacement profile before mutating the registry.
+
+## 3. ConfigStore Profile Loading
+
+- [x] 3.1 Implement `IronAgent::load_profiles(store: &ConfigStore)` using ConfigStore profile ID listing and record retrieval.
+- [x] 3.2 Decode supported schema-version 1 profile payloads into `AgentProfile` values and register them by record ID as stable profile IDs.
+- [x] 3.3 Return fatal errors for ConfigStore list/read failures while reporting unsupported schema versions, missing listed records, invalid profile payloads, reserved default conflicts, and duplicate names as per-profile load diagnostics.
+- [x] 3.4 Process stored profile records by stable profile ID in ascending order so duplicate-name winners are deterministic.
+- [x] 3.5 Implement additive merge semantics so loaded profiles replace matching non-reserved IDs, existing registry entries win duplicate-name conflicts, and profiles absent from ConfigStore remain registered.
+- [x] 3.6 Ensure invalid loaded replacements leave existing in-memory profiles unchanged.
+- [x] 3.7 Add tests for successful load, replacement on load, unsupported schema version diagnostics, invalid payload diagnostics, invalid ID diagnostics, reserved default diagnostics, duplicate-name diagnostics, ID-sorted duplicate handling, additive merge behavior, atomic invalid replacement behavior, and best-effort loading of other valid profiles.
+
+## 4. Profile Provider Resolution
+
+- [x] 4.1 Implement `IronRuntime::resolve_profile_provider(profile: &AgentProfile)` by returning a resolved provider abstraction that uses the existing injected/default provider path for `RuntimeDefault` profiles and derives a managed provider context from managed provider slug/model with no API-key override for managed profiles.
+- [x] 4.2 Add tests with mock credential stores for successful managed profile provider resolution.
+- [x] 4.3 Add tests for runtime-default profile resolution without a credential resolver.
+- [x] 4.4 Add tests for missing resolver, missing credential, unsupported provider or credential mode, and OAuth failure surfaces where existing test utilities support them.
+
+## 5. Default Profile Semantics
+
+- [x] 5.1 Define how the default profile is represented for this implementation slice without adding a separate non-profile execution path.
+- [x] 5.2 Add tests showing unspecified profile selection resolves to the default `AgentProfile` before provider resolution.
+- [x] 5.3 Add tests showing non-blank profile `identity_prompt` is used as the profile identity layer and blank/missing `identity_prompt` falls back to the built-in default identity prompt.
+
+## 6. Verification
+
+- [x] 6.1 Run targeted Rust tests for profile domain, IronAgent registry/loading, default profile selection, and provider resolution.
+- [x] 6.2 Run `cargo check --manifest-path src-tauri/Cargo.toml` if this crate is checked through the workspace app, or the narrowest equivalent Rust check for `iron-core` if available.
+- [x] 6.3 Update any rustdoc examples or public API documentation needed for the new profile APIs.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -279,6 +279,12 @@ pub enum ApprovalStrategy {
     /// Defer to the tool's `requires_approval` setting.
     #[default]
     PerTool,
+    /// Auto-approve tool calls.
+    ///
+    /// This variant is representational plumbing for profile policy; it does
+    /// not change existing tool-approval behavior until delegate-task/runtime
+    /// enforcement is implemented.
+    AutoApprove,
 }
 
 impl ApprovalStrategy {
@@ -288,6 +294,7 @@ impl ApprovalStrategy {
             ApprovalStrategy::Always => true,
             ApprovalStrategy::Never => false,
             ApprovalStrategy::PerTool => tool_requires_approval,
+            ApprovalStrategy::AutoApprove => false,
         }
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -294,7 +294,7 @@ impl ApprovalStrategy {
             ApprovalStrategy::Always => true,
             ApprovalStrategy::Never => false,
             ApprovalStrategy::PerTool => tool_requires_approval,
-            ApprovalStrategy::AutoApprove => false,
+            ApprovalStrategy::AutoApprove => tool_requires_approval,
         }
     }
 }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,11 +1,18 @@
 use crate::durable::{DurableSession, SessionId};
+use crate::profile::{
+    default_identity_prompt, managed_profile_prompt_context, AgentApproval, AgentProfile,
+    AgentProfileId, AgentProfileProvider, ResolvedProfileProvider, SkillFilter, ToolFilter,
+};
 use crate::prompt_lifecycle::AcpPromptSink;
 use crate::prompt_runner::PromptRunner;
 use crate::provider_credential::domain::ProviderPromptContext;
 use crate::runtime::{ConnectionId, IronRuntime};
 use agent_client_protocol::schema as acp;
+use parking_lot::RwLock;
 use std::cell::RefCell;
+use std::collections::HashMap;
 use std::rc::Rc;
+use std::sync::Arc;
 use tracing::{debug, info, warn};
 
 pub trait ClientChannel {
@@ -83,22 +90,50 @@ impl ClientChannel for NopClientChannel {
 
 pub(crate) type SharedClientChannel = Rc<dyn ClientChannel>;
 
+pub(crate) type ProfileRegistry = HashMap<AgentProfileId, AgentProfile>;
+
+fn default_connection_profile_registry() -> ProfileRegistry {
+    let mut registry = HashMap::new();
+    let default = AgentProfile {
+        name: "default".to_string(),
+        provider: AgentProfileProvider::RuntimeDefault,
+        tools: ToolFilter::Inherit,
+        skills: SkillFilter::Inherit,
+        approval: AgentApproval::PerTool,
+        identity_prompt: Some(default_identity_prompt().to_string()),
+    };
+    registry.insert(AgentProfileId::from("default"), default);
+    registry
+}
+
 pub struct IronConnection {
     id: ConnectionId,
     runtime: IronRuntime,
     client: RefCell<Option<SharedClientChannel>>,
+    profile_registry: Arc<RwLock<ProfileRegistry>>,
 }
 
 static CONNECTION_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
 
 impl IronConnection {
     pub fn new(runtime: IronRuntime) -> Self {
+        Self::new_with_profile_registry(
+            runtime,
+            Arc::new(RwLock::new(default_connection_profile_registry())),
+        )
+    }
+
+    pub fn new_with_profile_registry(
+        runtime: IronRuntime,
+        profile_registry: Arc<RwLock<ProfileRegistry>>,
+    ) -> Self {
         let id = ConnectionId(CONNECTION_COUNTER.fetch_add(1, std::sync::atomic::Ordering::SeqCst));
         runtime.register_connection(id);
         Self {
             id,
             runtime,
             client: RefCell::new(None),
+            profile_registry,
         }
     }
 
@@ -112,6 +147,25 @@ impl IronConnection {
 
     pub fn set_client(&self, client: SharedClientChannel) {
         *self.client.borrow_mut() = Some(client);
+    }
+
+    fn selected_profile(&self, session_profile_id: Option<&AgentProfileId>) -> AgentProfile {
+        let registry = self.profile_registry.read();
+        session_profile_id
+            .and_then(|id| registry.get(id).cloned())
+            .unwrap_or_else(|| {
+                registry
+                    .get(&AgentProfileId::from("default"))
+                    .cloned()
+                    .unwrap_or_else(|| AgentProfile {
+                        name: "default".to_string(),
+                        provider: AgentProfileProvider::RuntimeDefault,
+                        tools: ToolFilter::Inherit,
+                        skills: SkillFilter::Inherit,
+                        approval: AgentApproval::PerTool,
+                        identity_prompt: Some(default_identity_prompt().to_string()),
+                    })
+            })
     }
 
     fn client_channel(&self) -> SharedClientChannel {
@@ -208,6 +262,7 @@ impl IronConnection {
     pub async fn handle_prompt(
         &self,
         args: acp::PromptRequest,
+        session_profile_id: Option<&AgentProfileId>,
     ) -> agent_client_protocol::Result<acp::PromptResponse> {
         debug!(session_id = %args.session_id, "ACP prompt received");
 
@@ -250,6 +305,17 @@ impl IronConnection {
 
         let sink = AcpPromptSink::new(acp_session_id.clone(), client.clone());
 
+        // All agent execution is profile-backed. Use the session profile or fall
+        // back to the default profile unless a managed provider context was stored
+        // by a prior model switch.
+        let selected_profile = self.selected_profile(session_profile_id);
+        {
+            let mut session = durable.lock();
+            if session.instructions.is_none() {
+                session.set_instructions(selected_profile.effective_identity_prompt());
+            }
+        }
+
         // Check if the session has a stored managed provider from a prior model switch
         let stored_context = {
             let session = durable.lock();
@@ -283,11 +349,36 @@ impl IronConnection {
                 }
             }
         } else {
-            let runner = PromptRunner::new(self.runtime.clone());
-            let stop_reason = runner
-                .run(&durable, &ephemeral, &sink, &config, max_iterations)
-                .await;
-            (Some(runner), stop_reason)
+            match self
+                .runtime
+                .resolve_profile_provider(&selected_profile)
+                .await
+            {
+                Ok(ResolvedProfileProvider::RuntimeDefault(_)) => {
+                    let runner = PromptRunner::new(self.runtime.clone());
+                    let stop_reason = runner
+                        .run(&durable, &ephemeral, &sink, &config, max_iterations)
+                        .await;
+                    (Some(runner), stop_reason)
+                }
+                Ok(ResolvedProfileProvider::Managed(provider)) => {
+                    let context = managed_profile_prompt_context(&selected_profile.provider)
+                        .expect("managed profile always yields a prompt context");
+                    let runner = PromptRunner::new_managed(self.runtime.clone(), provider, context);
+                    let stop_reason = runner
+                        .run(&durable, &ephemeral, &sink, &config, max_iterations)
+                        .await;
+                    (Some(runner), stop_reason)
+                }
+                Err(e) => {
+                    warn!(error = %e, "Failed to resolve selected profile provider");
+                    {
+                        let mut session = durable.lock();
+                        session.add_agent_text(format!("[Provider error: {}]", e));
+                    }
+                    (None, acp::StopReason::EndTurn)
+                }
+            }
         };
 
         self.runtime.finish_prompt(iron_session_id);
@@ -343,6 +434,7 @@ impl IronConnection {
         &self,
         args: acp::PromptRequest,
         provider_context: ProviderPromptContext,
+        session_profile_id: Option<&AgentProfileId>,
     ) -> agent_client_protocol::Result<acp::PromptResponse> {
         debug!(session_id = %args.session_id, provider = %provider_context.provider_slug.as_str(), "Managed prompt received");
 
@@ -384,6 +476,16 @@ impl IronConnection {
         let max_iterations = config.max_iterations;
 
         let sink = AcpPromptSink::new(acp_session_id.clone(), client.clone());
+
+        // Apply the selected profile identity layer unless the session already
+        // has explicit instructions.
+        let selected_profile = self.selected_profile(session_profile_id);
+        {
+            let mut session = durable.lock();
+            if session.instructions.is_none() {
+                session.set_instructions(selected_profile.effective_identity_prompt());
+            }
+        }
 
         // Resolve the managed provider for this prompt
         let provider = match self

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -149,23 +149,30 @@ impl IronConnection {
         *self.client.borrow_mut() = Some(client);
     }
 
-    fn selected_profile(&self, session_profile_id: Option<&AgentProfileId>) -> AgentProfile {
+    fn selected_profile(
+        &self,
+        session_profile_id: Option<&AgentProfileId>,
+    ) -> Result<AgentProfile, agent_client_protocol::Error> {
         let registry = self.profile_registry.read();
-        session_profile_id
-            .and_then(|id| registry.get(id).cloned())
-            .unwrap_or_else(|| {
-                registry
-                    .get(&AgentProfileId::from("default"))
-                    .cloned()
-                    .unwrap_or_else(|| AgentProfile {
-                        name: "default".to_string(),
-                        provider: AgentProfileProvider::RuntimeDefault,
-                        tools: ToolFilter::Inherit,
-                        skills: SkillFilter::Inherit,
-                        approval: AgentApproval::PerTool,
-                        identity_prompt: Some(default_identity_prompt().to_string()),
-                    })
-            })
+        match session_profile_id {
+            Some(id) => registry.get(id).cloned().ok_or_else(|| {
+                agent_client_protocol::Error::invalid_params().data(serde_json::json!({
+                    "profile_id": id.as_str(),
+                    "error": "profile not found"
+                }))
+            }),
+            None => Ok(registry
+                .get(&AgentProfileId::from("default"))
+                .cloned()
+                .unwrap_or_else(|| AgentProfile {
+                    name: "default".to_string(),
+                    provider: AgentProfileProvider::RuntimeDefault,
+                    tools: ToolFilter::Inherit,
+                    skills: SkillFilter::Inherit,
+                    approval: AgentApproval::PerTool,
+                    identity_prompt: Some(default_identity_prompt().to_string()),
+                })),
+        }
     }
 
     fn client_channel(&self) -> SharedClientChannel {
@@ -308,7 +315,7 @@ impl IronConnection {
         // All agent execution is profile-backed. Use the session profile or fall
         // back to the default profile unless a managed provider context was stored
         // by a prior model switch.
-        let selected_profile = self.selected_profile(session_profile_id);
+        let selected_profile = self.selected_profile(session_profile_id)?;
         {
             let mut session = durable.lock();
             if session.instructions.is_none() {
@@ -479,7 +486,7 @@ impl IronConnection {
 
         // Apply the selected profile identity layer unless the session already
         // has explicit instructions.
-        let selected_profile = self.selected_profile(session_profile_id);
+        let selected_profile = self.selected_profile(session_profile_id)?;
         {
             let mut session = durable.lock();
             if session.instructions.is_none() {

--- a/src/facade.rs
+++ b/src/facade.rs
@@ -801,6 +801,9 @@ impl IronAgent {
         }
         let name = normalize_profile_name(&profile.name)
             .ok_or_else(|| format!("invalid profile name: '{}'", profile.name))?;
+        if name.eq_ignore_ascii_case("default") {
+            return Err("profile name 'default' is reserved".to_string());
+        }
 
         let mut registry = self.profile_registry.write();
 
@@ -939,31 +942,25 @@ impl IronAgent {
                 continue;
             }
 
-            // Existing registry entries win duplicate-name conflicts. We hold
-            // the registry read lock while checking.
-            {
-                let registry = self.profile_registry.read();
-                let name = profile.name.trim();
-                let conflict = registry.iter().any(|(existing_id, existing_profile)| {
-                    existing_id.as_str() != profile_id.as_str()
-                        && existing_profile.name.trim() == name
-                });
-                if conflict {
-                    report.diagnostics.push(ProfileLoadDiagnostic {
-                        profile_id: profile_id.clone(),
-                        name: Some(profile.name.clone()),
-                        issue: ProfileLoadIssue::DuplicateName,
-                    });
-                    continue;
-                }
-            }
-
-            // Register the loaded profile, replacing any existing entry for the
-            // same non-reserved ID. Use the additive semantics of `register_profile`
-            // by writing directly to preserve atomic validation.
+            // Existing registry entries win duplicate-name conflicts. Hold the
+            // write lock for the entire check-and-insert so the conflict check
+            // and insertion are atomic with respect to concurrent registrations.
             let mut registry = self.profile_registry.write();
             let normalized_name =
                 normalize_profile_name(&profile.name).unwrap_or_else(|| profile.name.clone());
+            let conflict = registry.iter().any(|(existing_id, existing_profile)| {
+                existing_id.as_str() != profile_id.as_str()
+                    && existing_profile.name == normalized_name
+            });
+            if conflict {
+                report.diagnostics.push(ProfileLoadDiagnostic {
+                    profile_id: profile_id.clone(),
+                    name: Some(profile.name.clone()),
+                    issue: ProfileLoadIssue::DuplicateName,
+                });
+                continue;
+            }
+
             let mut profile = profile;
             profile.name = normalized_name;
             registry.insert(profile_id.clone(), profile.clone());
@@ -1150,7 +1147,8 @@ impl AgentConnection {
     ///
     /// The selected profile ID is resolved against the agent's profile registry
     /// at prompt time. If the profile is not found or is removed before a prompt
-    /// runs, execution falls back to the built-in default profile.
+    /// runs, the prompt returns an error instead of falling back to the built-in
+    /// default profile.
     ///
     /// # Errors
     ///

--- a/src/facade.rs
+++ b/src/facade.rs
@@ -1,7 +1,7 @@
 use crate::plugin::rich_output::{transcript_text as plugin_transcript_text, view as plugin_view};
 use crate::{
     capability::{CapabilityBackend, CapabilityDescriptor, CapabilityId},
-    config::Config,
+    config::{Config, ConfigStore},
     connection::{ClientChannel, IronConnection},
     context::handoff::{HandoffExporter, HandoffImporter},
     durable::{
@@ -9,6 +9,11 @@ use crate::{
         TimelineEntry,
     },
     error::RuntimeError,
+    profile::{
+        default_identity_prompt, normalize_profile_name, AgentApproval, AgentProfile,
+        AgentProfileEntry, AgentProfileId, AgentProfileProvider, ProfileLoadDiagnostic,
+        ProfileLoadIssue, ProfileLoadReport, SkillFilter, ToolFilter, PROFILE_SCHEMA_VERSION,
+    },
     provider_credential::domain::{ProviderAuthStatus, ProviderPromptContext, ProviderSlug},
     provider_credential::store::DynCredentialStore,
     runtime::{ConnectionId, IronRuntime},
@@ -17,7 +22,7 @@ use crate::{
 use agent_client_protocol::schema as acp;
 use futures::Stream;
 use iron_providers::Provider;
-use parking_lot::Mutex;
+use parking_lot::{Mutex, RwLock};
 use std::{
     cell::RefCell,
     collections::HashMap,
@@ -470,6 +475,29 @@ struct StreamPromptState {
 }
 
 // ---------------------------------------------------------------------------
+// Profile registry helpers
+// ---------------------------------------------------------------------------
+
+type ProfileRegistry = HashMap<AgentProfileId, AgentProfile>;
+
+fn default_profile_registry() -> ProfileRegistry {
+    let mut registry = HashMap::new();
+    let default = AgentProfileEntry {
+        id: AgentProfileId::from("default"),
+        profile: AgentProfile {
+            name: "default".to_string(),
+            provider: AgentProfileProvider::RuntimeDefault,
+            tools: ToolFilter::Inherit,
+            skills: SkillFilter::Inherit,
+            approval: AgentApproval::PerTool,
+            identity_prompt: Some(default_identity_prompt().to_string()),
+        },
+    };
+    registry.insert(default.id, default.profile);
+    registry
+}
+
+// ---------------------------------------------------------------------------
 // IronAgent
 // ---------------------------------------------------------------------------
 
@@ -502,6 +530,7 @@ struct StreamPromptState {
 /// ```
 pub struct IronAgent {
     runtime: IronRuntime,
+    profile_registry: Arc<RwLock<ProfileRegistry>>,
 }
 
 impl IronAgent {
@@ -512,6 +541,7 @@ impl IronAgent {
     pub fn new<P: Provider + 'static>(config: Config, provider: P) -> Self {
         Self {
             runtime: IronRuntime::new(config, provider),
+            profile_registry: Arc::new(RwLock::new(default_profile_registry())),
         }
     }
 
@@ -526,6 +556,7 @@ impl IronAgent {
     ) -> Self {
         Self {
             runtime: IronRuntime::from_handle(config, provider, handle),
+            profile_registry: Arc::new(RwLock::new(default_profile_registry())),
         }
     }
 
@@ -537,6 +568,7 @@ impl IronAgent {
     ) -> Self {
         Self {
             runtime: IronRuntime::new_with_credential_store(config, provider, credential_store),
+            profile_registry: Arc::new(RwLock::new(default_profile_registry())),
         }
     }
 
@@ -731,12 +763,239 @@ impl IronAgent {
         self.runtime.get_session_tool_diagnostics(session_id)
     }
 
+    /// Return the built-in default profile entry.
+    ///
+    /// The default profile uses the runtime default provider, inherits tools
+    /// and skills, requires per-tool approval, and provides a generic identity
+    /// prompt.
+    pub fn default_profile(&self) -> AgentProfileEntry {
+        AgentProfileEntry {
+            id: AgentProfileId::from("default"),
+            profile: AgentProfile {
+                name: "default".to_string(),
+                provider: AgentProfileProvider::RuntimeDefault,
+                tools: ToolFilter::Inherit,
+                skills: SkillFilter::Inherit,
+                approval: AgentApproval::PerTool,
+                identity_prompt: Some(default_identity_prompt().to_string()),
+            },
+        }
+    }
+
+    /// Register or replace an agent profile by stable ID.
+    ///
+    /// Validates the profile name and rejects reserved `default` IDs/names.
+    /// If the ID is already registered, the previous profile is replaced only
+    /// when the replacement is valid and does not duplicate a name owned by
+    /// another profile ID.
+    pub fn register_profile(
+        &self,
+        id: AgentProfileId,
+        profile: AgentProfile,
+    ) -> Result<(), String> {
+        if id.as_str().eq_ignore_ascii_case("default") {
+            return Err("profile ID 'default' is reserved".to_string());
+        }
+        if !crate::profile::is_valid_profile_id(id.as_str()) {
+            return Err(format!("invalid profile ID: '{}'", id.as_str()));
+        }
+        let name = normalize_profile_name(&profile.name)
+            .ok_or_else(|| format!("invalid profile name: '{}'", profile.name))?;
+
+        let mut registry = self.profile_registry.write();
+
+        // If replacing, the new name must not duplicate a name owned by a
+        // different profile ID.
+        let name_conflict = registry.iter().any(|(existing_id, existing_profile)| {
+            existing_id.as_str() != id.as_str() && existing_profile.name == name
+        });
+        if name_conflict {
+            return Err(format!(
+                "profile name '{}' is already used by another profile",
+                name
+            ));
+        }
+
+        let mut profile = profile;
+        profile.name = name;
+        registry.insert(id, profile);
+        Ok(())
+    }
+
+    /// Unregister a profile by stable ID.
+    ///
+    /// Returns `true` if a profile was removed. The built-in `default` profile
+    /// cannot be unregistered.
+    pub fn unregister_profile(&self, id: &AgentProfileId) -> bool {
+        if id.as_str().eq_ignore_ascii_case("default") {
+            return false;
+        }
+        self.profile_registry.write().remove(id).is_some()
+    }
+
+    /// List all registered profiles with deterministic ordering.
+    ///
+    /// Profiles are ordered by stable profile ID ascending. The built-in
+    /// `default` profile is always included.
+    pub fn list_profiles(&self) -> Vec<AgentProfileEntry> {
+        let registry = self.profile_registry.read();
+        let mut ids: Vec<&AgentProfileId> = registry.keys().collect();
+        ids.sort_by(|a, b| a.as_str().cmp(b.as_str()));
+        ids.into_iter()
+            .map(|id| AgentProfileEntry {
+                id: id.clone(),
+                profile: registry[id].clone(),
+            })
+            .collect()
+    }
+
+    /// Load typed profiles from a `ConfigStore` and merge them into the registry.
+    ///
+    /// This is a best-effort operation: valid profiles are registered by their
+    /// record ID, while invalid, reserved, or duplicate records are reported as
+    /// per-profile diagnostics. Fatal store failures are returned as `Err`.
+    /// Profiles not present in the store remain registered.
+    pub async fn load_profiles(
+        &self,
+        store: &ConfigStore,
+    ) -> Result<ProfileLoadReport, crate::config::ConfigError> {
+        let record_ids = store.list_profile_ids().await?;
+
+        // Sort IDs ascending for deterministic duplicate-name handling.
+        let mut record_ids = record_ids;
+        record_ids.sort();
+
+        let mut report = ProfileLoadReport::empty();
+
+        for record_id in record_ids {
+            let record = match store.get_profile(&record_id).await? {
+                Some(record) => record,
+                None => {
+                    report.diagnostics.push(ProfileLoadDiagnostic {
+                        profile_id: AgentProfileId::from(record_id),
+                        name: None,
+                        issue: ProfileLoadIssue::MissingRecord,
+                    });
+                    continue;
+                }
+            };
+
+            if record.schema_version != PROFILE_SCHEMA_VERSION {
+                report.diagnostics.push(ProfileLoadDiagnostic {
+                    profile_id: AgentProfileId::from(record.id.clone()),
+                    name: None,
+                    issue: ProfileLoadIssue::UnsupportedSchemaVersion {
+                        version: record.schema_version,
+                    },
+                });
+                continue;
+            }
+
+            let profile: AgentProfile = match serde_json::from_value(record.payload.clone()) {
+                Ok(profile) => profile,
+                Err(_) => {
+                    report.diagnostics.push(ProfileLoadDiagnostic {
+                        profile_id: AgentProfileId::from(record.id.clone()),
+                        name: None,
+                        issue: ProfileLoadIssue::InvalidPayload,
+                    });
+                    continue;
+                }
+            };
+
+            let profile_id = AgentProfileId::from(record.id.clone());
+
+            // Reject reserved default ID/name.
+            if profile_id.as_str().eq_ignore_ascii_case("default")
+                || profile.name.trim().eq_ignore_ascii_case("default")
+            {
+                report.diagnostics.push(ProfileLoadDiagnostic {
+                    profile_id: profile_id.clone(),
+                    name: Some(profile.name.clone()),
+                    issue: ProfileLoadIssue::ReservedDefault,
+                });
+                continue;
+            }
+
+            // Reject invalid IDs before mutating.
+            if !crate::profile::is_valid_profile_id(profile_id.as_str()) {
+                report.diagnostics.push(ProfileLoadDiagnostic {
+                    profile_id: profile_id.clone(),
+                    name: Some(profile.name.clone()),
+                    issue: ProfileLoadIssue::InvalidProfileId,
+                });
+                continue;
+            }
+
+            // Validate name. We intentionally do not normalize here because
+            // `register_profile` normalizes; however, an invalid name must be
+            // reported before any mutation.
+            if normalize_profile_name(&profile.name).is_none() {
+                report.diagnostics.push(ProfileLoadDiagnostic {
+                    profile_id: profile_id.clone(),
+                    name: Some(profile.name.clone()),
+                    issue: ProfileLoadIssue::InvalidName,
+                });
+                continue;
+            }
+
+            // Existing registry entries win duplicate-name conflicts. We hold
+            // the registry read lock while checking.
+            {
+                let registry = self.profile_registry.read();
+                let name = profile.name.trim();
+                let conflict = registry.iter().any(|(existing_id, existing_profile)| {
+                    existing_id.as_str() != profile_id.as_str()
+                        && existing_profile.name.trim() == name
+                });
+                if conflict {
+                    report.diagnostics.push(ProfileLoadDiagnostic {
+                        profile_id: profile_id.clone(),
+                        name: Some(profile.name.clone()),
+                        issue: ProfileLoadIssue::DuplicateName,
+                    });
+                    continue;
+                }
+            }
+
+            // Register the loaded profile, replacing any existing entry for the
+            // same non-reserved ID. Use the additive semantics of `register_profile`
+            // by writing directly to preserve atomic validation.
+            let mut registry = self.profile_registry.write();
+            let normalized_name =
+                normalize_profile_name(&profile.name).unwrap_or_else(|| profile.name.clone());
+            let mut profile = profile;
+            profile.name = normalized_name;
+            registry.insert(profile_id.clone(), profile.clone());
+            report.loaded.push(AgentProfileEntry {
+                id: profile_id,
+                profile,
+            });
+        }
+
+        Ok(report)
+    }
+
+    /// Look up a registered profile by stable ID.
+    ///
+    /// Returns `None` if the profile is not registered. The built-in `default`
+    /// profile is always available.
+    pub fn get_profile(&self, id: &AgentProfileId) -> Option<AgentProfileEntry> {
+        self.profile_registry
+            .read()
+            .get(id)
+            .map(|profile| AgentProfileEntry {
+                id: id.clone(),
+                profile: profile.clone(),
+            })
+    }
+
     /// Establish a new connection to the agent.
     ///
     /// Returns an [`AgentConnection`] which can be used to create sessions
     /// and interact with the agent. Multiple connections can exist simultaneously.
     pub fn connect(&self) -> AgentConnection {
-        AgentConnection::new(self.runtime.clone())
+        AgentConnection::new(self.runtime.clone(), self.profile_registry.clone())
     }
 
     /// Shut down the agent runtime.
@@ -752,6 +1011,7 @@ impl Clone for IronAgent {
     fn clone(&self) -> Self {
         Self {
             runtime: self.runtime.clone(),
+            profile_registry: self.profile_registry.clone(),
         }
     }
 }
@@ -816,8 +1076,11 @@ impl AgentConnection {
         }
     }
 
-    fn new(runtime: IronRuntime) -> Self {
-        let inner = Rc::new(IronConnection::new(runtime));
+    fn new(runtime: IronRuntime, profile_registry: Arc<RwLock<ProfileRegistry>>) -> Self {
+        let inner = Rc::new(IronConnection::new_with_profile_registry(
+            runtime,
+            profile_registry,
+        ));
         let permission_handler = Rc::new(RefCell::new(None));
         let async_permission_handler = Rc::new(RefCell::new(None));
         let active_streams = Rc::new(RefCell::new(HashMap::new()));
@@ -879,6 +1142,31 @@ impl AgentConnection {
             durable,
             connection: self.inner.clone(),
             active_streams: self.active_streams.clone(),
+            profile_id: None,
+        })
+    }
+
+    /// Create a new session with an explicit profile.
+    ///
+    /// The selected profile ID is resolved against the agent's profile registry
+    /// at prompt time. If the profile is not found or is removed before a prompt
+    /// runs, execution falls back to the built-in default profile.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the runtime has been shut down.
+    pub fn create_session_with_profile(
+        &self,
+        profile_id: AgentProfileId,
+    ) -> Result<AgentSession, RuntimeError> {
+        let connection_id = self.inner.id();
+        let (session_id, durable) = self.inner.runtime().create_session(connection_id)?;
+        Ok(AgentSession {
+            id: session_id,
+            durable,
+            connection: self.inner.clone(),
+            active_streams: self.active_streams.clone(),
+            profile_id: Some(profile_id),
         })
     }
 
@@ -1005,6 +1293,7 @@ impl AgentConnection {
             durable,
             connection: self.inner.clone(),
             active_streams: self.active_streams.clone(),
+            profile_id: None,
         })
     }
 }
@@ -1344,6 +1633,7 @@ pub struct AgentSession {
     durable: Arc<Mutex<DurableSession>>,
     connection: Rc<IronConnection>,
     active_streams: Rc<RefCell<HashMap<String, StreamPromptState>>>,
+    profile_id: Option<AgentProfileId>,
 }
 
 impl AgentSession {
@@ -1387,7 +1677,11 @@ impl AgentSession {
             acp_session_id,
             vec![acp::ContentBlock::Text(acp::TextContent::new(text))],
         );
-        match self.connection.handle_prompt(request).await {
+        match self
+            .connection
+            .handle_prompt(request, self.profile_id.as_ref())
+            .await
+        {
             Ok(response) => response.stop_reason.into(),
             Err(_) => PromptOutcome::EndTurn,
         }
@@ -1398,7 +1692,11 @@ impl AgentSession {
         let acp_session_id = acp::SessionId::new(self.id.to_string());
         let acp_blocks: Vec<_> = blocks.iter().map(to_acp_content_block).collect();
         let request = acp::PromptRequest::new(acp_session_id, acp_blocks);
-        match self.connection.handle_prompt(request).await {
+        match self
+            .connection
+            .handle_prompt(request, self.profile_id.as_ref())
+            .await
+        {
             Ok(response) => response.stop_reason.into(),
             Err(_) => PromptOutcome::EndTurn,
         }
@@ -1436,7 +1734,7 @@ impl AgentSession {
         );
         match self
             .connection
-            .handle_prompt_managed(request, provider_context)
+            .handle_prompt_managed(request, provider_context, self.profile_id.as_ref())
             .await
         {
             Ok(response) => response.stop_reason.into(),
@@ -1474,7 +1772,7 @@ impl AgentSession {
         let request = acp::PromptRequest::new(acp_session_id, acp_blocks);
         match self
             .connection
-            .handle_prompt_managed(request, provider_context)
+            .handle_prompt_managed(request, provider_context, self.profile_id.as_ref())
             .await
         {
             Ok(response) => response.stop_reason.into(),
@@ -1596,9 +1894,10 @@ impl AgentSession {
         let connection = self.connection.clone();
         let active_streams = self.active_streams.clone();
         let status_cell = status.clone();
+        let profile_id = self.profile_id.clone();
 
         tokio::task::spawn_local(async move {
-            let outcome = match connection.handle_prompt(request).await {
+            let outcome = match connection.handle_prompt(request, profile_id.as_ref()).await {
                 Ok(response) => response.stop_reason.into(),
                 Err(_) => PromptOutcome::EndTurn,
             };
@@ -1714,10 +2013,11 @@ impl AgentSession {
         let connection = self.connection.clone();
         let active_streams = self.active_streams.clone();
         let status_cell = status.clone();
+        let profile_id = self.profile_id.clone();
 
         tokio::task::spawn_local(async move {
             let outcome = match connection
-                .handle_prompt_managed(request, provider_context)
+                .handle_prompt_managed(request, provider_context, profile_id.as_ref())
                 .await
             {
                 Ok(response) => response.stop_reason.into(),
@@ -2250,6 +2550,7 @@ impl Clone for AgentSession {
             durable: self.durable.clone(),
             connection: self.connection.clone(),
             active_streams: self.active_streams.clone(),
+            profile_id: self.profile_id.clone(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,6 +174,7 @@ pub mod error;
 pub mod facade;
 pub mod mcp;
 pub mod plugin;
+pub mod profile;
 pub mod prompt;
 pub mod prompt_lifecycle;
 pub mod prompt_runner;
@@ -212,6 +213,12 @@ pub use error::{RuntimeError, RuntimeResult};
 pub use facade::{
     AgentConnection, AgentSession, IronAgent, PermissionRequest, PermissionVerdict, PromptEvent,
     PromptEvents, PromptHandle, PromptOutcome, PromptStatus, ToolResultStatus,
+};
+pub use profile::{
+    default_identity_prompt, managed_profile_prompt_context, normalize_profile_name, AgentApproval,
+    AgentProfile, AgentProfileEntry, AgentProfileId, AgentProfileProvider, ProfileLoadDiagnostic,
+    ProfileLoadIssue, ProfileLoadReport, ResolvedProfileProvider, SkillFilter, ToolFilter,
+    PROFILE_SCHEMA_VERSION,
 };
 pub use prompt_turn::PromptTurn;
 pub use runtime::{ConnectionId, IronRuntime};

--- a/src/profile/mod.rs
+++ b/src/profile/mod.rs
@@ -1,0 +1,338 @@
+//! Agent identity profile types and registry helpers.
+//!
+//! Profiles represent durable agent identities: provider/model selection, tool
+//! and skill boundaries, approval posture, and a profile-specific identity
+//! prompt layer. They intentionally do not store credential secret material;
+//! managed provider credentials are resolved from `iron-core`'s credential
+//! state at execution time.
+
+use crate::provider_credential::domain::{ProviderPromptContext, ProviderSlug};
+use iron_providers::Provider;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+/// Schema version for typed `AgentProfile` payloads stored in `ConfigStore`.
+pub const PROFILE_SCHEMA_VERSION: i64 = 1;
+
+/// Stable identifier for an agent profile.
+///
+/// For durable profiles, the `ConfigStore` profile record ID is the stable
+/// profile ID. The user-facing display name lives inside [`AgentProfile::name`].
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct AgentProfileId(pub String);
+
+impl AgentProfileId {
+    /// Borrow the underlying ID string.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<String> for AgentProfileId {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl From<&str> for AgentProfileId {
+    fn from(s: &str) -> Self {
+        Self(s.to_string())
+    }
+}
+
+/// A user-facing agent profile entry pairing a stable ID with its profile.
+#[derive(Debug, Clone, PartialEq)]
+pub struct AgentProfileEntry {
+    /// Stable profile identifier.
+    pub id: AgentProfileId,
+    /// Profile value, including the user-facing name.
+    pub profile: AgentProfile,
+}
+
+/// Provider selection context stored in an agent profile.
+///
+/// Profiles intentionally do not include API keys or other credential secrets.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AgentProfileProvider {
+    /// Use the runtime's injected/default provider path.
+    RuntimeDefault,
+    /// Use a managed provider resolved from `iron-core` credential state.
+    Managed {
+        /// Provider slug used for registry and credential lookup.
+        provider_slug: ProviderSlug,
+        /// Model identifier passed to the provider.
+        model: String,
+    },
+}
+
+/// Tool availability policy for a profile.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub enum ToolFilter {
+    /// Inherit the runtime's available tool set.
+    #[default]
+    Inherit,
+    /// Only allow tools with these names.
+    Allow(Vec<String>),
+    /// Deny tools with these names.
+    Deny(Vec<String>),
+}
+
+/// Skill availability policy for a profile.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub enum SkillFilter {
+    /// No skills are available.
+    #[default]
+    None,
+    /// Only allow skills with these names.
+    Allow(Vec<String>),
+    /// Inherit the runtime's available skill catalog.
+    Inherit,
+}
+
+/// Approval posture for a profile.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub enum AgentApproval {
+    /// Require approval for each tool call.
+    #[default]
+    PerTool,
+    /// Auto-approve tool calls (plumbing only; not enforced by this slice).
+    AutoApprove,
+    /// Read-only execution; no tool calls are allowed.
+    ReadOnly,
+}
+
+/// An agent identity profile.
+///
+/// `name` is a user-facing unique label. The stable identity handle is the
+/// profile ID supplied at registration or loaded from `ConfigStore`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AgentProfile {
+    /// User-facing profile name. Must be unique within the registered set.
+    pub name: String,
+    /// Provider/model selection for this profile.
+    #[serde(flatten)]
+    pub provider: AgentProfileProvider,
+    /// Tool availability policy.
+    #[serde(default)]
+    pub tools: ToolFilter,
+    /// Skill availability policy.
+    #[serde(default)]
+    pub skills: SkillFilter,
+    /// Approval posture.
+    #[serde(default)]
+    pub approval: AgentApproval,
+    /// Optional profile-specific model-facing identity instructions.
+    ///
+    /// A non-blank value replaces the default identity prompt. A blank or
+    /// absent value falls back to the built-in default profile's identity
+    /// prompt during execution preparation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub identity_prompt: Option<String>,
+}
+
+impl AgentProfile {
+    /// Create a profile with the given name using the runtime default provider.
+    pub fn with_name<S: Into<String>>(name: S) -> Self {
+        Self {
+            name: name.into(),
+            provider: AgentProfileProvider::RuntimeDefault,
+            tools: ToolFilter::default(),
+            skills: SkillFilter::default(),
+            approval: AgentApproval::default(),
+            identity_prompt: None,
+        }
+    }
+
+    /// Return the effective identity prompt for this profile.
+    ///
+    /// If the profile has a non-blank custom identity prompt, that is returned.
+    /// Otherwise the built-in default identity prompt is returned.
+    pub fn effective_identity_prompt(&self) -> &str {
+        match self.identity_prompt {
+            Some(ref prompt) if !prompt.trim().is_empty() => prompt,
+            _ => default_identity_prompt(),
+        }
+    }
+}
+
+/// Built-in default identity prompt for profiles without a custom prompt.
+pub fn default_identity_prompt() -> &'static str {
+    "You are a helpful software engineering agent."
+}
+
+/// A resolved provider ready for execution, preserving ownership semantics.
+pub enum ResolvedProfileProvider {
+    /// The runtime's injected/default provider.
+    RuntimeDefault(Arc<dyn Provider>),
+    /// An owned managed provider constructed through credential resolution.
+    Managed(Box<dyn Provider>),
+}
+
+impl ResolvedProfileProvider {
+    /// Borrow the provider as a trait object.
+    pub fn as_provider(&self) -> &dyn Provider {
+        match self {
+            ResolvedProfileProvider::RuntimeDefault(arc) => arc.as_ref(),
+            ResolvedProfileProvider::Managed(boxed) => boxed.as_ref(),
+        }
+    }
+}
+
+/// Issue category reported for a skipped profile during `load_profiles`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProfileLoadIssue {
+    /// The stored profile schema version is not supported.
+    UnsupportedSchemaVersion { version: i64 },
+    /// The stored payload could not be decoded as an `AgentProfile`.
+    InvalidPayload,
+    /// The profile ID is invalid or reserved.
+    InvalidProfileId,
+    /// The profile name is empty, contains control characters, or is reserved.
+    InvalidName,
+    /// The profile ID or name equals the reserved `default` identifier.
+    ReservedDefault,
+    /// Another registered profile already uses the trimmed name.
+    DuplicateName,
+    /// The listed record was missing when read.
+    MissingRecord,
+}
+
+/// Per-profile diagnostic returned by best-effort profile loading.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProfileLoadDiagnostic {
+    /// Stable profile ID from the store listing.
+    pub profile_id: AgentProfileId,
+    /// Parsed profile name, if available from the payload.
+    pub name: Option<String>,
+    /// Issue category describing why the profile was skipped.
+    pub issue: ProfileLoadIssue,
+}
+
+/// Result of loading typed profiles from `ConfigStore`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProfileLoadReport {
+    /// Profiles that were successfully loaded/merged into the registry.
+    pub loaded: Vec<AgentProfileEntry>,
+    /// Profiles that were skipped, with per-profile diagnostics.
+    pub diagnostics: Vec<ProfileLoadDiagnostic>,
+}
+
+impl ProfileLoadReport {
+    /// Create an empty load report.
+    pub fn empty() -> Self {
+        Self {
+            loaded: Vec::new(),
+            diagnostics: Vec::new(),
+        }
+    }
+}
+
+/// Validate a non-default profile ID.
+///
+/// Returns `true` for non-empty strings that contain no control characters and
+/// are not ASCII-case-insensitive equal to `"default"`.
+pub fn is_valid_profile_id(id: &str) -> bool {
+    let trimmed = id.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+    if trimmed.as_bytes().iter().any(|b| b.is_ascii_control()) {
+        return false;
+    }
+    !trimmed.eq_ignore_ascii_case("default")
+}
+
+/// Validate and normalize a profile name.
+///
+/// Returns the trimmed name if it is non-empty, contains no control characters,
+/// and is not the reserved `"default"` identifier. Returns `None` otherwise.
+pub fn normalize_profile_name(name: &str) -> Option<String> {
+    let trimmed = name.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if trimmed.as_bytes().iter().any(|b| b.is_ascii_control()) {
+        return None;
+    }
+    if trimmed.eq_ignore_ascii_case("default") {
+        return None;
+    }
+    Some(trimmed.to_string())
+}
+
+/// Build a managed `ProviderPromptContext` from a profile without a profile API key.
+pub fn managed_profile_prompt_context(
+    provider: &AgentProfileProvider,
+) -> Option<ProviderPromptContext> {
+    match provider {
+        AgentProfileProvider::RuntimeDefault => None,
+        AgentProfileProvider::Managed {
+            provider_slug,
+            model,
+        } => Some(ProviderPromptContext {
+            provider_slug: provider_slug.clone(),
+            model: model.clone(),
+            api_key: None,
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_profile_id_accepts_non_reserved() {
+        assert!(is_valid_profile_id("my-profile"));
+        assert!(is_valid_profile_id("  spaced-id  "));
+    }
+
+    #[test]
+    fn valid_profile_id_rejects_default_variants() {
+        assert!(!is_valid_profile_id("default"));
+        assert!(!is_valid_profile_id("Default"));
+        assert!(!is_valid_profile_id("DEFAULT"));
+    }
+
+    #[test]
+    fn valid_profile_id_rejects_empty_and_control() {
+        assert!(!is_valid_profile_id(""));
+        assert!(!is_valid_profile_id("   "));
+        assert!(!is_valid_profile_id("id\0"));
+    }
+
+    #[test]
+    fn normalize_profile_name_trims_and_rejects_reserved() {
+        assert_eq!(normalize_profile_name("  Foo  "), Some("Foo".to_string()));
+        assert_eq!(normalize_profile_name("default"), None);
+        assert_eq!(normalize_profile_name(""), None);
+        assert_eq!(normalize_profile_name("\t"), None);
+        assert_eq!(normalize_profile_name("a\nb"), None);
+    }
+
+    #[test]
+    fn default_profile_identity_prompt() {
+        assert_eq!(
+            default_identity_prompt(),
+            "You are a helpful software engineering agent."
+        );
+    }
+
+    #[test]
+    fn profile_effective_identity_prompt() {
+        let mut profile = AgentProfile::with_name("test");
+        assert_eq!(
+            profile.effective_identity_prompt(),
+            default_identity_prompt()
+        );
+
+        profile.identity_prompt = Some("Custom.".to_string());
+        assert_eq!(profile.effective_identity_prompt(), "Custom.");
+
+        profile.identity_prompt = Some("   ".to_string());
+        assert_eq!(
+            profile.effective_identity_prompt(),
+            default_identity_prompt()
+        );
+    }
+}

--- a/src/profile/mod.rs
+++ b/src/profile/mod.rs
@@ -81,11 +81,11 @@ pub enum ToolFilter {
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub enum SkillFilter {
     /// No skills are available.
-    #[default]
     None,
     /// Only allow skills with these names.
     Allow(Vec<String>),
     /// Inherit the runtime's available skill catalog.
+    #[default]
     Inherit,
 }
 

--- a/src/prompt/runtime_context.rs
+++ b/src/prompt/runtime_context.rs
@@ -66,6 +66,7 @@ fn approval_strategy_label(strategy: ApprovalStrategy) -> &'static str {
         ApprovalStrategy::Always => "always",
         ApprovalStrategy::Never => "never",
         ApprovalStrategy::PerTool => "per-tool",
+        ApprovalStrategy::AutoApprove => "auto-approve",
     }
 }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -15,6 +15,9 @@ use crate::{
     plugin::registry::{PluginAvailabilitySummary, PluginRegistry},
     plugin::status::{PluginInfo, PluginStatus},
     plugin::wasm_host::WasmHost,
+    profile::{
+        managed_profile_prompt_context, AgentProfile, AgentProfileProvider, ResolvedProfileProvider,
+    },
     provider_credential::domain::{
         ProviderAuthError, ProviderAuthResult, ProviderAuthStatus, ProviderPromptContext,
         ProviderSlug,
@@ -487,6 +490,29 @@ impl IronRuntime {
             })?;
 
         Ok(provider)
+    }
+
+    /// Resolve a provider for the given agent profile.
+    ///
+    /// `RuntimeDefault` profiles use the runtime's injected/default provider.
+    /// `Managed` profiles derive a managed provider context from the profile's
+    /// provider slug and model, resolving credentials from `iron-core`'s
+    /// credential state without a profile-supplied API key.
+    pub async fn resolve_profile_provider(
+        &self,
+        profile: &AgentProfile,
+    ) -> ProviderAuthResult<ResolvedProfileProvider> {
+        match &profile.provider {
+            AgentProfileProvider::RuntimeDefault => Ok(ResolvedProfileProvider::RuntimeDefault(
+                self.inner.provider.clone(),
+            )),
+            AgentProfileProvider::Managed { .. } => {
+                let context = managed_profile_prompt_context(&profile.provider)
+                    .expect("managed profile always yields a prompt context");
+                let provider = self.resolve_managed_provider(&context).await?;
+                Ok(ResolvedProfileProvider::Managed(provider))
+            }
+        }
     }
 
     /// Get the client-visible auth status for a provider.

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -182,7 +182,7 @@ impl InProcessClient {
         &self,
         request: acp_schema::PromptRequest,
     ) -> agent_client_protocol::Result<acp_schema::PromptResponse> {
-        self.with_client_channel(|| self.connection.handle_prompt(request))
+        self.with_client_channel(|| self.connection.handle_prompt(request, None))
             .await
     }
 

--- a/tests/profile_tests.rs
+++ b/tests/profile_tests.rs
@@ -14,7 +14,8 @@ use iron_core::{
         store::{InMemoryCredentialStore, ProviderCredentialStore},
         DurableCredentialStore,
     },
-    Config, IronAgent, IronRuntime, PROFILE_SCHEMA_VERSION as EXPORTED_SCHEMA_VERSION,
+    Config, IronAgent, IronRuntime, PromptOutcome,
+    PROFILE_SCHEMA_VERSION as EXPORTED_SCHEMA_VERSION,
 };
 use iron_providers::{InferenceRequest, Provider, ProviderEvent};
 use serde_json::json;
@@ -881,22 +882,20 @@ async fn prompt_with_profile_uses_custom_identity_prompt() {
 }
 
 #[tokio::test]
-async fn prompt_with_profile_unknown_falls_back_to_default_identity() {
+async fn prompt_with_profile_unknown_returns_error_without_mutating_session() {
     let agent = test_agent();
     let conn = agent.connect();
     let session = conn
         .create_session_with_profile(AgentProfileId::from("unknown"))
         .unwrap();
-    let _ = session.prompt("hello").await;
+    let outcome = session.prompt("hello").await;
 
+    assert_eq!(outcome, PromptOutcome::EndTurn);
     let durable = agent
         .runtime()
         .get_session(session.id())
         .expect("session exists");
-    assert_eq!(
-        durable.lock().instructions,
-        Some(default_identity_prompt().to_string())
-    );
+    assert_eq!(durable.lock().instructions, None);
 }
 
 #[tokio::test]

--- a/tests/profile_tests.rs
+++ b/tests/profile_tests.rs
@@ -1,0 +1,1028 @@
+use futures::stream::{self, BoxStream};
+use futures::StreamExt;
+use iron_core::config::{ConfigStore, ProfileInput};
+use iron_core::{
+    profile::{
+        default_identity_prompt, normalize_profile_name, AgentApproval, AgentProfile,
+        AgentProfileId, AgentProfileProvider, ProfileLoadIssue, ResolvedProfileProvider,
+        SkillFilter, ToolFilter, PROFILE_SCHEMA_VERSION,
+    },
+    provider_credential::{
+        domain::{
+            CredentialMode, OAuthTokenSet, ProviderPromptContext, ProviderSlug, StoredCredential,
+        },
+        store::{InMemoryCredentialStore, ProviderCredentialStore},
+        DurableCredentialStore,
+    },
+    Config, IronAgent, IronRuntime, PROFILE_SCHEMA_VERSION as EXPORTED_SCHEMA_VERSION,
+};
+use iron_providers::{InferenceRequest, Provider, ProviderEvent};
+use serde_json::json;
+use std::sync::Arc;
+
+// ---------------------------------------------------------------------------
+// Test provider
+// ---------------------------------------------------------------------------
+
+#[derive(Default)]
+struct TestProvider;
+
+impl Provider for TestProvider {
+    fn infer(
+        &self,
+        _request: InferenceRequest,
+    ) -> iron_providers::ProviderFuture<'_, Vec<ProviderEvent>> {
+        Box::pin(async { Ok(vec![ProviderEvent::Complete]) })
+    }
+
+    fn infer_stream(
+        &self,
+        _request: InferenceRequest,
+    ) -> iron_providers::ProviderFuture<
+        '_,
+        BoxStream<'static, iron_providers::ProviderResult<ProviderEvent>>,
+    > {
+        Box::pin(async { Ok(stream::empty().boxed()) })
+    }
+}
+
+fn test_agent() -> IronAgent {
+    IronAgent::new(Config::default(), TestProvider)
+}
+
+fn test_profile(name: &str) -> AgentProfile {
+    AgentProfile {
+        name: name.to_string(),
+        provider: AgentProfileProvider::RuntimeDefault,
+        tools: ToolFilter::Inherit,
+        skills: SkillFilter::Inherit,
+        approval: AgentApproval::PerTool,
+        identity_prompt: None,
+    }
+}
+
+fn managed_profile(name: &str, provider_slug: &str, model: &str) -> AgentProfile {
+    AgentProfile {
+        name: name.to_string(),
+        provider: AgentProfileProvider::Managed {
+            provider_slug: ProviderSlug::new(provider_slug),
+            model: model.to_string(),
+        },
+        tools: ToolFilter::Inherit,
+        skills: SkillFilter::Inherit,
+        approval: AgentApproval::PerTool,
+        identity_prompt: None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Domain type tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn schema_version_constant_is_one() {
+    assert_eq!(PROFILE_SCHEMA_VERSION, 1);
+    assert_eq!(EXPORTED_SCHEMA_VERSION, 1);
+}
+
+#[test]
+fn profile_serialization_roundtrip() {
+    let profile = AgentProfile {
+        name: "code-reviewer".to_string(),
+        provider: AgentProfileProvider::Managed {
+            provider_slug: ProviderSlug::new("openai"),
+            model: "gpt-4o".to_string(),
+        },
+        tools: ToolFilter::Allow(vec!["read".to_string(), "search".to_string()]),
+        skills: SkillFilter::Allow(vec!["rust".to_string()]),
+        approval: AgentApproval::ReadOnly,
+        identity_prompt: Some("You review code.".to_string()),
+    };
+
+    let value = serde_json::to_value(&profile).unwrap();
+    let decoded: AgentProfile = serde_json::from_value(value).unwrap();
+    assert_eq!(decoded, profile);
+}
+
+#[test]
+fn runtime_default_provider_serialization() {
+    let profile = AgentProfile {
+        name: "assistant".to_string(),
+        provider: AgentProfileProvider::RuntimeDefault,
+        tools: ToolFilter::Inherit,
+        skills: SkillFilter::Inherit,
+        approval: AgentApproval::PerTool,
+        identity_prompt: None,
+    };
+
+    let value = serde_json::to_value(&profile).unwrap();
+    assert!(value.get("RuntimeDefault").is_some() || value.get("runtime_default").is_some());
+    let decoded: AgentProfile = serde_json::from_value(value).unwrap();
+    assert_eq!(decoded, profile);
+}
+
+#[test]
+fn managed_provider_context_has_no_api_key() {
+    let profile = managed_profile("assistant", "openai", "gpt-4o");
+    let ctx = iron_core::profile::managed_profile_prompt_context(&profile.provider);
+    assert_eq!(
+        ctx,
+        Some(ProviderPromptContext {
+            provider_slug: ProviderSlug::new("openai"),
+            model: "gpt-4o".to_string(),
+            api_key: None,
+        })
+    );
+}
+
+#[test]
+fn normalize_profile_name_trims_and_rejects_reserved() {
+    assert_eq!(normalize_profile_name("  Foo  "), Some("Foo".to_string()));
+    assert_eq!(normalize_profile_name("default"), None);
+    assert_eq!(normalize_profile_name("Default"), None);
+    assert_eq!(normalize_profile_name(""), None);
+    assert_eq!(normalize_profile_name("\t"), None);
+    assert_eq!(normalize_profile_name("a\nb"), None);
+}
+
+#[test]
+fn effective_identity_prompt_fallback_and_override() {
+    let mut profile = AgentProfile::with_name("test");
+    assert_eq!(
+        profile.effective_identity_prompt(),
+        default_identity_prompt()
+    );
+
+    profile.identity_prompt = Some("Custom identity.".to_string());
+    assert_eq!(profile.effective_identity_prompt(), "Custom identity.");
+
+    profile.identity_prompt = Some("   ".to_string());
+    assert_eq!(
+        profile.effective_identity_prompt(),
+        default_identity_prompt()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// IronAgent registry tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn default_profile_is_always_registered() {
+    let agent = test_agent();
+    let profiles = agent.list_profiles();
+    assert_eq!(profiles.len(), 1);
+    assert_eq!(profiles[0].id.as_str(), "default");
+    assert_eq!(profiles[0].profile.name, "default");
+    assert!(matches!(
+        profiles[0].profile.provider,
+        AgentProfileProvider::RuntimeDefault
+    ));
+    assert!(matches!(profiles[0].profile.tools, ToolFilter::Inherit));
+    assert!(matches!(profiles[0].profile.skills, SkillFilter::Inherit));
+    assert!(matches!(
+        profiles[0].profile.approval,
+        AgentApproval::PerTool
+    ));
+}
+
+#[test]
+fn register_and_list_profile() {
+    let agent = test_agent();
+    let profile = test_profile("My Profile");
+    agent
+        .register_profile(AgentProfileId::from("prof-1"), profile.clone())
+        .unwrap();
+
+    let profiles = agent.list_profiles();
+    assert_eq!(profiles.len(), 2);
+    let entry = profiles.iter().find(|e| e.id.as_str() == "prof-1").unwrap();
+    assert_eq!(entry.profile.name, "My Profile");
+}
+
+#[test]
+fn register_rejects_reserved_default_id() {
+    let agent = test_agent();
+    let profile = test_profile("custom");
+    assert!(agent
+        .register_profile(AgentProfileId::from("default"), profile.clone())
+        .is_err());
+    assert!(agent
+        .register_profile(AgentProfileId::from("Default"), profile.clone())
+        .is_err());
+}
+
+#[test]
+fn register_rejects_reserved_default_name() {
+    let agent = test_agent();
+    let mut profile = test_profile("default");
+    assert!(agent
+        .register_profile(AgentProfileId::from("prof-1"), profile.clone())
+        .is_err());
+    profile.name = "Default".to_string();
+    assert!(agent
+        .register_profile(AgentProfileId::from("prof-1"), profile.clone())
+        .is_err());
+}
+
+#[test]
+fn register_rejects_invalid_name() {
+    let agent = test_agent();
+    let profile = AgentProfile::with_name("");
+    assert!(agent
+        .register_profile(AgentProfileId::from("prof-1"), profile)
+        .is_err());
+
+    let profile = AgentProfile::with_name("   ");
+    assert!(agent
+        .register_profile(AgentProfileId::from("prof-1"), profile)
+        .is_err());
+
+    let profile = AgentProfile::with_name("a\nb");
+    assert!(agent
+        .register_profile(AgentProfileId::from("prof-1"), profile)
+        .is_err());
+}
+
+#[test]
+fn register_rejects_duplicate_name() {
+    let agent = test_agent();
+    let profile1 = test_profile("Unique Name");
+    let profile2 = test_profile("Unique Name");
+    agent
+        .register_profile(AgentProfileId::from("prof-1"), profile1)
+        .unwrap();
+    assert!(agent
+        .register_profile(AgentProfileId::from("prof-2"), profile2)
+        .is_err());
+}
+
+#[test]
+fn register_normalizes_name() {
+    let agent = test_agent();
+    let profile = AgentProfile::with_name("  Spaced Name  ");
+    agent
+        .register_profile(AgentProfileId::from("prof-1"), profile)
+        .unwrap();
+    let entry = agent.get_profile(&AgentProfileId::from("prof-1")).unwrap();
+    assert_eq!(entry.profile.name, "Spaced Name");
+}
+
+#[test]
+fn replace_profile_keeps_id() {
+    let agent = test_agent();
+    let profile1 = test_profile("First");
+    let profile2 = test_profile("Second");
+    agent
+        .register_profile(AgentProfileId::from("prof-1"), profile1)
+        .unwrap();
+    agent
+        .register_profile(AgentProfileId::from("prof-1"), profile2)
+        .unwrap();
+
+    let entry = agent.get_profile(&AgentProfileId::from("prof-1")).unwrap();
+    assert_eq!(entry.profile.name, "Second");
+}
+
+#[test]
+fn replace_rejects_duplicate_name_owned_by_other() {
+    let agent = test_agent();
+    let profile1 = test_profile("First");
+    let profile2 = test_profile("Second");
+    agent
+        .register_profile(AgentProfileId::from("prof-1"), profile1)
+        .unwrap();
+    agent
+        .register_profile(AgentProfileId::from("prof-2"), profile2)
+        .unwrap();
+
+    // prof-1 cannot be replaced with name "Second" because prof-2 owns it.
+    let replacement = test_profile("Second");
+    assert!(agent
+        .register_profile(AgentProfileId::from("prof-1"), replacement)
+        .is_err());
+
+    // prof-1 should remain unchanged.
+    let entry = agent.get_profile(&AgentProfileId::from("prof-1")).unwrap();
+    assert_eq!(entry.profile.name, "First");
+}
+
+#[test]
+fn invalid_replacement_leaves_existing_unchanged() {
+    let agent = test_agent();
+    let valid = test_profile("Valid");
+    agent
+        .register_profile(AgentProfileId::from("prof-1"), valid)
+        .unwrap();
+
+    let invalid = AgentProfile::with_name("");
+    assert!(agent
+        .register_profile(AgentProfileId::from("prof-1"), invalid)
+        .is_err());
+
+    let entry = agent.get_profile(&AgentProfileId::from("prof-1")).unwrap();
+    assert_eq!(entry.profile.name, "Valid");
+}
+
+#[test]
+fn unregister_profile() {
+    let agent = test_agent();
+    agent
+        .register_profile(AgentProfileId::from("prof-1"), test_profile("One"))
+        .unwrap();
+    assert!(agent.unregister_profile(&AgentProfileId::from("prof-1")));
+    assert!(!agent.unregister_profile(&AgentProfileId::from("prof-1")));
+    assert!(agent.get_profile(&AgentProfileId::from("prof-1")).is_none());
+}
+
+#[test]
+fn unregister_default_is_noop() {
+    let agent = test_agent();
+    assert!(!agent.unregister_profile(&AgentProfileId::from("default")));
+    assert!(agent
+        .get_profile(&AgentProfileId::from("default"))
+        .is_some());
+}
+
+#[test]
+fn unregister_frees_name() {
+    let agent = test_agent();
+    agent
+        .register_profile(AgentProfileId::from("prof-1"), test_profile("Freed"))
+        .unwrap();
+    agent.unregister_profile(&AgentProfileId::from("prof-1"));
+    agent
+        .register_profile(AgentProfileId::from("prof-2"), test_profile("Freed"))
+        .unwrap();
+}
+
+#[test]
+fn list_profiles_is_deterministic() {
+    let agent = test_agent();
+    agent
+        .register_profile(AgentProfileId::from("charlie"), test_profile("Charlie"))
+        .unwrap();
+    agent
+        .register_profile(AgentProfileId::from("alpha"), test_profile("Alpha"))
+        .unwrap();
+    agent
+        .register_profile(AgentProfileId::from("bravo"), test_profile("Bravo"))
+        .unwrap();
+
+    let ids: Vec<String> = agent
+        .list_profiles()
+        .into_iter()
+        .map(|e| e.id.as_str().to_string())
+        .collect();
+    assert_eq!(ids, vec!["alpha", "bravo", "charlie", "default"]);
+}
+
+// ---------------------------------------------------------------------------
+// ConfigStore loading tests
+// ---------------------------------------------------------------------------
+
+async fn store_with_profile_payload(
+    id: &str,
+    schema_version: i64,
+    payload: serde_json::Value,
+) -> ConfigStore {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+    store
+        .set_profile(&ProfileInput {
+            id: id.to_string(),
+            schema_version,
+            payload,
+        })
+        .await
+        .unwrap();
+    store
+}
+
+#[tokio::test]
+async fn load_profiles_success() {
+    let store = store_with_profile_payload(
+        "prof-1",
+        PROFILE_SCHEMA_VERSION,
+        json!({"name": "Loaded", "RuntimeDefault": {}}),
+    )
+    .await;
+
+    let agent = test_agent();
+    let report = agent.load_profiles(&store).await.unwrap();
+    assert_eq!(report.loaded.len(), 1);
+    assert_eq!(report.loaded[0].id.as_str(), "prof-1");
+    assert_eq!(report.loaded[0].profile.name, "Loaded");
+    assert!(report.diagnostics.is_empty());
+}
+
+#[tokio::test]
+async fn load_profiles_replaces_existing() {
+    let store = store_with_profile_payload(
+        "prof-1",
+        PROFILE_SCHEMA_VERSION,
+        json!({"name": "From Store", "RuntimeDefault": {}}),
+    )
+    .await;
+
+    let agent = test_agent();
+    agent
+        .register_profile(AgentProfileId::from("prof-1"), test_profile("Original"))
+        .unwrap();
+
+    let report = agent.load_profiles(&store).await.unwrap();
+    assert_eq!(report.loaded.len(), 1);
+    assert_eq!(report.loaded[0].profile.name, "From Store");
+}
+
+#[tokio::test]
+async fn load_profiles_unsupported_schema_version() {
+    let store = store_with_profile_payload(
+        "prof-1",
+        999,
+        json!({"name": "Future", "RuntimeDefault": {}}),
+    )
+    .await;
+
+    let agent = test_agent();
+    let report = agent.load_profiles(&store).await.unwrap();
+    assert!(report.loaded.is_empty());
+    assert_eq!(report.diagnostics.len(), 1);
+    assert!(matches!(
+        report.diagnostics[0].issue,
+        ProfileLoadIssue::UnsupportedSchemaVersion { version: 999 }
+    ));
+}
+
+#[tokio::test]
+async fn load_profiles_invalid_payload() {
+    let store = store_with_profile_payload(
+        "prof-1",
+        PROFILE_SCHEMA_VERSION,
+        json!({"not_a_name": "oops"}),
+    )
+    .await;
+
+    let agent = test_agent();
+    let report = agent.load_profiles(&store).await.unwrap();
+    assert!(report.loaded.is_empty());
+    assert_eq!(report.diagnostics.len(), 1);
+    assert!(matches!(
+        report.diagnostics[0].issue,
+        ProfileLoadIssue::InvalidPayload
+    ));
+}
+
+#[tokio::test]
+async fn load_profiles_invalid_id() {
+    let store = store_with_profile_payload(
+        "default",
+        PROFILE_SCHEMA_VERSION,
+        json!({"name": "Evil", "RuntimeDefault": {}}),
+    )
+    .await;
+
+    let agent = test_agent();
+    let report = agent.load_profiles(&store).await.unwrap();
+    assert!(report.loaded.is_empty());
+    assert!(report.diagnostics.iter().any(|d| matches!(
+        d.issue,
+        ProfileLoadIssue::ReservedDefault | ProfileLoadIssue::InvalidProfileId
+    )));
+}
+
+#[tokio::test]
+async fn load_profiles_reserved_name() {
+    let store = store_with_profile_payload(
+        "prof-1",
+        PROFILE_SCHEMA_VERSION,
+        json!({"name": "Default", "RuntimeDefault": {}}),
+    )
+    .await;
+
+    let agent = test_agent();
+    let report = agent.load_profiles(&store).await.unwrap();
+    assert!(report.loaded.is_empty());
+    assert!(report
+        .diagnostics
+        .iter()
+        .any(|d| matches!(d.issue, ProfileLoadIssue::ReservedDefault)));
+}
+
+#[tokio::test]
+async fn load_profiles_invalid_name() {
+    let store = store_with_profile_payload(
+        "prof-1",
+        PROFILE_SCHEMA_VERSION,
+        json!({"name": "", "RuntimeDefault": {}}),
+    )
+    .await;
+
+    let agent = test_agent();
+    let report = agent.load_profiles(&store).await.unwrap();
+    assert!(report.loaded.is_empty());
+    assert!(report
+        .diagnostics
+        .iter()
+        .any(|d| matches!(d.issue, ProfileLoadIssue::InvalidName)));
+}
+
+#[tokio::test]
+async fn load_profiles_duplicate_name_skips_later() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+    store
+        .set_profile(&ProfileInput {
+            id: "b".to_string(),
+            schema_version: PROFILE_SCHEMA_VERSION,
+            payload: json!({"name": "Dup", "RuntimeDefault": {}}),
+        })
+        .await
+        .unwrap();
+    store
+        .set_profile(&ProfileInput {
+            id: "a".to_string(),
+            schema_version: PROFILE_SCHEMA_VERSION,
+            payload: json!({"name": "Dup", "RuntimeDefault": {}}),
+        })
+        .await
+        .unwrap();
+
+    let agent = test_agent();
+    let report = agent.load_profiles(&store).await.unwrap();
+    assert_eq!(report.loaded.len(), 1);
+    assert_eq!(report.loaded[0].id.as_str(), "a");
+    assert_eq!(report.diagnostics.len(), 1);
+    assert!(matches!(
+        report.diagnostics[0].issue,
+        ProfileLoadIssue::DuplicateName
+    ));
+}
+
+#[tokio::test]
+async fn load_profiles_existing_registry_wins_duplicate() {
+    let store = store_with_profile_payload(
+        "prof-1",
+        PROFILE_SCHEMA_VERSION,
+        json!({"name": "Existing", "RuntimeDefault": {}}),
+    )
+    .await;
+
+    let agent = test_agent();
+    agent
+        .register_profile(AgentProfileId::from("prof-2"), test_profile("Existing"))
+        .unwrap();
+
+    let report = agent.load_profiles(&store).await.unwrap();
+    assert!(report.loaded.is_empty());
+    assert_eq!(report.diagnostics.len(), 1);
+    assert!(matches!(
+        report.diagnostics[0].issue,
+        ProfileLoadIssue::DuplicateName
+    ));
+}
+
+#[tokio::test]
+async fn load_profiles_is_additive() {
+    let store = store_with_profile_payload(
+        "prof-1",
+        PROFILE_SCHEMA_VERSION,
+        json!({"name": "From Store", "RuntimeDefault": {}}),
+    )
+    .await;
+
+    let agent = test_agent();
+    agent
+        .register_profile(AgentProfileId::from("prof-2"), test_profile("In Memory"))
+        .unwrap();
+
+    let report = agent.load_profiles(&store).await.unwrap();
+    assert_eq!(report.loaded.len(), 1);
+    let profiles = agent.list_profiles();
+    assert_eq!(profiles.len(), 3);
+    assert!(profiles.iter().any(|e| e.id.as_str() == "prof-1"));
+    assert!(profiles.iter().any(|e| e.id.as_str() == "prof-2"));
+    assert!(profiles.iter().any(|e| e.id.as_str() == "default"));
+}
+
+#[tokio::test]
+async fn load_profiles_invalid_replacement_leaves_existing() {
+    let store = store_with_profile_payload(
+        "prof-1",
+        PROFILE_SCHEMA_VERSION,
+        json!({"name": "", "RuntimeDefault": {}}),
+    )
+    .await;
+
+    let agent = test_agent();
+    agent
+        .register_profile(AgentProfileId::from("prof-1"), test_profile("Original"))
+        .unwrap();
+
+    let report = agent.load_profiles(&store).await.unwrap();
+    assert!(report.loaded.is_empty());
+    assert_eq!(report.diagnostics.len(), 1);
+
+    let entry = agent.get_profile(&AgentProfileId::from("prof-1")).unwrap();
+    assert_eq!(entry.profile.name, "Original");
+}
+
+#[tokio::test]
+async fn load_profiles_best_effort() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+    store
+        .set_profile(&ProfileInput {
+            id: "good".to_string(),
+            schema_version: PROFILE_SCHEMA_VERSION,
+            payload: json!({"name": "Good", "RuntimeDefault": {}}),
+        })
+        .await
+        .unwrap();
+    store
+        .set_profile(&ProfileInput {
+            id: "bad".to_string(),
+            schema_version: PROFILE_SCHEMA_VERSION,
+            payload: json!({"name": "", "RuntimeDefault": {}}),
+        })
+        .await
+        .unwrap();
+
+    let agent = test_agent();
+    let report = agent.load_profiles(&store).await.unwrap();
+    assert_eq!(report.loaded.len(), 1);
+    assert_eq!(report.loaded[0].id.as_str(), "good");
+    assert_eq!(report.diagnostics.len(), 1);
+    assert_eq!(report.diagnostics[0].profile_id.as_str(), "bad");
+}
+
+#[tokio::test]
+async fn load_profiles_excludes_builtin_default() {
+    let store = store_with_profile_payload(
+        "prof-1",
+        PROFILE_SCHEMA_VERSION,
+        json!({"name": "Loaded", "RuntimeDefault": {}}),
+    )
+    .await;
+
+    let agent = test_agent();
+    let report = agent.load_profiles(&store).await.unwrap();
+    assert!(!report.loaded.iter().any(|e| e.id.as_str() == "default"));
+}
+
+// ---------------------------------------------------------------------------
+// Provider resolution tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn resolve_runtime_default_provider() {
+    let agent = test_agent();
+    let default = agent.default_profile();
+    let resolved = agent
+        .runtime()
+        .resolve_profile_provider(&default.profile)
+        .await
+        .unwrap();
+    assert!(matches!(
+        resolved,
+        ResolvedProfileProvider::RuntimeDefault(_)
+    ));
+}
+
+#[tokio::test]
+async fn resolve_managed_provider_with_credentials() {
+    let config_store = ConfigStore::open_in_memory().await.unwrap();
+    let durable = Arc::new(DurableCredentialStore::new(config_store));
+    let store: Arc<dyn ProviderCredentialStore> = durable.clone();
+    store
+        .set(
+            &ProviderSlug::new("openai"),
+            StoredCredential::ApiKey("sk-test".into()),
+        )
+        .await;
+
+    let runtime = IronRuntime::new_with_credential_store(Config::default(), TestProvider, store);
+    let profile = managed_profile("managed", "openai", "gpt-4o");
+    let resolved = runtime.resolve_profile_provider(&profile).await.unwrap();
+    assert!(matches!(resolved, ResolvedProfileProvider::Managed(_)));
+}
+
+#[tokio::test]
+async fn resolve_managed_provider_missing_resolver() {
+    let runtime = IronRuntime::new(Config::default(), TestProvider);
+    let profile = managed_profile("managed", "openai", "gpt-4o");
+    let result = runtime.resolve_profile_provider(&profile).await;
+    assert!(matches!(
+        result,
+        Err(iron_core::provider_credential::domain::ProviderAuthError::NotConfigured(_))
+    ));
+}
+
+#[tokio::test]
+async fn resolve_managed_provider_missing_credential() {
+    let config_store = ConfigStore::open_in_memory().await.unwrap();
+    let durable = Arc::new(DurableCredentialStore::new(config_store));
+    let store: Arc<dyn ProviderCredentialStore> = durable.clone();
+
+    let runtime = IronRuntime::new_with_credential_store(Config::default(), TestProvider, store);
+    let profile = managed_profile("managed", "openai", "gpt-4o");
+    let result = runtime.resolve_profile_provider(&profile).await;
+    assert!(matches!(
+        result,
+        Err(iron_core::provider_credential::domain::ProviderAuthError::NotConfigured(_))
+    ));
+}
+
+#[tokio::test]
+async fn resolve_managed_provider_nonexistent_provider_is_not_configured() {
+    // A provider slug with no stored credential resolves as NotConfigured.
+    let in_memory = Arc::new(InMemoryCredentialStore::new());
+    let store: Arc<dyn ProviderCredentialStore> = in_memory.clone();
+    let runtime = IronRuntime::new_with_credential_store(Config::default(), TestProvider, store);
+    let profile = managed_profile("managed", "nonexistent-provider", "model");
+    let result = runtime.resolve_profile_provider(&profile).await;
+    assert!(matches!(
+        result,
+        Err(iron_core::provider_credential::domain::ProviderAuthError::NotConfigured(_))
+    ));
+}
+
+// ---------------------------------------------------------------------------
+// Default profile selection / identity prompt tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn unspecified_profile_resolves_to_default() {
+    let agent = test_agent();
+    let default = agent.default_profile();
+    assert_eq!(default.id.as_str(), "default");
+    assert_eq!(
+        default.profile.effective_identity_prompt(),
+        default_identity_prompt()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Profile registry sharing tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn iron_agent_clone_shares_profile_registry() {
+    let agent = test_agent();
+    let clone = agent.clone();
+
+    agent
+        .register_profile(AgentProfileId::from("prof-1"), test_profile("Original"))
+        .unwrap();
+    assert!(clone.get_profile(&AgentProfileId::from("prof-1")).is_some());
+
+    clone
+        .register_profile(AgentProfileId::from("prof-2"), test_profile("From Clone"))
+        .unwrap();
+    assert!(agent.get_profile(&AgentProfileId::from("prof-2")).is_some());
+}
+
+// ---------------------------------------------------------------------------
+// Profile-backed prompt execution tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn prompt_applies_default_profile_identity_prompt() {
+    let agent = test_agent();
+    let conn = agent.connect();
+    let session = conn.create_session().unwrap();
+
+    let _ = session.prompt("hello").await;
+
+    let durable = agent
+        .runtime()
+        .get_session(session.id())
+        .expect("session exists");
+    assert_eq!(
+        durable.lock().instructions,
+        Some(default_identity_prompt().to_string())
+    );
+}
+
+#[tokio::test]
+async fn prompt_preserves_explicit_session_instructions() {
+    let agent = test_agent();
+    let conn = agent.connect();
+    let session = conn.create_session().unwrap();
+    session.set_instructions("Explicit instructions");
+
+    let _ = session.prompt("hello").await;
+
+    let durable = agent
+        .runtime()
+        .get_session(session.id())
+        .expect("session exists");
+    assert_eq!(
+        durable.lock().instructions,
+        Some("Explicit instructions".to_string())
+    );
+}
+
+#[tokio::test]
+async fn prompt_managed_applies_default_profile_identity_prompt() {
+    let agent = test_agent();
+    let conn = agent.connect();
+    let session = conn.create_session().unwrap();
+
+    let context = ProviderPromptContext {
+        provider_slug: ProviderSlug::new("openai"),
+        model: "gpt-4o".to_string(),
+        api_key: Some("sk-test".to_string()),
+    };
+    let _ = session.prompt_managed("hello", context).await;
+
+    let durable = agent
+        .runtime()
+        .get_session(session.id())
+        .expect("session exists");
+    assert_eq!(
+        durable.lock().instructions,
+        Some(default_identity_prompt().to_string())
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Explicit profile selection execution tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn prompt_with_profile_uses_custom_identity_prompt() {
+    let agent = test_agent();
+    agent
+        .register_profile(
+            AgentProfileId::from("rust-expert"),
+            AgentProfile {
+                name: "Rust Expert".to_string(),
+                provider: AgentProfileProvider::RuntimeDefault,
+                tools: ToolFilter::Inherit,
+                skills: SkillFilter::Inherit,
+                approval: AgentApproval::PerTool,
+                identity_prompt: Some("You are a Rust expert.".to_string()),
+            },
+        )
+        .unwrap();
+
+    let conn = agent.connect();
+    let session = conn
+        .create_session_with_profile(AgentProfileId::from("rust-expert"))
+        .unwrap();
+    let _ = session.prompt("hello").await;
+
+    let durable = agent
+        .runtime()
+        .get_session(session.id())
+        .expect("session exists");
+    assert_eq!(
+        durable.lock().instructions,
+        Some("You are a Rust expert.".to_string())
+    );
+}
+
+#[tokio::test]
+async fn prompt_with_profile_unknown_falls_back_to_default_identity() {
+    let agent = test_agent();
+    let conn = agent.connect();
+    let session = conn
+        .create_session_with_profile(AgentProfileId::from("unknown"))
+        .unwrap();
+    let _ = session.prompt("hello").await;
+
+    let durable = agent
+        .runtime()
+        .get_session(session.id())
+        .expect("session exists");
+    assert_eq!(
+        durable.lock().instructions,
+        Some(default_identity_prompt().to_string())
+    );
+}
+
+#[tokio::test]
+async fn prompt_with_profile_uses_managed_provider_resolution() {
+    let config_store = ConfigStore::open_in_memory().await.unwrap();
+    let durable = Arc::new(DurableCredentialStore::new(config_store));
+    let store: Arc<dyn ProviderCredentialStore> = durable.clone();
+    store
+        .set(
+            &ProviderSlug::new("openai"),
+            StoredCredential::ApiKey("sk-test".into()),
+        )
+        .await;
+
+    let agent = IronAgent::new_with_credential_store(Config::default(), TestProvider, store);
+    agent
+        .register_profile(
+            AgentProfileId::from("managed-assistant"),
+            managed_profile("Managed Assistant", "openai", "gpt-4o"),
+        )
+        .unwrap();
+
+    let conn = agent.connect();
+    let session = conn
+        .create_session_with_profile(AgentProfileId::from("managed-assistant"))
+        .unwrap();
+    let _ = session.prompt("hello").await;
+
+    let durable = agent
+        .runtime()
+        .get_session(session.id())
+        .expect("session exists");
+    assert_eq!(
+        durable.lock().instructions,
+        Some(default_identity_prompt().to_string())
+    );
+}
+
+#[tokio::test]
+async fn resolve_managed_provider_unsupported_oauth_for_openai() {
+    // openai supports only API keys; storing an OAuth credential yields
+    // UnsupportedCredential from the resolver.
+    let config_store = ConfigStore::open_in_memory().await.unwrap();
+    let durable = Arc::new(DurableCredentialStore::new(config_store));
+    let store: Arc<dyn ProviderCredentialStore> = durable.clone();
+    store
+        .set(
+            &ProviderSlug::new("openai"),
+            StoredCredential::OAuthBearer(OAuthTokenSet {
+                access_token: "at".into(),
+                refresh_token: "rt".into(),
+                expires_at: None,
+                id_token: None,
+            }),
+        )
+        .await;
+
+    let runtime = IronRuntime::new_with_credential_store(Config::default(), TestProvider, store);
+    let profile = managed_profile("managed", "openai", "gpt-4o");
+    let result = runtime.resolve_profile_provider(&profile).await;
+    assert!(matches!(
+        result,
+        Err(iron_core::provider_credential::domain::ProviderAuthError::UnsupportedCredential {
+            provider,
+            mode: CredentialMode::OAuthBearer,
+        }) if provider == "openai"
+    ));
+}
+
+#[tokio::test]
+async fn resolve_managed_provider_unsupported_api_key_for_codex() {
+    // codex supports only OAuth; providing an API key yields UnsupportedCredential.
+    let config_store = ConfigStore::open_in_memory().await.unwrap();
+    let durable = Arc::new(DurableCredentialStore::new(config_store));
+    let store: Arc<dyn ProviderCredentialStore> = durable.clone();
+
+    let runtime = IronRuntime::new_with_credential_store(Config::default(), TestProvider, store);
+    let mut profile = managed_profile("managed", "codex", "codex-model");
+    profile.provider = AgentProfileProvider::Managed {
+        provider_slug: ProviderSlug::new("codex"),
+        model: "codex-model".to_string(),
+    };
+    // Build a context with an explicit API key to bypass stored-credential lookup.
+    let context = ProviderPromptContext {
+        provider_slug: ProviderSlug::new("codex"),
+        model: "codex-model".to_string(),
+        api_key: Some("sk-test".to_string()),
+    };
+    let result = runtime.resolve_managed_provider(&context).await;
+    assert!(matches!(
+        result,
+        Err(iron_core::provider_credential::domain::ProviderAuthError::UnsupportedCredential {
+            provider,
+            mode: CredentialMode::ApiKey,
+        }) if provider == "codex"
+    ));
+}
+
+#[test]
+fn custom_identity_prompt_replaces_default() {
+    let profile = AgentProfile {
+        name: "custom".to_string(),
+        provider: AgentProfileProvider::RuntimeDefault,
+        tools: ToolFilter::Inherit,
+        skills: SkillFilter::Inherit,
+        approval: AgentApproval::PerTool,
+        identity_prompt: Some("You are a Rust expert.".to_string()),
+    };
+    assert_eq!(
+        profile.effective_identity_prompt(),
+        "You are a Rust expert."
+    );
+}
+
+#[test]
+fn blank_identity_prompt_falls_back_to_default() {
+    let profile = AgentProfile {
+        name: "custom".to_string(),
+        provider: AgentProfileProvider::RuntimeDefault,
+        tools: ToolFilter::Inherit,
+        skills: SkillFilter::Inherit,
+        approval: AgentApproval::PerTool,
+        identity_prompt: Some("   ".to_string()),
+    };
+    assert_eq!(
+        profile.effective_identity_prompt(),
+        default_identity_prompt()
+    );
+}


### PR DESCRIPTION
## Summary
- add typed AgentProfile APIs, profile registry/loading, diagnostics, and OpenSpec artifacts
- wire default and explicit profile-backed prompt execution through provider resolution
- add runtime-default and managed provider resolution with credential-safe profile contexts
- add tests covering registration, loading, default/explicit profile selection, and provider errors

## Verification
- cargo check
- cargo clippy --all-targets -- -D warnings
- cargo test

Closes #59
Closes #60

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent identity profiles: create/manage typed profiles with identity prompts, provider/model selection, and tool/skill filters
  * Profile-backed execution: sessions can select profiles; defaults to a protected built-in profile when none chosen
  * New AutoApprove approval strategy for automatic tool approval

* **Profile Loading & Resolution**
  * Import profiles from durable storage with per-profile validation diagnostics and best-effort loading
  * Runtime resolves profile provider (runtime-default vs managed) and surfaces actionable provider auth errors

* **Tests**
  * Comprehensive tests covering profiles, loading, provider resolution, and prompt/identity behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->