### PR TITLE
feat: add delegated tasks and stored prompts

### DIFF
--- a/openspec/changes/archive/2026-06-15-delegated-tasks-and-stored-prompts/design.md
+++ b/openspec/changes/archive/2026-06-15-delegated-tasks-and-stored-prompts/design.md
@@ -1,0 +1,179 @@
+## Context
+
+`IronRuntime` already owns most low-level mechanics needed for delegated execution: session creation, hidden-session flags, session-effective tool catalogs, parent-child session relationships, cancellation propagation, profile provider resolution, and prompt execution through `PromptRunner`. The missing design is how to expose these pieces as a safe sub-agent primitive without turning child sessions into a hidden approval bypass.
+
+`ConfigStore` already has an opaque `prompts` table with versioned JSON payloads. Stored prompts can therefore define typed payload semantics on top of the existing storage contract rather than adding a new table. The first useful invocation surface is session-bound use from AgentIron slash commands; later scheduled tasks and CLI one-shots should reuse the same invocation engine.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Define `delegate_task` as the core child-agent spawning primitive.
+- Make delegated child sessions hidden from normal session listings by default while exposing explicit APIs for frontend inspection.
+- Preserve existing and expected tool approval behavior for `delegate_task` itself.
+- Support child approval routing modes so a child run can either auto-approve child tool calls or propagate each approval request to the parent/main UI.
+- Define sub-agent tool policy defaults and configuration semantics, including parent inheritance, profile boundaries, blocklists, and auditable additions.
+- Use existing profile provider resolution for delegated runs.
+- Use existing session relationship tracking for parent-child registration, cancellation propagation, and cleanup.
+- Define typed stored prompts that can be loaded from ConfigStore prompt records.
+- Define stored-prompt invocation through delegated child execution.
+
+**Non-Goals:**
+
+- Implementing the scheduler feature.
+- Implementing CLI one-shot execution beyond designing compatible stored-prompt invocation semantics.
+- Replacing existing ConfigStore prompt storage.
+- Designing rich prompt-template variables, conditionals, or templating languages.
+- Persisting long-term delegation history outside the existing durable session/audit structures unless required for the initial delegation record.
+- Changing global approval strategy semantics unrelated to delegated execution.
+
+## Decisions
+
+### Treat delegation as a normal tool call plus child approval routing
+
+`delegate_task` should be registered as a normal tool and should follow existing and expected tool approval settings and workflows. The runtime must not hardcode `delegate_task` to always require approval, always skip approval, or otherwise special-case it outside the normal tool approval model.
+
+Once a delegation starts, the frontend/user chooses the child approval routing mode for that child run:
+
+- `AutoApproveChildTools`: child tool calls are allowed without per-call UI prompts for the duration of the delegated run.
+- `PropagateToParent`: child tool approval requests are passed back to the parent/main UI one-by-one and resolved through the regular approval workflow.
+
+This keeps delegation from becoming a hidden privilege escalation path while still allowing intentional high-trust sub-agent runs.
+
+Alternative considered: treating approval of `delegate_task` as approval for all child tool calls. That is simpler but collapses two different decisions: whether to spawn a child and whether to approve each child capability use.
+
+### Hide delegated child sessions by default, not from audit
+
+Delegated child sessions should be created hidden by default so they do not clutter normal session lists. Hidden sessions must still be explicitly inspectable by frontend APIs, and delegation results should include enough identifiers for the frontend to open or audit the child session.
+
+Suggested API shape:
+
+```rust
+pub fn list_child_sessions(parent: SessionId) -> Vec<SessionSummary>;
+pub fn list_hidden_sessions() -> Vec<SessionSummary>;
+pub fn get_delegation_tree(root: SessionId) -> DelegationTree;
+```
+
+The exact names can change during implementation, but hidden must mean "omitted from default listings," not "secret."
+
+### Use existing parent-child session relationships
+
+`IronRuntime::register_child` and `unregister_child` already enforce parent/child existence, same-connection relationships, acyclic relationships, and cancellation/closure propagation. Delegated child runs should reuse this relationship graph where possible.
+
+The existing same-connection restriction may need revisiting if `IronRuntime::new_connection()` creates a separate standalone connection for the child as described in issue #57. The proposal should resolve this tension explicitly: either child sessions share the parent connection for relationship tracking, or relationship registration is generalized to permit delegated child connections while preserving ownership and cancellation invariants.
+
+### Keep profile policy as a hard boundary
+
+Delegated execution should select an `AgentProfile` and use existing profile provider resolution. The selected profile's `ToolFilter` is a hard boundary over the child tool catalog. Configured tool additions must not bypass profile restrictions.
+
+Recommended catalog derivation:
+
+```text
+base = ParentEffective | ChildDefault
+candidate = base union configured_additions
+profile_bounded = apply(selected_profile.tools, candidate)
+final = profile_bounded minus subagent_blocklist
+```
+
+The default policy should use `ParentEffective` as the base catalog with no additions and no extra blocklist.
+
+Alternative considered: letting sub-agent additions bypass profile filters. That gives configuration maximum power but makes profiles less meaningful as identity and safety boundaries.
+
+### Report privilege expansion explicitly
+
+If configured additions make a child tool visible when it was not present in the parent session's effective catalog, that is a privilege expansion. The runtime should surface this in delegation metadata and in any frontend-visible approval context for the delegated run.
+
+Suggested metadata:
+
+```text
+inherited_tools
+removed_tools
+added_tools
+unavailable_requested_tools
+tool_catalog_digest
+```
+
+The exact digest algorithm can be an implementation detail, but it should be deterministic over the final model-visible tool definitions and approval flags.
+
+### Keep tool visibility separate from approval
+
+Tool policy decides which tools a child can see and call. Approval routing decides whether a visible child call is allowed immediately or must ask the parent/main UI. A tool may be visible and still require approval. A configured addition may be visible and still require propagated per-call approval.
+
+This separation avoids encoding approval semantics into catalog construction and keeps `SessionToolCatalog::requires_approval` useful for both parent and child runs.
+
+### Define a delegation record for audit and cleanup
+
+Delegated runs should produce a record tying parent approval, child execution, and result together. At minimum, the runtime should know:
+
+- parent session ID;
+- parent tool call ID;
+- delegation ID;
+- child session ID;
+- selected profile ID or default-profile marker;
+- child approval routing mode;
+- max iterations or budget;
+- final child outcome;
+- child tool catalog digest;
+- goal/context digests where available.
+
+This record may initially be in-memory plus represented in durable session history through tool records and child session transcripts. If richer persistence is needed, that should be called out during implementation rather than added implicitly.
+
+### Keep delegate_task result compact
+
+The exact structured `delegate_task` result payload is not fully settled. The result should be small enough for model context but include identifiers needed for audit and UI linking.
+
+Likely fields:
+
+```json
+{
+  "delegation_id": "...",
+  "child_session_id": "...",
+  "outcome": "end_turn",
+  "final_text": "..."
+}
+```
+
+Richer audit details should be available through runtime/frontend APIs rather than forcing every detail into the model transcript.
+
+### Define stored prompts as reusable task definitions
+
+Stored prompts should be typed payloads over ConfigStore prompt records. A minimal `StoredPrompt` should include:
+
+```rust
+pub struct StoredPrompt {
+    pub instructions: String,
+    pub skills: Vec<String>,
+    pub profile: Option<AgentProfileId>,
+}
+```
+
+The stored prompt ID can serve as the stable prompt name for this slice. Rename/alias semantics can be deferred.
+
+### Invoke stored prompts through delegation machinery
+
+Stored prompts should not define a separate execution path. Invoking a stored prompt should resolve the prompt, compose its instructions with optional extra context, apply the selected profile and requested skills, and run through the same child-session/delegation machinery used by `delegate_task`.
+
+Invocation surfaces should be layered:
+
+```text
+StoredPrompt registry
+        │
+        ▼
+Prompt invocation engine
+        │
+        ├─ session slash command
+        ├─ run_task tool
+        ├─ scheduled task runner (future)
+        └─ CLI one-shot (future)
+```
+
+Session-bound invocation can inherit the current parent session and approval UI. Scheduler and CLI one-shot invocation need explicit non-interactive or interactive approval behavior, but those surfaces are future work.
+
+## Risks / Trade-offs
+
+- Child approval propagation can be subtle to implement because child prompt execution needs a sink that routes approval requests to the parent/main UI without confusing child and parent tool-call IDs.
+- Parent-effective tool inheritance is safest by default but may surprise users who expect a selected profile to fully define child capabilities. Mitigation: document `ParentEffective` as the default and expose explicit policy choices.
+- Allowing configured additions introduces privilege expansion. Mitigation: keep profile filters as hard boundaries and report expansions explicitly.
+- Hidden child sessions reduce UI clutter but can hide important work if frontend inspection APIs are weak. Mitigation: require explicit child-session listing/tree APIs.
+- Stored prompt execution across session, scheduler, and CLI contexts may diverge. Mitigation: define a shared invocation engine and treat surfaces as adapters.
+- The final `delegate_task` result payload is not settled. Mitigation: keep a compact initial result and expose richer audit details through explicit APIs.

--- a/openspec/changes/archive/2026-06-15-delegated-tasks-and-stored-prompts/proposal.md
+++ b/openspec/changes/archive/2026-06-15-delegated-tasks-and-stored-prompts/proposal.md
@@ -1,0 +1,42 @@
+## Why
+
+AgentIron needs a core sub-agent spawning primitive so a model, frontend, scheduler, or CLI can delegate bounded work to a child agent identity without losing normal approval, cancellation, and audit behavior. GitHub issue #57 describes this as `delegate_task`: a model-callable tool that creates a child session, runs it with an optional profile, and returns the result.
+
+AgentIron also needs named reusable prompt templates that can invoke that same child-session machinery. GitHub issue #62 describes stored prompts and `run_task`, which should allow session-bound slash commands first and later scheduled tasks and one-shot CLI execution.
+
+These issues should be designed together because stored prompts depend on delegated child execution, and the child execution design must define visibility, approval propagation, tool scoping, and audit semantics before higher-level invocation surfaces build on it.
+
+## What Changes
+
+- Add a `delegate_task` tool that can spawn a hidden child session, run a bounded goal/context with an optional profile, and return a structured result.
+- Add runtime APIs for creating standalone child connections/sessions and for exposing hidden delegated sessions to frontend code without showing them in normal session listings by default.
+- Preserve normal tool approval semantics for `delegate_task` itself; it must not be hardcoded to always require approval or always bypass approval.
+- Add delegated child approval routing so child tool calls can either be auto-approved for that child run or propagated back to the parent/main UI one-by-one through the regular approval workflow.
+- Add sub-agent tool policy semantics with a safe default that inherits the parent session's effective tool catalog, applies the selected profile's `ToolFilter` as a hard boundary, and applies configured sub-agent blocklists.
+- Support configured child tool additions while reporting additions that were not present in the parent effective catalog as privilege expansions in delegation metadata and frontend-visible approval context.
+- Reuse existing profile provider resolution, session tool catalogs, child-session relationship tracking, cancellation propagation, and prompt-running infrastructure where possible.
+- Add a typed `StoredPrompt` model over existing ConfigStore prompt records with instructions, skills, and optional profile selection.
+- Add prompt registry/load APIs for registering, unregistering, listing, and loading stored prompts from ConfigStore.
+- Add a `run_task` invocation path for stored prompts that reuses delegated child-session machinery and can be used from session-bound slash commands first, with scheduler and CLI one-shot usage designed as future invocation surfaces.
+- Add tests with mock providers for delegation, child approval propagation, tool policy enforcement, hidden-session visibility APIs, stored-prompt loading, and `run_task` invocation.
+
+## Capabilities
+
+### New Capabilities
+
+- `delegated-task-tool`: Sub-agent delegation primitive for hidden child sessions, child approval routing, tool-scope policy, cancellation propagation, and audit metadata.
+- `stored-prompts`: Typed reusable prompt definitions and invocation semantics layered on delegated child execution.
+
+### Modified Capabilities
+
+- `agent-profiles`: Existing profile `ToolFilter`, `SkillFilter`, provider resolution, and approval policy become execution inputs for delegated child runs.
+- `core-config-store`: Existing opaque prompt records become the durable storage substrate for typed stored prompts without replacing the ConfigStore prompt table.
+
+## Impact
+
+- **Public API**: new delegation, child-session inspection, stored-prompt registration/loading, and stored-prompt invocation APIs.
+- **Runtime orchestration**: child sessions are hidden by default but auditable; cancellation and closure should continue to propagate through existing parent-child relationships.
+- **Approval flow**: child tool calls can be routed back to the parent/main UI instead of silently inheriting broad approval.
+- **Tool policy**: sub-agents get explicit catalog derivation rules, including auditable privilege expansion for configured additions.
+- **Config store integration**: typed stored prompts decode from existing opaque ConfigStore prompt records using schema-versioned payloads.
+- **Future work**: this proposal prepares scheduler execution and CLI one-shot prompt execution without requiring those surfaces in the initial implementation.

--- a/openspec/changes/archive/2026-06-15-delegated-tasks-and-stored-prompts/specs/delegated-task-tool/spec.md
+++ b/openspec/changes/archive/2026-06-15-delegated-tasks-and-stored-prompts/specs/delegated-task-tool/spec.md
@@ -1,0 +1,128 @@
+## ADDED Requirements
+
+### Requirement: Core SHALL provide a delegated task tool
+
+The system SHALL provide a model-callable `delegate_task` tool that starts a bounded child-agent run for a goal, optional context, optional profile, and optional iteration limit.
+
+#### Scenario: Delegate task schema is exposed
+- **WHEN** `delegate_task` is registered as a tool
+- **THEN** its input schema includes required `goal` text
+- **AND** supports optional `context`, optional `profile`, and optional `max_iterations`
+
+#### Scenario: Delegated run returns identifiers
+- **WHEN** a delegated child run completes
+- **THEN** the tool result includes the child session ID
+- **AND** includes a delegation ID or equivalent audit handle
+- **AND** includes the final child outcome
+
+#### Scenario: Invalid delegate arguments are rejected
+- **WHEN** the model calls `delegate_task` without a valid goal or with invalid bounds
+- **THEN** the tool returns an actionable error
+- **AND** no child session is created
+
+### Requirement: Delegated child sessions SHALL be hidden by default and inspectable
+
+The system SHALL create delegated child sessions as hidden from normal session listings by default, while exposing explicit APIs for frontend code to inspect hidden delegated sessions.
+
+#### Scenario: Child session is hidden from default listing
+- **WHEN** `delegate_task` creates a child session
+- **THEN** the child session is hidden from normal session listings by default
+- **AND** the parent session remains visible according to normal session visibility rules
+
+#### Scenario: Frontend can inspect child sessions
+- **WHEN** frontend code requests delegated children for a parent session or hidden delegated sessions
+- **THEN** the system returns the delegated child session metadata needed to inspect or open those sessions
+
+#### Scenario: Hidden does not mean unauditable
+- **WHEN** a delegated child session is hidden from default listings
+- **THEN** the system still retains durable child session history and parent-child relationship metadata needed for audit
+
+### Requirement: Delegation SHALL preserve normal approval workflow semantics
+
+The system SHALL evaluate approval for `delegate_task` itself through the existing tool approval strategy and workflow rather than hardcoding special approval behavior for delegation.
+
+#### Scenario: Delegate task follows configured approval behavior
+- **WHEN** the model proposes a `delegate_task` tool call
+- **THEN** the runtime evaluates whether approval is required using the same approval workflow used for other tools
+- **AND** approval, denial, or cancellation of the `delegate_task` call is recorded like other tool calls
+
+#### Scenario: Denied delegate task does not create child
+- **WHEN** a `delegate_task` tool call is denied before execution
+- **THEN** no child session is created
+- **AND** the parent tool call records the denied outcome
+
+### Requirement: Delegated child approval requests SHALL be routable
+
+The system SHALL support per-delegation child approval routing modes that either auto-approve child tool calls for that child run or propagate child approval requests to the parent/main UI one-by-one.
+
+#### Scenario: Child tool calls are auto-approved for a delegated run
+- **WHEN** a delegated run is configured with child tool auto-approval
+- **AND** the child model calls a visible child tool that would otherwise require approval
+- **THEN** the child tool call proceeds without prompting the user for that individual child call
+- **AND** the child durable history records the tool call outcome
+
+#### Scenario: Child approval request is propagated to parent UI
+- **WHEN** a delegated run is configured to propagate child approvals
+- **AND** the child model calls a visible child tool that requires approval
+- **THEN** the approval request is sent to the parent/main UI approval workflow
+- **AND** the child's tool execution follows the returned allow, deny, or cancel verdict
+
+#### Scenario: Propagated denial is recorded in child history
+- **WHEN** a propagated child approval request is denied
+- **THEN** the child tool call is not executed
+- **AND** the child session records a denied terminal tool outcome
+
+### Requirement: Delegated child sessions SHALL participate in cancellation propagation
+
+The system SHALL register delegated child sessions under their parent session so parent cancellation or closure propagates to active child prompts and descendants.
+
+#### Scenario: Parent cancellation cancels child prompt
+- **WHEN** a parent session with an active delegated child prompt is cancelled or closed
+- **THEN** the child prompt is cancelled
+- **AND** in-flight child tool records are tied off with terminal cancellation outcomes
+
+#### Scenario: Delegation cleanup removes relationship
+- **WHEN** a delegated child run completes or fails
+- **THEN** runtime cleanup unregisters the child relationship when appropriate
+- **AND** does not leave stale parent-child edges
+
+### Requirement: Delegated child tool catalogs SHALL be policy-bounded
+
+The system SHALL derive delegated child tool catalogs from an explicit sub-agent tool policy with the selected profile's `ToolFilter` as a hard boundary.
+
+#### Scenario: Default child catalog inherits parent effective tools
+- **WHEN** a delegated run uses the default sub-agent tool policy
+- **THEN** the child catalog starts from the parent session's effective tool catalog
+- **AND** the selected profile's `ToolFilter` is applied to that catalog
+
+#### Scenario: Blocklist removes inherited tools
+- **WHEN** sub-agent configuration blocklists a tool name
+- **THEN** that tool is absent from the child catalog even if it was present in the parent effective catalog
+
+#### Scenario: Profile filter bounds configured additions
+- **WHEN** sub-agent configuration adds a tool that the selected profile's `ToolFilter` does not allow
+- **THEN** the tool is absent from the child catalog
+- **AND** the system reports that profile policy excluded the requested addition
+
+#### Scenario: Added tools are privilege expansions when absent from parent
+- **WHEN** sub-agent configuration adds a tool not present in the parent session's effective catalog
+- **THEN** the delegation metadata reports the added tool as a privilege expansion
+- **AND** the frontend-visible approval context can show the expansion before or during delegated execution
+
+#### Scenario: Final child catalog has deterministic digest
+- **WHEN** a delegated child catalog is built
+- **THEN** the system computes a deterministic digest over the final model-visible tool definitions and approval flags
+- **AND** the digest is available in delegation metadata
+
+### Requirement: Delegated runs SHALL use selected profile provider resolution
+
+The system SHALL resolve the selected child profile through existing profile provider resolution before running the child prompt.
+
+#### Scenario: Delegated run uses default profile when unspecified
+- **WHEN** `delegate_task` does not specify a profile
+- **THEN** the delegated child run uses the built-in default profile
+
+#### Scenario: Delegated run uses selected managed profile
+- **WHEN** `delegate_task` specifies a managed profile
+- **THEN** the runtime resolves the managed provider through the existing profile provider resolution path
+- **AND** provider resolution errors are returned as child run failures without exposing credential secrets

--- a/openspec/changes/archive/2026-06-15-delegated-tasks-and-stored-prompts/specs/stored-prompts/spec.md
+++ b/openspec/changes/archive/2026-06-15-delegated-tasks-and-stored-prompts/specs/stored-prompts/spec.md
@@ -1,0 +1,86 @@
+## ADDED Requirements
+
+### Requirement: Core SHALL define typed stored prompts
+
+The system SHALL define a typed `StoredPrompt` payload for reusable prompt tasks stored in ConfigStore prompt records.
+
+#### Scenario: Stored prompt captures reusable task instructions
+- **WHEN** a caller constructs a `StoredPrompt`
+- **THEN** the prompt includes `instructions` text
+- **AND** includes a list of requested `skills`
+- **AND** may include an optional profile ID
+
+#### Scenario: Stored prompt omits credential material
+- **WHEN** a stored prompt selects a profile
+- **THEN** it references the profile by ID
+- **AND** does not store provider API keys or credential secret material
+
+### Requirement: Core SHALL register and list stored prompts
+
+The system SHALL provide APIs to register, unregister, retrieve, and list stored prompts by stable prompt name or ID for the lifetime of the runtime or agent instance.
+
+#### Scenario: Stored prompt is registered
+- **WHEN** a caller registers a stored prompt with a valid name or ID
+- **THEN** the prompt can be retrieved by that name or ID
+- **AND** list operations include it with deterministic ordering
+
+#### Scenario: Stored prompt is replaced
+- **WHEN** a caller registers a stored prompt using an existing name or ID
+- **THEN** the new prompt replaces the previous prompt if validation succeeds
+
+#### Scenario: Stored prompt is unregistered
+- **WHEN** a caller unregisters a stored prompt by name or ID
+- **THEN** later retrieval by that name or ID reports that no prompt is registered
+
+### Requirement: Core SHALL load typed stored prompts from ConfigStore
+
+The system SHALL load typed stored prompts from existing ConfigStore prompt records by decoding supported schema-versioned payloads and reporting per-prompt diagnostics for invalid records.
+
+#### Scenario: Stored prompt loads successfully
+- **WHEN** ConfigStore contains a prompt record with a supported stored-prompt schema version and valid payload
+- **THEN** the system registers the decoded stored prompt under the prompt record ID
+
+#### Scenario: Invalid stored prompt is skipped
+- **WHEN** ConfigStore contains an invalid stored-prompt payload
+- **THEN** loading skips that prompt
+- **AND** returns a diagnostic for the invalid prompt record
+- **AND** continues loading other valid prompt records
+
+#### Scenario: Unsupported stored prompt schema is skipped
+- **WHEN** ConfigStore contains a prompt record with an unsupported schema version
+- **THEN** loading skips that prompt
+- **AND** reports an unsupported-schema diagnostic for that prompt record
+
+### Requirement: Stored prompt invocation SHALL use delegated execution machinery
+
+The system SHALL invoke stored prompts through the same delegated child-session machinery used by delegated task execution rather than creating a separate prompt execution path.
+
+#### Scenario: Stored prompt is invoked within a session
+- **WHEN** a session-bound caller invokes a stored prompt by name with optional extra context
+- **THEN** the system composes the stored instructions and extra context into a delegated child run
+- **AND** uses the stored prompt's profile when present or the default profile when absent
+
+#### Scenario: Stored prompt skills respect profile boundary
+- **WHEN** a stored prompt requests skills
+- **AND** the selected profile's `SkillFilter` excludes one or more requested skills
+- **THEN** excluded skills are not activated for the child run
+- **AND** the invocation reports diagnostics for excluded requested skills
+
+#### Scenario: Stored prompt result includes child session reference
+- **WHEN** a stored prompt invocation completes
+- **THEN** the invocation result includes the delegated child session ID
+- **AND** includes the final child outcome
+
+### Requirement: Stored prompt invocation SHALL support multiple invocation surfaces
+
+The system SHALL define stored prompt invocation so it can be used by session-bound slash commands initially and by scheduled tasks or CLI one-shot execution in future changes.
+
+#### Scenario: Session slash command can invoke stored prompt
+- **WHEN** frontend code handles a session slash command that references a stored prompt
+- **THEN** it can call the stored-prompt invocation API with the current parent session
+- **AND** child approvals can use the parent/main UI approval workflow
+
+#### Scenario: Future non-session invocation remains compatible
+- **WHEN** a future scheduler or CLI one-shot surface invokes a stored prompt without an interactive parent session
+- **THEN** it can reuse the same stored-prompt registry and invocation model
+- **AND** must supply or derive explicit approval behavior for non-interactive execution

--- a/openspec/changes/archive/2026-06-15-delegated-tasks-and-stored-prompts/tasks.md
+++ b/openspec/changes/archive/2026-06-15-delegated-tasks-and-stored-prompts/tasks.md
@@ -1,0 +1,63 @@
+## 1. Delegated Task Domain and API
+
+- [x] 1.1 Define public/internal delegation input types for `goal`, optional `context`, optional `profile`, `max_iterations`, child approval routing mode, and child tool policy.
+- [x] 1.2 Define delegation result and audit metadata types with delegation ID, parent session ID, parent tool call ID, child session ID, selected profile, approval routing mode, final outcome, and tool catalog digest.
+- [x] 1.3 Add child-session inspection APIs for hidden sessions, child sessions, or delegation trees so frontend code can inspect delegated work explicitly.
+- [x] 1.4 Add or expose `IronRuntime::new_connection()` or an equivalent child-session connection creation API while preserving session ownership and cancellation invariants.
+- [x] 1.5 Resolve whether delegated child sessions share the parent connection or whether parent-child registration can span child connections safely.
+
+## 2. Child Session Construction
+
+- [x] 2.1 Create delegated child sessions hidden by default.
+- [x] 2.2 Register child sessions under the parent session and ensure cleanup unregisters relationships on completion/failure.
+- [x] 2.3 Ensure parent cancellation or closure cancels active child prompts and leaves terminal durable records.
+- [x] 2.4 Apply selected profile identity prompt, provider resolution, and max-iteration bounds to child runs.
+- [x] 2.5 Return enough child identifiers in results for frontend audit and session opening.
+
+## 3. Child Tool Policy
+
+- [x] 3.1 Implement default child tool policy as parent effective catalog inheritance with the selected profile `ToolFilter` as a hard boundary.
+- [x] 3.2 Add configured sub-agent blocklist support applied after profile filtering.
+- [x] 3.3 Add configured child tool additions from the child/default runtime catalog without bypassing profile filters.
+- [x] 3.4 Report additions not present in the parent effective catalog as privilege expansions in delegation metadata.
+- [x] 3.5 Add deterministic final tool catalog digesting based on model-visible tool definitions and approval flags.
+- [x] 3.6 Add diagnostics for requested additions that are unavailable because the tool is missing, plugin/MCP state disables it, auth is missing, or profile policy excludes it.
+
+## 4. Approval Routing
+
+- [x] 4.1 Ensure `delegate_task` itself follows normal tool approval settings and workflows without hardcoded approval special-casing.
+- [x] 4.2 Add child approval routing mode for auto-approving child tool calls for a delegated run.
+- [x] 4.3 Add child approval routing mode for propagating each child tool approval request to the parent/main UI.
+- [x] 4.4 Preserve child tool-call durable records when child approvals are allowed, denied, or cancelled through propagated approval.
+- [x] 4.5 Add tests showing a propagated child approval request can be allowed, denied, and cancelled through the parent/main approval flow.
+
+## 5. Delegate Task Tool
+
+- [x] 5.1 Implement `DelegateTask` as a `Tool` with JSON schema for `goal`, optional `context`, optional `profile`, and optional `max_iterations`.
+- [x] 5.2 Register `delegate_task` through `IronRuntime::register_delegate_task_tool()` or equivalent public registration API.
+- [x] 5.3 Parse and validate tool arguments with actionable errors for missing goal, unknown profile, invalid max iterations, and invalid child policy inputs.
+- [x] 5.4 Run the child prompt through the selected profile/provider path and delegated approval sink.
+- [x] 5.5 Return a compact structured JSON result with delegation ID, child session ID, outcome, and final model-readable result text.
+
+## 6. Stored Prompt Domain and Registry
+
+- [x] 6.1 Define `StoredPrompt` with `instructions: String`, `skills: Vec<String>`, and `profile: Option<AgentProfileId>` using schema version 1.
+- [x] 6.2 Add runtime or agent APIs to register, unregister, list, and retrieve stored prompts by stable prompt name/ID.
+- [x] 6.3 Implement `load_prompts(store: &ConfigStore)` by decoding typed ConfigStore prompt records with per-prompt diagnostics for invalid payloads or unsupported schema versions.
+- [x] 6.4 Validate stored prompt names/IDs and prompt payloads without changing ConfigStore's opaque prompt record contract.
+- [x] 6.5 Add tests for prompt registration, replacement, unregister, list ordering, ConfigStore loading, invalid payload diagnostics, and unsupported schema diagnostics.
+
+## 7. Stored Prompt Invocation
+
+- [x] 7.1 Add a shared stored-prompt invocation path that composes stored instructions, optional extra context, selected profile, requested skills, and delegated child execution.
+- [x] 7.2 Add `RunTask` or equivalent invocation tool for model-callable stored-prompt execution where appropriate.
+- [x] 7.3 Ensure session-bound invocation can be used by frontend slash-command handling without requiring scheduler or CLI implementation in this change.
+- [x] 7.4 Ensure requested stored-prompt skills cannot exceed the selected profile's `SkillFilter` boundary.
+- [x] 7.5 Add tests for invoking a stored prompt within a session with mock providers and delegated child execution.
+
+## 8. Verification
+
+- [x] 8.1 Add unit tests for child tool policy inheritance, blocklists, profile-filter boundaries, additions, and privilege-expansion reporting.
+- [x] 8.2 Add integration tests for hidden child sessions, child-session inspection APIs, cancellation propagation, and delegated approval propagation.
+- [x] 8.3 Add mock-provider tests for `delegate_task` and stored-prompt invocation outcomes.
+- [x] 8.4 Run the narrowest relevant Rust checks and tests for runtime, profile, stored prompt, and prompt runner changes.

--- a/openspec/specs/delegated-task-tool/spec.md
+++ b/openspec/specs/delegated-task-tool/spec.md
@@ -1,0 +1,132 @@
+# delegated-task-tool Specification
+
+## Purpose
+Define delegated child-agent execution through the `delegate_task` tool, including hidden child sessions, approval routing, cancellation propagation, child tool policy boundaries, and profile-backed provider resolution.
+
+## Requirements
+### Requirement: Core SHALL provide a delegated task tool
+
+The system SHALL provide a model-callable `delegate_task` tool that starts a bounded child-agent run for a goal, optional context, optional profile, and optional iteration limit.
+
+#### Scenario: Delegate task schema is exposed
+- **WHEN** `delegate_task` is registered as a tool
+- **THEN** its input schema includes required `goal` text
+- **AND** supports optional `context`, optional `profile`, and optional `max_iterations`
+
+#### Scenario: Delegated run returns identifiers
+- **WHEN** a delegated child run completes
+- **THEN** the tool result includes the child session ID
+- **AND** includes a delegation ID or equivalent audit handle
+- **AND** includes the final child outcome
+
+#### Scenario: Invalid delegate arguments are rejected
+- **WHEN** the model calls `delegate_task` without a valid goal or with invalid bounds
+- **THEN** the tool returns an actionable error
+- **AND** no child session is created
+
+### Requirement: Delegated child sessions SHALL be hidden by default and inspectable
+
+The system SHALL create delegated child sessions as hidden from normal session listings by default, while exposing explicit APIs for frontend code to inspect hidden delegated sessions.
+
+#### Scenario: Child session is hidden from default listing
+- **WHEN** `delegate_task` creates a child session
+- **THEN** the child session is hidden from normal session listings by default
+- **AND** the parent session remains visible according to normal session visibility rules
+
+#### Scenario: Frontend can inspect child sessions
+- **WHEN** frontend code requests delegated children for a parent session or hidden delegated sessions
+- **THEN** the system returns the delegated child session metadata needed to inspect or open those sessions
+
+#### Scenario: Hidden does not mean unauditable
+- **WHEN** a delegated child session is hidden from default listings
+- **THEN** the system still retains durable child session history and parent-child relationship metadata needed for audit
+
+### Requirement: Delegation SHALL preserve normal approval workflow semantics
+
+The system SHALL evaluate approval for `delegate_task` itself through the existing tool approval strategy and workflow rather than hardcoding special approval behavior for delegation.
+
+#### Scenario: Delegate task follows configured approval behavior
+- **WHEN** the model proposes a `delegate_task` tool call
+- **THEN** the runtime evaluates whether approval is required using the same approval workflow used for other tools
+- **AND** approval, denial, or cancellation of the `delegate_task` call is recorded like other tool calls
+
+#### Scenario: Denied delegate task does not create child
+- **WHEN** a `delegate_task` tool call is denied before execution
+- **THEN** no child session is created
+- **AND** the parent tool call records the denied outcome
+
+### Requirement: Delegated child approval requests SHALL be routable
+
+The system SHALL support per-delegation child approval routing modes that either auto-approve child tool calls for that child run or propagate child approval requests to the parent/main UI one-by-one.
+
+#### Scenario: Child tool calls are auto-approved for a delegated run
+- **WHEN** a delegated run is configured with child tool auto-approval
+- **AND** the child model calls a visible child tool that would otherwise require approval
+- **THEN** the child tool call proceeds without prompting the user for that individual child call
+- **AND** the child durable history records the tool call outcome
+
+#### Scenario: Child approval request is propagated to parent UI
+- **WHEN** a delegated run is configured to propagate child approvals
+- **AND** the child model calls a visible child tool that requires approval
+- **THEN** the approval request is sent to the parent/main UI approval workflow
+- **AND** the child's tool execution follows the returned allow, deny, or cancel verdict
+
+#### Scenario: Propagated denial is recorded in child history
+- **WHEN** a propagated child approval request is denied
+- **THEN** the child tool call is not executed
+- **AND** the child session records a denied terminal tool outcome
+
+### Requirement: Delegated child sessions SHALL participate in cancellation propagation
+
+The system SHALL register delegated child sessions under their parent session so parent cancellation or closure propagates to active child prompts and descendants.
+
+#### Scenario: Parent cancellation cancels child prompt
+- **WHEN** a parent session with an active delegated child prompt is cancelled or closed
+- **THEN** the child prompt is cancelled
+- **AND** in-flight child tool records are tied off with terminal cancellation outcomes
+
+#### Scenario: Delegation cleanup removes relationship
+- **WHEN** a delegated child run completes or fails
+- **THEN** runtime cleanup unregisters the child relationship when appropriate
+- **AND** does not leave stale parent-child edges
+
+### Requirement: Delegated child tool catalogs SHALL be policy-bounded
+
+The system SHALL derive delegated child tool catalogs from an explicit sub-agent tool policy with the selected profile's `ToolFilter` as a hard boundary.
+
+#### Scenario: Default child catalog inherits parent effective tools
+- **WHEN** a delegated run uses the default sub-agent tool policy
+- **THEN** the child catalog starts from the parent session's effective tool catalog
+- **AND** the selected profile's `ToolFilter` is applied to that catalog
+
+#### Scenario: Blocklist removes inherited tools
+- **WHEN** sub-agent configuration blocklists a tool name
+- **THEN** that tool is absent from the child catalog even if it was present in the parent effective catalog
+
+#### Scenario: Profile filter bounds configured additions
+- **WHEN** sub-agent configuration adds a tool that the selected profile's `ToolFilter` does not allow
+- **THEN** the tool is absent from the child catalog
+- **AND** the system reports that profile policy excluded the requested addition
+
+#### Scenario: Added tools are privilege expansions when absent from parent
+- **WHEN** sub-agent configuration adds a tool not present in the parent session's effective catalog
+- **THEN** the delegation metadata reports the added tool as a privilege expansion
+- **AND** the frontend-visible approval context can show the expansion before or during delegated execution
+
+#### Scenario: Final child catalog has deterministic digest
+- **WHEN** a delegated child catalog is built
+- **THEN** the system computes a deterministic digest over the final model-visible tool definitions and approval flags
+- **AND** the digest is available in delegation metadata
+
+### Requirement: Delegated runs SHALL use selected profile provider resolution
+
+The system SHALL resolve the selected child profile through existing profile provider resolution before running the child prompt.
+
+#### Scenario: Delegated run uses default profile when unspecified
+- **WHEN** `delegate_task` does not specify a profile
+- **THEN** the delegated child run uses the built-in default profile
+
+#### Scenario: Delegated run uses selected managed profile
+- **WHEN** `delegate_task` specifies a managed profile
+- **THEN** the runtime resolves the managed provider through the existing profile provider resolution path
+- **AND** provider resolution errors are returned as child run failures without exposing credential secrets

--- a/openspec/specs/stored-prompts/spec.md
+++ b/openspec/specs/stored-prompts/spec.md
@@ -1,0 +1,90 @@
+# stored-prompts Specification
+
+## Purpose
+Define typed reusable stored prompts and session-bound invocation through delegated child execution.
+
+## Requirements
+### Requirement: Core SHALL define typed stored prompts
+
+The system SHALL define a typed `StoredPrompt` payload for reusable prompt tasks stored in ConfigStore prompt records.
+
+#### Scenario: Stored prompt captures reusable task instructions
+- **WHEN** a caller constructs a `StoredPrompt`
+- **THEN** the prompt includes `instructions` text
+- **AND** includes a list of requested `skills`
+- **AND** may include an optional profile ID
+
+#### Scenario: Stored prompt omits credential material
+- **WHEN** a stored prompt selects a profile
+- **THEN** it references the profile by ID
+- **AND** does not store provider API keys or credential secret material
+
+### Requirement: Core SHALL register and list stored prompts
+
+The system SHALL provide APIs to register, unregister, retrieve, and list stored prompts by stable prompt name or ID for the lifetime of the runtime or agent instance.
+
+#### Scenario: Stored prompt is registered
+- **WHEN** a caller registers a stored prompt with a valid name or ID
+- **THEN** the prompt can be retrieved by that name or ID
+- **AND** list operations include it with deterministic ordering
+
+#### Scenario: Stored prompt is replaced
+- **WHEN** a caller registers a stored prompt using an existing name or ID
+- **THEN** the new prompt replaces the previous prompt if validation succeeds
+
+#### Scenario: Stored prompt is unregistered
+- **WHEN** a caller unregisters a stored prompt by name or ID
+- **THEN** later retrieval by that name or ID reports that no prompt is registered
+
+### Requirement: Core SHALL load typed stored prompts from ConfigStore
+
+The system SHALL load typed stored prompts from existing ConfigStore prompt records by decoding supported schema-versioned payloads and reporting per-prompt diagnostics for invalid records.
+
+#### Scenario: Stored prompt loads successfully
+- **WHEN** ConfigStore contains a prompt record with a supported stored-prompt schema version and valid payload
+- **THEN** the system registers the decoded stored prompt under the prompt record ID
+
+#### Scenario: Invalid stored prompt is skipped
+- **WHEN** ConfigStore contains an invalid stored-prompt payload
+- **THEN** loading skips that prompt
+- **AND** returns a diagnostic for the invalid prompt record
+- **AND** continues loading other valid prompt records
+
+#### Scenario: Unsupported stored prompt schema is skipped
+- **WHEN** ConfigStore contains a prompt record with an unsupported schema version
+- **THEN** loading skips that prompt
+- **AND** reports an unsupported-schema diagnostic for that prompt record
+
+### Requirement: Stored prompt invocation SHALL use delegated execution machinery
+
+The system SHALL invoke stored prompts through the same delegated child-session machinery used by delegated task execution rather than creating a separate prompt execution path.
+
+#### Scenario: Stored prompt is invoked within a session
+- **WHEN** a session-bound caller invokes a stored prompt by name with optional extra context
+- **THEN** the system composes the stored instructions and extra context into a delegated child run
+- **AND** uses the stored prompt's profile when present or the default profile when absent
+
+#### Scenario: Stored prompt skills respect profile boundary
+- **WHEN** a stored prompt requests skills
+- **AND** the selected profile's `SkillFilter` excludes one or more requested skills
+- **THEN** excluded skills are not activated for the child run
+- **AND** the invocation reports diagnostics for excluded requested skills
+
+#### Scenario: Stored prompt result includes child session reference
+- **WHEN** a stored prompt invocation completes
+- **THEN** the invocation result includes the delegated child session ID
+- **AND** includes the final child outcome
+
+### Requirement: Stored prompt invocation SHALL support multiple invocation surfaces
+
+The system SHALL define stored prompt invocation so it can be used by session-bound slash commands initially and by scheduled tasks or CLI one-shot execution in future changes.
+
+#### Scenario: Session slash command can invoke stored prompt
+- **WHEN** frontend code handles a session slash command that references a stored prompt
+- **THEN** it can call the stored-prompt invocation API with the current parent session
+- **AND** child approvals can use the parent/main UI approval workflow
+
+#### Scenario: Future non-session invocation remains compatible
+- **WHEN** a future scheduler or CLI one-shot surface invokes a stored prompt without an interactive parent session
+- **THEN** it can reuse the same stored-prompt registry and invocation model
+- **AND** must supply or derive explicit approval behavior for non-interactive execution

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -113,8 +113,6 @@ pub struct IronConnection {
     profile_registry: Arc<RwLock<ProfileRegistry>>,
 }
 
-static CONNECTION_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
-
 impl IronConnection {
     pub fn new(runtime: IronRuntime) -> Self {
         Self::new_with_profile_registry(
@@ -127,7 +125,7 @@ impl IronConnection {
         runtime: IronRuntime,
         profile_registry: Arc<RwLock<ProfileRegistry>>,
     ) -> Self {
-        let id = ConnectionId(CONNECTION_COUNTER.fetch_add(1, std::sync::atomic::Ordering::SeqCst));
+        let id = crate::runtime::next_connection_id();
         runtime.register_connection(id);
         Self {
             id,
@@ -318,6 +316,7 @@ impl IronConnection {
         let selected_profile = self.selected_profile(session_profile_id)?;
         {
             let mut session = durable.lock();
+            session.profile_id = session_profile_id.cloned();
             if session.instructions.is_none() {
                 session.set_instructions(selected_profile.effective_identity_prompt());
             }
@@ -489,6 +488,7 @@ impl IronConnection {
         let selected_profile = self.selected_profile(session_profile_id)?;
         {
             let mut session = durable.lock();
+            session.profile_id = session_profile_id.cloned();
             if session.instructions.is_none() {
                 session.set_instructions(selected_profile.effective_identity_prompt());
             }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -316,7 +316,9 @@ impl IronConnection {
         let selected_profile = self.selected_profile(session_profile_id)?;
         {
             let mut session = durable.lock();
-            session.profile_id = session_profile_id.cloned();
+            if let Some(profile_id) = session_profile_id {
+                session.profile_id = Some(profile_id.clone());
+            }
             if session.instructions.is_none() {
                 session.set_instructions(selected_profile.effective_identity_prompt());
             }
@@ -488,7 +490,9 @@ impl IronConnection {
         let selected_profile = self.selected_profile(session_profile_id)?;
         {
             let mut session = durable.lock();
-            session.profile_id = session_profile_id.cloned();
+            if let Some(profile_id) = session_profile_id {
+                session.profile_id = Some(profile_id.clone());
+            }
             if session.instructions.is_none() {
                 session.set_instructions(selected_profile.effective_identity_prompt());
             }

--- a/src/delegation/mod.rs
+++ b/src/delegation/mod.rs
@@ -1,0 +1,402 @@
+//! Delegated child-agent execution types and helpers.
+//!
+//! This module defines the input, policy, result, and audit metadata types for
+//! `delegate_task` and for stored-prompt invocation, which both reuse the same
+//! child-session machinery.
+
+pub mod runtime;
+pub mod sink;
+
+use crate::durable::SessionId;
+use crate::profile::{AgentProfileId, SkillFilter, ToolFilter};
+use crate::tool::ToolDefinition;
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+
+/// Schema version for typed delegation payloads stored externally.
+pub const DELEGATION_SCHEMA_VERSION: i64 = 1;
+
+/// How child tool approval requests are handled during a delegated run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub enum ChildApprovalMode {
+    /// Propagate each child approval request to the parent/main UI workflow.
+    #[default]
+    PropagateToParent,
+    /// Auto-approve all visible child tool calls for this delegated run.
+    AutoApprove,
+}
+
+/// Base catalog used when deriving a child tool set.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub enum SubAgentToolBase {
+    /// Inherit the parent session's effective tool catalog.
+    #[default]
+    ParentEffective,
+    /// Build from a fresh child session's runtime-default catalog.
+    ChildDefault,
+}
+
+/// Configurable tool policy for a delegated child run.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct SubAgentToolPolicy {
+    /// Which catalog to start from.
+    #[serde(default)]
+    pub base: SubAgentToolBase,
+    /// Tool names to remove from the candidate catalog after profile filtering.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub deny: Vec<String>,
+    /// Tool names to add from the runtime/default catalog.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub additions: Vec<String>,
+}
+
+impl SubAgentToolPolicy {
+    /// Default safe policy: inherit parent effective tools, apply profile filter.
+    pub fn inherit_parent() -> Self {
+        Self {
+            base: SubAgentToolBase::ParentEffective,
+            deny: Vec::new(),
+            additions: Vec::new(),
+        }
+    }
+}
+
+/// Input for starting a delegated child run.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DelegationRequest {
+    /// The high-level goal passed to the child agent.
+    pub goal: String,
+    /// Optional extra context for the child run.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context: Option<String>,
+    /// Optional profile to use for the child run.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub profile_id: Option<AgentProfileId>,
+    /// Requested skills to activate in the child run after profile filtering.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub requested_skills: Vec<String>,
+    /// Maximum inference/tool iterations for the child run.
+    #[serde(default = "default_max_iterations")]
+    pub max_iterations: u32,
+    /// How child tool approval requests are handled.
+    #[serde(default)]
+    pub child_approval_mode: ChildApprovalMode,
+    /// Tool policy for the child run.
+    #[serde(default)]
+    pub tool_policy: SubAgentToolPolicy,
+}
+
+fn default_max_iterations() -> u32 {
+    10
+}
+
+impl DelegationRequest {
+    /// Validate request invariants.
+    pub fn validate(&self) -> Result<(), String> {
+        let goal = self.goal.trim();
+        if goal.is_empty() {
+            return Err("delegation goal is required".to_string());
+        }
+        if self.max_iterations == 0 {
+            return Err("max_iterations must be greater than zero".to_string());
+        }
+        Ok(())
+    }
+}
+
+/// Outcome of a delegated child run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum DelegationOutcome {
+    EndTurn,
+    Cancelled,
+    MaxTurnRequests,
+}
+
+impl From<agent_client_protocol::schema::StopReason> for DelegationOutcome {
+    fn from(reason: agent_client_protocol::schema::StopReason) -> Self {
+        match reason {
+            agent_client_protocol::schema::StopReason::EndTurn => DelegationOutcome::EndTurn,
+            agent_client_protocol::schema::StopReason::Cancelled => DelegationOutcome::Cancelled,
+            agent_client_protocol::schema::StopReason::MaxTurnRequests => {
+                DelegationOutcome::MaxTurnRequests
+            }
+            _ => DelegationOutcome::EndTurn,
+        }
+    }
+}
+
+/// Result returned to the caller/model from a delegated run.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DelegationResult {
+    /// Stable delegation ID for audit.
+    pub delegation_id: String,
+    /// Child session ID.
+    pub child_session_id: SessionId,
+    /// Final outcome of the child run.
+    pub outcome: DelegationOutcome,
+    /// Final model-readable result text, if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub final_text: Option<String>,
+}
+
+/// Audit/diagnostic metadata for a delegated run.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DelegationMetadata {
+    pub delegation_id: String,
+    pub parent_session_id: SessionId,
+    pub parent_tool_call_id: Option<String>,
+    pub child_session_id: SessionId,
+    pub profile_id: Option<AgentProfileId>,
+    pub child_approval_mode: ChildApprovalMode,
+    pub max_iterations: u32,
+    pub outcome: Option<DelegationOutcome>,
+    pub tool_catalog_digest: String,
+    pub inherited_tools: Vec<String>,
+    pub removed_tools: Vec<String>,
+    pub added_tools: Vec<String>,
+    pub unavailable_requested_additions: Vec<String>,
+    pub excluded_by_profile: Vec<String>,
+    pub tool_policy_diagnostics: Vec<ToolPolicyDiagnostic>,
+    pub requested_skills: Vec<String>,
+    pub activated_skills: Vec<String>,
+    pub excluded_skills_by_profile: Vec<String>,
+    pub unavailable_requested_skills: Vec<String>,
+}
+
+/// Reason a requested child tool policy change could not be applied.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "reason")]
+pub enum ToolPolicyDiagnosticReason {
+    /// The requested tool is not known to the runtime/session-effective catalog.
+    Missing,
+    /// The selected profile's `ToolFilter` excluded the requested tool.
+    ExcludedByProfile,
+    /// The MCP server providing this tool is disabled for the session.
+    McpServerNotEnabled {
+        #[serde(rename = "server_id")]
+        server_id: String,
+    },
+    /// The MCP server providing this tool is not healthy.
+    McpServerNotHealthy {
+        #[serde(rename = "server_id")]
+        server_id: String,
+        #[serde(rename = "health")]
+        health: String,
+    },
+    /// The plugin providing this tool is not enabled for the session.
+    PluginNotEnabled {
+        #[serde(rename = "plugin_id")]
+        plugin_id: String,
+    },
+    /// The plugin providing this tool is not installed.
+    PluginNotInstalled {
+        #[serde(rename = "plugin_id")]
+        plugin_id: String,
+    },
+    /// The plugin providing this tool has no loaded manifest.
+    PluginManifestMissing {
+        #[serde(rename = "plugin_id")]
+        plugin_id: String,
+    },
+    /// The plugin providing this tool is not healthy.
+    PluginNotHealthy {
+        #[serde(rename = "plugin_id")]
+        plugin_id: String,
+        #[serde(rename = "health")]
+        health: String,
+    },
+    /// The plugin tool requires authentication that is not satisfied.
+    PluginAuthRequired {
+        #[serde(rename = "plugin_id")]
+        plugin_id: String,
+    },
+    /// The plugin tool requires scopes that are not granted.
+    PluginScopeMissing {
+        #[serde(rename = "plugin_id")]
+        plugin_id: String,
+        #[serde(rename = "required")]
+        required: Vec<String>,
+        #[serde(rename = "missing")]
+        missing: Vec<String>,
+    },
+}
+
+/// Frontend/audit diagnostic for child tool policy derivation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ToolPolicyDiagnostic {
+    pub tool_name: String,
+    pub reason: ToolPolicyDiagnosticReason,
+}
+
+/// Result of deriving a child tool catalog from policy.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DerivedToolCatalog {
+    /// Final model-visible tool definitions.
+    pub definitions: Vec<ToolDefinition>,
+    /// Tools inherited from the parent effective catalog.
+    pub inherited_tools: Vec<String>,
+    /// Tools removed by blocklist.
+    pub removed_tools: Vec<String>,
+    /// Tools added beyond the parent effective catalog.
+    pub added_tools: Vec<String>,
+    /// Requested additions that could not be made available.
+    pub unavailable_requested_additions: Vec<String>,
+    /// Tools excluded by profile filter.
+    pub excluded_by_profile: Vec<String>,
+    /// Structured diagnostics for requested policy changes that were not applied.
+    pub diagnostics: Vec<ToolPolicyDiagnostic>,
+    /// Deterministic digest of the final catalog.
+    pub digest: String,
+}
+
+/// Compute a deterministic digest over tool definitions and approval flags.
+pub fn compute_tool_catalog_digest(definitions: &[ToolDefinition]) -> String {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    let mut hasher = DefaultHasher::new();
+    for def in definitions {
+        def.name.hash(&mut hasher);
+        def.requires_approval.hash(&mut hasher);
+    }
+    format!("{:016x}", hasher.finish())
+}
+
+/// Apply a profile tool filter to a candidate tool list.
+pub fn apply_tool_filter(
+    definitions: &[ToolDefinition],
+    filter: &ToolFilter,
+) -> (Vec<ToolDefinition>, Vec<String>) {
+    let mut allowed = Vec::new();
+    let mut excluded = Vec::new();
+
+    match filter {
+        ToolFilter::Inherit => {
+            allowed = definitions.to_vec();
+        }
+        ToolFilter::Allow(names) => {
+            let set: HashSet<_> = names.iter().cloned().collect();
+            for def in definitions {
+                if set.contains(&def.name) {
+                    allowed.push(def.clone());
+                } else {
+                    excluded.push(def.name.clone());
+                }
+            }
+        }
+        ToolFilter::Deny(names) => {
+            let set: HashSet<_> = names.iter().cloned().collect();
+            for def in definitions {
+                if set.contains(&def.name) {
+                    excluded.push(def.name.clone());
+                } else {
+                    allowed.push(def.clone());
+                }
+            }
+        }
+    }
+
+    (allowed, excluded)
+}
+
+/// Apply a profile skill filter to requested skill names.
+pub fn apply_skill_filter(
+    requested: &[String],
+    filter: &SkillFilter,
+) -> (Vec<String>, Vec<String>) {
+    let mut allowed = Vec::new();
+    let mut excluded = Vec::new();
+
+    match filter {
+        SkillFilter::None => {
+            excluded.extend(requested.iter().cloned());
+        }
+        SkillFilter::Inherit => {
+            allowed.extend(requested.iter().cloned());
+        }
+        SkillFilter::Allow(names) => {
+            let set: HashSet<_> = names.iter().cloned().collect();
+            for skill in requested {
+                if set.contains(skill) {
+                    allowed.push(skill.clone());
+                } else {
+                    excluded.push(skill.clone());
+                }
+            }
+        }
+    }
+
+    (allowed, excluded)
+}
+
+/// Validate a delegation tool call argument payload.
+pub fn validate_delegation_arguments(
+    value: &serde_json::Value,
+) -> Result<DelegationRequest, String> {
+    serde_json::from_value(value.clone()).map_err(|e| format!("invalid delegate_task args: {}", e))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tool::ToolDefinition;
+
+    #[test]
+    fn delegation_request_rejects_empty_goal() {
+        let req = DelegationRequest {
+            goal: "   ".to_string(),
+            context: None,
+            profile_id: None,
+            requested_skills: Vec::new(),
+            max_iterations: 5,
+            child_approval_mode: ChildApprovalMode::AutoApprove,
+            tool_policy: SubAgentToolPolicy::default(),
+        };
+        assert!(req.validate().is_err());
+    }
+
+    #[test]
+    fn delegation_request_rejects_zero_iterations() {
+        let req = DelegationRequest {
+            goal: "do work".to_string(),
+            context: None,
+            profile_id: None,
+            requested_skills: Vec::new(),
+            max_iterations: 0,
+            child_approval_mode: ChildApprovalMode::AutoApprove,
+            tool_policy: SubAgentToolPolicy::default(),
+        };
+        assert!(req.validate().is_err());
+    }
+
+    #[test]
+    fn apply_tool_filter_inherit_passes_through() {
+        let defs = vec![ToolDefinition::new("read", "read", serde_json::json!({}))];
+        let (allowed, excluded) = apply_tool_filter(&defs, &ToolFilter::Inherit);
+        assert_eq!(allowed.len(), 1);
+        assert!(excluded.is_empty());
+    }
+
+    #[test]
+    fn apply_tool_filter_allow_excludes_others() {
+        let defs = vec![
+            ToolDefinition::new("read", "read", serde_json::json!({})),
+            ToolDefinition::new("write", "write", serde_json::json!({})),
+        ];
+        let (allowed, excluded) =
+            apply_tool_filter(&defs, &ToolFilter::Allow(vec!["read".to_string()]));
+        assert_eq!(allowed.len(), 1);
+        assert_eq!(allowed[0].name, "read");
+        assert_eq!(excluded, vec!["write".to_string()]);
+    }
+
+    #[test]
+    fn apply_skill_filter_respects_allow() {
+        let (allowed, excluded) = apply_skill_filter(
+            &["rust".to_string(), "python".to_string()],
+            &SkillFilter::Allow(vec!["rust".to_string()]),
+        );
+        assert_eq!(allowed, vec!["rust".to_string()]);
+        assert_eq!(excluded, vec!["python".to_string()]);
+    }
+}

--- a/src/delegation/mod.rs
+++ b/src/delegation/mod.rs
@@ -70,7 +70,12 @@ pub struct DelegationRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub context: Option<String>,
     /// Optional profile to use for the child run.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "profile",
+        alias = "profile_id",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
     pub profile_id: Option<AgentProfileId>,
     /// Requested skills to activate in the child run after profile filtering.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -110,6 +115,8 @@ pub enum DelegationOutcome {
     EndTurn,
     Cancelled,
     MaxTurnRequests,
+    /// The run stopped for a reason that is not recognized by this core version.
+    Unknown,
 }
 
 impl From<agent_client_protocol::schema::StopReason> for DelegationOutcome {
@@ -120,7 +127,9 @@ impl From<agent_client_protocol::schema::StopReason> for DelegationOutcome {
             agent_client_protocol::schema::StopReason::MaxTurnRequests => {
                 DelegationOutcome::MaxTurnRequests
             }
-            _ => DelegationOutcome::EndTurn,
+            agent_client_protocol::schema::StopReason::MaxTokens
+            | agent_client_protocol::schema::StopReason::Refusal
+            | _ => DelegationOutcome::Unknown,
         }
     }
 }
@@ -255,8 +264,14 @@ pub fn compute_tool_catalog_digest(definitions: &[ToolDefinition]) -> String {
     use std::hash::{Hash, Hasher};
 
     let mut hasher = DefaultHasher::new();
-    for def in definitions {
+    // Canonicalize ordering so the digest is independent of input order.
+    let mut defs: Vec<&ToolDefinition> = definitions.iter().collect();
+    defs.sort_by(|a, b| a.name.cmp(&b.name));
+    for def in defs {
+        // Hash all model-visible fields so schema/description changes are reflected.
         def.name.hash(&mut hasher);
+        def.description.hash(&mut hasher);
+        def.input_schema.to_string().hash(&mut hasher);
         def.requires_approval.hash(&mut hasher);
     }
     format!("{:016x}", hasher.finish())
@@ -333,7 +348,10 @@ pub fn apply_skill_filter(
 pub fn validate_delegation_arguments(
     value: &serde_json::Value,
 ) -> Result<DelegationRequest, String> {
-    serde_json::from_value(value.clone()).map_err(|e| format!("invalid delegate_task args: {}", e))
+    let request: DelegationRequest = serde_json::from_value(value.clone())
+        .map_err(|e| format!("invalid delegate_task args: {}", e))?;
+    request.validate()?;
+    Ok(request)
 }
 
 #[cfg(test)]

--- a/src/delegation/runtime.rs
+++ b/src/delegation/runtime.rs
@@ -123,7 +123,7 @@ impl IronRuntime {
             let diagnostic = parent_catalog
                 .as_ref()
                 .zip(parent_durable.as_ref())
-                .and_then(|(catalog, durable)| catalog.inspect_tool(&*durable.lock(), name));
+                .and_then(|(catalog, durable)| catalog.inspect_tool(&durable.lock(), name));
 
             match diagnostic {
                 Some(diagnostic) if diagnostic.available => {
@@ -190,14 +190,14 @@ impl IronRuntime {
 
         let inherited_tools: Vec<String> = final_names
             .iter()
+            .filter(|n| parent_names.contains(*n))
             .cloned()
-            .filter(|n| parent_names.contains(n))
             .collect();
 
         let added_tools: Vec<String> = final_names
             .iter()
+            .filter(|n| !parent_names.contains(*n))
             .cloned()
-            .filter(|n| !parent_names.contains(n))
             .collect();
 
         let digest = compute_tool_catalog_digest(&final_defs);
@@ -352,7 +352,7 @@ impl IronRuntime {
             session
                 .messages
                 .last()
-                .and_then(|m| Some(m.text_content()))
+                .map(|m| m.text_content())
                 .filter(|t| !t.is_empty())
                 .map(|t| t.to_string())
         };

--- a/src/delegation/runtime.rs
+++ b/src/delegation/runtime.rs
@@ -1,0 +1,393 @@
+//! Runtime extension methods for delegated child execution.
+
+use crate::connection::SharedClientChannel;
+use crate::delegation::sink::DelegationPromptSink;
+use crate::delegation::{
+    apply_skill_filter, apply_tool_filter, compute_tool_catalog_digest, DelegationMetadata,
+    DelegationOutcome, DelegationRequest, DelegationResult, DerivedToolCatalog, SubAgentToolBase,
+    ToolPolicyDiagnostic, ToolPolicyDiagnosticReason,
+};
+use crate::durable::SessionId;
+use crate::profile::AgentProfile;
+use crate::prompt_runner::PromptRunner;
+use crate::runtime::IronRuntime;
+use crate::tool::ToolDefinition;
+use agent_client_protocol::schema as acp;
+use std::collections::{HashMap, HashSet};
+
+use crate::mcp::session_catalog::ToolSource;
+use crate::plugin::effective_tools::UnavailableReason;
+
+/// Map a session-catalog unavailability reason to a delegation policy diagnostic.
+fn map_unavailable_reason(
+    source: &ToolSource,
+    reason: UnavailableReason,
+) -> Option<ToolPolicyDiagnosticReason> {
+    match (source, reason) {
+        (ToolSource::Mcp { server_id }, UnavailableReason::McpServerNotEnabled) => {
+            Some(ToolPolicyDiagnosticReason::McpServerNotEnabled {
+                server_id: server_id.clone(),
+            })
+        }
+        (ToolSource::Mcp { server_id }, UnavailableReason::McpServerNotHealthy(health)) => {
+            Some(ToolPolicyDiagnosticReason::McpServerNotHealthy {
+                server_id: server_id.clone(),
+                health: format!("{:?}", health),
+            })
+        }
+        (ToolSource::Plugin { plugin_id }, UnavailableReason::PluginNotEnabled) => {
+            Some(ToolPolicyDiagnosticReason::PluginNotEnabled {
+                plugin_id: plugin_id.clone(),
+            })
+        }
+        (ToolSource::Plugin { plugin_id }, UnavailableReason::PluginNotInstalled) => {
+            Some(ToolPolicyDiagnosticReason::PluginNotInstalled {
+                plugin_id: plugin_id.clone(),
+            })
+        }
+        (ToolSource::Plugin { plugin_id }, UnavailableReason::ManifestMissing) => {
+            Some(ToolPolicyDiagnosticReason::PluginManifestMissing {
+                plugin_id: plugin_id.clone(),
+            })
+        }
+        (ToolSource::Plugin { plugin_id }, UnavailableReason::PluginNotHealthy(health)) => {
+            Some(ToolPolicyDiagnosticReason::PluginNotHealthy {
+                plugin_id: plugin_id.clone(),
+                health: format!("{:?}", health),
+            })
+        }
+        (ToolSource::Plugin { plugin_id }, UnavailableReason::AuthRequired) => {
+            Some(ToolPolicyDiagnosticReason::PluginAuthRequired {
+                plugin_id: plugin_id.clone(),
+            })
+        }
+        (
+            ToolSource::Plugin { plugin_id },
+            UnavailableReason::ScopeMissing { required, missing },
+        ) => Some(ToolPolicyDiagnosticReason::PluginScopeMissing {
+            plugin_id: plugin_id.clone(),
+            required,
+            missing,
+        }),
+        _ => None,
+    }
+}
+
+impl IronRuntime {
+    /// Derive a child tool catalog from policy, profile filter, and runtime state.
+    pub fn derive_child_tool_catalog(
+        &self,
+        parent_session_id: SessionId,
+        profile: &AgentProfile,
+        policy: &crate::delegation::SubAgentToolPolicy,
+    ) -> Result<DerivedToolCatalog, String> {
+        let parent_defs = self.get_effective_tool_definitions(parent_session_id);
+        let parent_names: HashSet<String> = parent_defs.iter().map(|d| d.name.clone()).collect();
+
+        let base_defs = match policy.base {
+            SubAgentToolBase::ParentEffective => parent_defs.clone(),
+            SubAgentToolBase::ChildDefault => {
+                // Build from a fresh hidden session's default catalog.
+                let conn_id = self.new_connection();
+                let (session_id, _) = self
+                    .create_hidden_session(conn_id)
+                    .map_err(|e| format!("failed to create child-default session: {}", e))?;
+                let defs = self.get_effective_tool_definitions(session_id);
+                self.close_session(session_id);
+                self.close_connection(conn_id);
+                defs
+            }
+        };
+
+        // Apply additions from runtime tool registry or parent session diagnostics.
+        let mut candidate_defs: HashMap<String, ToolDefinition> =
+            base_defs.into_iter().map(|d| (d.name.clone(), d)).collect();
+
+        let mut unavailable_requested_additions = Vec::new();
+        let mut diagnostics: Vec<ToolPolicyDiagnostic> = Vec::new();
+        let runtime_defs = self.tool_registry().definitions();
+        let runtime_map: HashMap<String, ToolDefinition> = runtime_defs
+            .into_iter()
+            .map(|d| (d.name.clone(), d))
+            .collect();
+
+        let parent_catalog = self.get_session_tool_catalog(parent_session_id);
+        let parent_durable = self.get_session(parent_session_id);
+
+        for name in &policy.additions {
+            if let Some(def) = runtime_map.get(name) {
+                candidate_defs.insert(name.clone(), def.clone());
+                continue;
+            }
+
+            let diagnostic = parent_catalog
+                .as_ref()
+                .zip(parent_durable.as_ref())
+                .and_then(|(catalog, durable)| catalog.inspect_tool(&*durable.lock(), name));
+
+            match diagnostic {
+                Some(diagnostic) if diagnostic.available => {
+                    // Tool is known to the parent session and available there;
+                    // treat as an addition request that is already satisfied.
+                    if let Some(def) = parent_catalog.as_ref().and_then(|c| c.get_definition(name))
+                    {
+                        candidate_defs.insert(name.clone(), def.clone());
+                    }
+                }
+                Some(diagnostic) => {
+                    unavailable_requested_additions.push(name.clone());
+                    if let Some(reason) = diagnostic
+                        .unavailable_reason
+                        .and_then(|reason| map_unavailable_reason(&diagnostic.source, reason))
+                    {
+                        diagnostics.push(ToolPolicyDiagnostic {
+                            tool_name: name.clone(),
+                            reason,
+                        });
+                    }
+                }
+                None => {
+                    unavailable_requested_additions.push(name.clone());
+                    diagnostics.push(ToolPolicyDiagnostic {
+                        tool_name: name.clone(),
+                        reason: ToolPolicyDiagnosticReason::Missing,
+                    });
+                }
+            }
+        }
+
+        let requested_additions: HashSet<String> = policy.additions.iter().cloned().collect();
+        let candidate: Vec<ToolDefinition> = candidate_defs.into_values().collect();
+
+        // Apply profile tool filter.
+        let (profile_bounded, excluded_by_profile) = apply_tool_filter(&candidate, &profile.tools);
+        diagnostics.extend(
+            excluded_by_profile
+                .iter()
+                .filter(|name| requested_additions.contains(*name))
+                .cloned()
+                .map(|tool_name| ToolPolicyDiagnostic {
+                    tool_name,
+                    reason: ToolPolicyDiagnosticReason::ExcludedByProfile,
+                }),
+        );
+
+        // Apply blocklist.
+        let deny_set: HashSet<String> = policy.deny.iter().cloned().collect();
+        let mut final_defs = Vec::new();
+        let mut removed_tools = Vec::new();
+        for def in profile_bounded {
+            if deny_set.contains(&def.name) {
+                removed_tools.push(def.name.clone());
+            } else {
+                final_defs.push(def);
+            }
+        }
+
+        final_defs.sort_by(|a, b| a.name.cmp(&b.name));
+
+        let final_names: HashSet<String> = final_defs.iter().map(|d| d.name.clone()).collect();
+
+        let inherited_tools: Vec<String> = final_names
+            .iter()
+            .cloned()
+            .filter(|n| parent_names.contains(n))
+            .collect();
+
+        let added_tools: Vec<String> = final_names
+            .iter()
+            .cloned()
+            .filter(|n| !parent_names.contains(n))
+            .collect();
+
+        let digest = compute_tool_catalog_digest(&final_defs);
+
+        Ok(DerivedToolCatalog {
+            definitions: final_defs,
+            inherited_tools,
+            removed_tools,
+            added_tools,
+            unavailable_requested_additions,
+            excluded_by_profile,
+            diagnostics,
+            digest,
+        })
+    }
+
+    /// Run a delegated child prompt and return the result.
+    ///
+    /// This creates a hidden child session, sets up a delegation sink, resolves the
+    /// selected profile/provider, runs the prompt, and cleans up the relationship.
+    pub async fn run_delegation(
+        &self,
+        parent_session_id: SessionId,
+        parent_tool_call_id: Option<String>,
+        request: DelegationRequest,
+        profile: AgentProfile,
+        parent_client: SharedClientChannel,
+        parent_session_acp_id: acp::SessionId,
+    ) -> Result<(DelegationResult, DelegationMetadata), String> {
+        request.validate()?;
+
+        let parent_connection_id = self
+            .get_session_connection(parent_session_id)
+            .ok_or_else(|| "parent session not found".to_string())?;
+
+        let (child_session_id, durable) = self
+            .create_hidden_session(parent_connection_id)
+            .map_err(|e| format!("failed to create child session: {}", e))?;
+
+        if let Err(e) = self.register_child(parent_session_id, child_session_id) {
+            self.close_session(child_session_id);
+            return Err(format!("failed to register child session: {}", e));
+        }
+
+        let delegation_id = format!("dlg-{}", uuid::Uuid::new_v4());
+
+        let catalog =
+            match self.derive_child_tool_catalog(parent_session_id, &profile, &request.tool_policy)
+            {
+                Ok(c) => c,
+                Err(e) => {
+                    self.unregister_child(parent_session_id, child_session_id);
+                    self.close_session(child_session_id);
+                    return Err(e);
+                }
+            };
+
+        // Hide tools not in the derived catalog.
+        let allowed_names: HashSet<String> =
+            catalog.definitions.iter().map(|d| d.name.clone()).collect();
+        let all_runtime_defs = self.tool_registry().definitions();
+        let hidden: Vec<String> = all_runtime_defs
+            .into_iter()
+            .map(|d| d.name)
+            .filter(|n| !allowed_names.contains(n))
+            .collect();
+        {
+            let mut session = durable.lock();
+            session.hidden_tools = hidden;
+        }
+
+        // Set identity prompt.
+        {
+            let mut session = durable.lock();
+            session.set_instructions(profile.effective_identity_prompt());
+        }
+
+        let (activated_skills, excluded_skills_by_profile, unavailable_requested_skills) = {
+            let (allowed_skills, excluded_skills) =
+                apply_skill_filter(&request.requested_skills, &profile.skills);
+            let mut activated = Vec::new();
+            let mut unavailable = Vec::new();
+            let mut session = durable.lock();
+            for skill_name in allowed_skills {
+                match session.load_available_skill(&skill_name) {
+                    Some(skill) if !skill.metadata.requires_trust => {
+                        session.activate_skill(
+                            &skill.metadata.id,
+                            &skill.body,
+                            skill.resources.clone(),
+                        );
+                        activated.push(skill.metadata.id.clone());
+                    }
+                    _ => unavailable.push(skill_name),
+                }
+            }
+            (activated, excluded_skills, unavailable)
+        };
+
+        // Build initial user message.
+        let user_text = if let Some(context) = &request.context {
+            format!("{}\n\nContext:\n{}", request.goal, context)
+        } else {
+            request.goal.clone()
+        };
+        {
+            let mut session = durable.lock();
+            session.add_user_text(user_text);
+        }
+
+        let ephemeral = match self.try_start_prompt(child_session_id) {
+            Ok(e) => e,
+            Err(e) => {
+                self.unregister_child(parent_session_id, child_session_id);
+                self.close_session(child_session_id);
+                return Err(format!("failed to start child prompt: {}", e));
+            }
+        };
+
+        let sink = DelegationPromptSink::new(
+            request.child_approval_mode,
+            parent_client,
+            parent_session_acp_id,
+        );
+
+        let runner = match self.resolve_profile_provider(&profile).await {
+            Ok(crate::profile::ResolvedProfileProvider::RuntimeDefault(_)) => {
+                PromptRunner::new(self.clone())
+            }
+            Ok(crate::profile::ResolvedProfileProvider::Managed(provider)) => {
+                let context = crate::profile::managed_profile_prompt_context(&profile.provider)
+                    .expect("managed profile always yields a prompt context");
+                PromptRunner::new_managed(self.clone(), provider, context)
+            }
+            Err(e) => {
+                self.finish_prompt(child_session_id);
+                self.unregister_child(parent_session_id, child_session_id);
+                self.close_session(child_session_id);
+                return Err(format!("failed to resolve profile provider: {}", e));
+            }
+        };
+
+        let config = self.config().clone();
+        let stop_reason =
+            Box::pin(runner.run(&durable, &ephemeral, &sink, &config, request.max_iterations))
+                .await;
+
+        self.finish_prompt(child_session_id);
+
+        let final_text = {
+            let session = durable.lock();
+            session
+                .messages
+                .last()
+                .and_then(|m| Some(m.text_content()))
+                .filter(|t| !t.is_empty())
+                .map(|t| t.to_string())
+        };
+
+        let outcome: DelegationOutcome = stop_reason.into();
+
+        let result = DelegationResult {
+            delegation_id: delegation_id.clone(),
+            child_session_id,
+            outcome,
+            final_text,
+        };
+
+        let metadata = DelegationMetadata {
+            delegation_id,
+            parent_session_id,
+            parent_tool_call_id,
+            child_session_id,
+            profile_id: request.profile_id.clone(),
+            child_approval_mode: request.child_approval_mode,
+            max_iterations: request.max_iterations,
+            outcome: Some(outcome),
+            tool_catalog_digest: catalog.digest.clone(),
+            inherited_tools: catalog.inherited_tools,
+            removed_tools: catalog.removed_tools,
+            added_tools: catalog.added_tools,
+            unavailable_requested_additions: catalog.unavailable_requested_additions,
+            excluded_by_profile: catalog.excluded_by_profile,
+            tool_policy_diagnostics: catalog.diagnostics,
+            requested_skills: request.requested_skills.clone(),
+            activated_skills,
+            excluded_skills_by_profile,
+            unavailable_requested_skills,
+        };
+
+        Ok((result, metadata))
+    }
+}

--- a/src/delegation/sink.rs
+++ b/src/delegation/sink.rs
@@ -1,0 +1,290 @@
+//! Prompt sinks for delegated child runs.
+
+use crate::connection::SharedClientChannel;
+use crate::delegation::ChildApprovalMode;
+use crate::prompt_lifecycle::{
+    ApprovalRequest, ApprovalVerdict, PromptLifecycleEvent, PromptSink, ToolUpdateStatus,
+};
+use agent_client_protocol::schema as acp;
+use std::pin::Pin;
+
+/// A prompt sink for a delegated child session.
+///
+/// In `AutoApprove` mode, all approval requests resolve to `AllowOnce`.
+/// In `PropagateToParent` mode, approval requests are forwarded to the parent
+/// connection's client channel so the parent/main UI can resolve them.
+pub(crate) struct DelegationPromptSink {
+    mode: ChildApprovalMode,
+    parent_client: SharedClientChannel,
+    parent_session_id: acp::SessionId,
+}
+
+impl DelegationPromptSink {
+    pub(crate) fn new(
+        mode: ChildApprovalMode,
+        parent_client: SharedClientChannel,
+        parent_session_id: acp::SessionId,
+    ) -> Self {
+        Self {
+            mode,
+            parent_client,
+            parent_session_id,
+        }
+    }
+}
+
+impl PromptSink for DelegationPromptSink {
+    fn emit(&self, event: PromptLifecycleEvent) -> Pin<Box<dyn std::future::Future<Output = ()>>> {
+        let parent_client = self.parent_client.clone();
+        let parent_session_id = self.parent_session_id.clone();
+
+        match event {
+            PromptLifecycleEvent::Output { text } => {
+                let prefixed = format!("[child] {}", text);
+                Box::pin(async move {
+                    let notif = crate::connection::notification(
+                        &parent_session_id,
+                        acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk::new(
+                            acp::ContentBlock::Text(acp::TextContent::new(&prefixed)),
+                        )),
+                    );
+                    let _ = parent_client.send_notification(notif).await;
+                })
+            }
+            PromptLifecycleEvent::ToolCallProposed {
+                call_id,
+                tool_name,
+                arguments,
+            } => {
+                let child_call_id = format!("child-{}", call_id);
+                Box::pin(async move {
+                    let notif = crate::connection::notification(
+                        &parent_session_id,
+                        acp::SessionUpdate::ToolCall(
+                            acp::ToolCall::new(acp::ToolCallId::new(child_call_id), &tool_name)
+                                .raw_input(arguments)
+                                .status(acp::ToolCallStatus::Pending),
+                        ),
+                    );
+                    let _ = parent_client.send_notification(notif).await;
+                })
+            }
+            PromptLifecycleEvent::ToolCallUpdate {
+                call_id,
+                tool_name,
+                status,
+                output,
+            } => {
+                let child_call_id = format!("child-{}", call_id);
+                Box::pin(async move {
+                    let acp_status = match status {
+                        ToolUpdateStatus::InProgress => acp::ToolCallStatus::InProgress,
+                        ToolUpdateStatus::Completed => acp::ToolCallStatus::Completed,
+                        ToolUpdateStatus::Failed => acp::ToolCallStatus::Failed,
+                    };
+                    let mut fields = acp::ToolCallUpdateFields::new().status(acp_status);
+                    if !tool_name.is_empty() {
+                        fields = fields.title(&tool_name);
+                    }
+                    if let Some(out) = output {
+                        fields = fields.raw_output(out);
+                    }
+                    let notif = crate::connection::notification(
+                        &parent_session_id,
+                        acp::SessionUpdate::ToolCallUpdate(acp::ToolCallUpdate::new(
+                            acp::ToolCallId::new(child_call_id),
+                            fields,
+                        )),
+                    );
+                    let _ = parent_client.send_notification(notif).await;
+                })
+            }
+            _ => Box::pin(async {}),
+        }
+    }
+
+    fn request_approval(
+        &self,
+        request: ApprovalRequest,
+    ) -> Pin<Box<dyn std::future::Future<Output = ApprovalVerdict>>> {
+        match self.mode {
+            ChildApprovalMode::AutoApprove => Box::pin(async { ApprovalVerdict::AllowOnce }),
+            ChildApprovalMode::PropagateToParent => {
+                let parent_client = self.parent_client.clone();
+                let parent_session_id = self.parent_session_id.clone();
+                let call_id = request.call_id.clone();
+                let tool_name = request.tool_name.clone();
+                let arguments = request.arguments.clone();
+
+                Box::pin(async move {
+                    let tool_call_update = acp::ToolCallUpdate::new(
+                        acp::ToolCallId::new(call_id),
+                        acp::ToolCallUpdateFields::new()
+                            .title(&tool_name)
+                            .raw_input(arguments)
+                            .status(acp::ToolCallStatus::InProgress),
+                    );
+
+                    let perm_request = acp::RequestPermissionRequest::new(
+                        parent_session_id,
+                        tool_call_update,
+                        vec![
+                            acp::PermissionOption::new(
+                                acp::PermissionOptionId::new("allow_once"),
+                                "Allow once",
+                                acp::PermissionOptionKind::AllowOnce,
+                            ),
+                            acp::PermissionOption::new(
+                                acp::PermissionOptionId::new("reject_once"),
+                                "Deny",
+                                acp::PermissionOptionKind::RejectOnce,
+                            ),
+                        ],
+                    );
+
+                    match parent_client.request_permission(perm_request).await {
+                        Ok(response) => match response.outcome {
+                            acp::RequestPermissionOutcome::Cancelled => ApprovalVerdict::Cancelled,
+                            acp::RequestPermissionOutcome::Selected(sel) => {
+                                let option_id = sel.option_id.to_string();
+                                if option_id.contains("allow") {
+                                    ApprovalVerdict::AllowOnce
+                                } else {
+                                    ApprovalVerdict::Denied
+                                }
+                            }
+                            _ => ApprovalVerdict::Denied,
+                        },
+                        Err(_) => ApprovalVerdict::Denied,
+                    }
+                })
+            }
+        }
+    }
+
+    fn parent_client_channel(&self) -> Option<SharedClientChannel> {
+        Some(self.parent_client.clone())
+    }
+
+    fn parent_session_acp_id(&self) -> Option<acp::SessionId> {
+        Some(self.parent_session_id.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::connection::ClientChannel;
+
+    enum TestPermissionOutcome {
+        Allow,
+        Deny,
+        Cancel,
+    }
+
+    struct TestClientChannel {
+        outcome: TestPermissionOutcome,
+    }
+
+    impl TestClientChannel {
+        fn allow() -> Self {
+            Self {
+                outcome: TestPermissionOutcome::Allow,
+            }
+        }
+
+        fn deny() -> Self {
+            Self {
+                outcome: TestPermissionOutcome::Deny,
+            }
+        }
+
+        fn cancel() -> Self {
+            Self {
+                outcome: TestPermissionOutcome::Cancel,
+            }
+        }
+    }
+
+    impl ClientChannel for TestClientChannel {
+        fn send_notification(
+            &self,
+            _notification: acp::SessionNotification,
+        ) -> Pin<Box<dyn std::future::Future<Output = agent_client_protocol::Result<()>>>> {
+            Box::pin(async { Ok(()) })
+        }
+
+        fn request_permission(
+            &self,
+            _request: acp::RequestPermissionRequest,
+        ) -> Pin<
+            Box<
+                dyn std::future::Future<
+                    Output = agent_client_protocol::Result<acp::RequestPermissionResponse>,
+                >,
+            >,
+        > {
+            let outcome = match self.outcome {
+                TestPermissionOutcome::Allow => acp::RequestPermissionOutcome::Selected(
+                    acp::SelectedPermissionOutcome::new(acp::PermissionOptionId::new("allow_once")),
+                ),
+                TestPermissionOutcome::Deny => {
+                    acp::RequestPermissionOutcome::Selected(acp::SelectedPermissionOutcome::new(
+                        acp::PermissionOptionId::new("reject_once"),
+                    ))
+                }
+                TestPermissionOutcome::Cancel => acp::RequestPermissionOutcome::Cancelled,
+            };
+            Box::pin(async move { Ok(acp::RequestPermissionResponse::new(outcome)) })
+        }
+    }
+
+    async fn propagated_verdict_for(channel: TestClientChannel) -> ApprovalVerdict {
+        let sink = DelegationPromptSink::new(
+            ChildApprovalMode::PropagateToParent,
+            std::rc::Rc::new(channel),
+            acp::SessionId::new("session-1"),
+        );
+        sink.request_approval(ApprovalRequest {
+            call_id: "c1".to_string(),
+            tool_name: "shell".to_string(),
+            arguments: serde_json::json!({}),
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn auto_approve_returns_allow_once() {
+        let sink = DelegationPromptSink::new(
+            ChildApprovalMode::AutoApprove,
+            std::rc::Rc::new(TestClientChannel::deny()),
+            acp::SessionId::new("session-1"),
+        );
+        let verdict = sink
+            .request_approval(ApprovalRequest {
+                call_id: "c1".to_string(),
+                tool_name: "shell".to_string(),
+                arguments: serde_json::json!({}),
+            })
+            .await;
+        assert_eq!(verdict, ApprovalVerdict::AllowOnce);
+    }
+
+    #[tokio::test]
+    async fn propagate_returns_parent_verdict() {
+        let verdict = propagated_verdict_for(TestClientChannel::allow()).await;
+        assert_eq!(verdict, ApprovalVerdict::AllowOnce);
+    }
+
+    #[tokio::test]
+    async fn propagate_returns_parent_denial() {
+        let verdict = propagated_verdict_for(TestClientChannel::deny()).await;
+        assert_eq!(verdict, ApprovalVerdict::Denied);
+    }
+
+    #[tokio::test]
+    async fn propagate_returns_parent_cancellation() {
+        let verdict = propagated_verdict_for(TestClientChannel::cancel()).await;
+        assert_eq!(verdict, ApprovalVerdict::Cancelled);
+    }
+}

--- a/src/durable.rs
+++ b/src/durable.rs
@@ -410,6 +410,9 @@ pub struct DurableSession {
     /// Pending workspace roots to be applied at the next turn boundary.
     #[serde(default)]
     pub pending_workspace_roots: Option<Vec<std::path::PathBuf>>,
+    /// The profile id last used for this session, if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub profile_id: Option<crate::profile::AgentProfileId>,
     #[serde(skip, default)]
     pub token_tracker: crate::context::SessionTokenTracker,
 }
@@ -439,6 +442,7 @@ impl DurableSession {
             hidden_tools: Vec::new(),
             workspace_roots: Vec::new(),
             pending_workspace_roots: None,
+            profile_id: None,
             token_tracker: crate::context::SessionTokenTracker::default(),
         }
     }

--- a/src/facade.rs
+++ b/src/facade.rs
@@ -17,6 +17,9 @@ use crate::{
     provider_credential::domain::{ProviderAuthStatus, ProviderPromptContext, ProviderSlug},
     provider_credential::store::DynCredentialStore,
     runtime::{ConnectionId, IronRuntime},
+    stored_prompt::{
+        load_prompts, PromptLoadReport, StoredPrompt, StoredPromptEntry, StoredPromptRegistry,
+    },
     tool::Tool,
 };
 use agent_client_protocol::schema as acp;
@@ -531,6 +534,7 @@ fn default_profile_registry() -> ProfileRegistry {
 pub struct IronAgent {
     runtime: IronRuntime,
     profile_registry: Arc<RwLock<ProfileRegistry>>,
+    stored_prompt_registry: Arc<RwLock<StoredPromptRegistry>>,
 }
 
 impl IronAgent {
@@ -539,9 +543,15 @@ impl IronAgent {
     /// This creates an agent with its own private Tokio runtime. For integration
     /// with an existing Tokio runtime, use [`IronAgent::with_tokio_handle`].
     pub fn new<P: Provider + 'static>(config: Config, provider: P) -> Self {
+        let runtime = IronRuntime::new(config, provider);
+        let profile_registry = Arc::new(RwLock::new(default_profile_registry()));
+        let stored_prompt_registry = Arc::new(RwLock::new(StoredPromptRegistry::new()));
+        runtime.set_profile_registry(profile_registry.clone());
+        runtime.set_stored_prompt_registry(stored_prompt_registry.clone());
         Self {
-            runtime: IronRuntime::new(config, provider),
-            profile_registry: Arc::new(RwLock::new(default_profile_registry())),
+            runtime,
+            profile_registry,
+            stored_prompt_registry,
         }
     }
 
@@ -554,9 +564,15 @@ impl IronAgent {
         provider: P,
         handle: tokio::runtime::Handle,
     ) -> Self {
+        let runtime = IronRuntime::from_handle(config, provider, handle);
+        let profile_registry = Arc::new(RwLock::new(default_profile_registry()));
+        let stored_prompt_registry = Arc::new(RwLock::new(StoredPromptRegistry::new()));
+        runtime.set_profile_registry(profile_registry.clone());
+        runtime.set_stored_prompt_registry(stored_prompt_registry.clone());
         Self {
-            runtime: IronRuntime::from_handle(config, provider, handle),
-            profile_registry: Arc::new(RwLock::new(default_profile_registry())),
+            runtime,
+            profile_registry,
+            stored_prompt_registry,
         }
     }
 
@@ -566,9 +582,15 @@ impl IronAgent {
         provider: P,
         credential_store: DynCredentialStore,
     ) -> Self {
+        let runtime = IronRuntime::new_with_credential_store(config, provider, credential_store);
+        let profile_registry = Arc::new(RwLock::new(default_profile_registry()));
+        let stored_prompt_registry = Arc::new(RwLock::new(StoredPromptRegistry::new()));
+        runtime.set_profile_registry(profile_registry.clone());
+        runtime.set_stored_prompt_registry(stored_prompt_registry.clone());
         Self {
-            runtime: IronRuntime::new_with_credential_store(config, provider, credential_store),
-            profile_registry: Arc::new(RwLock::new(default_profile_registry())),
+            runtime,
+            profile_registry,
+            stored_prompt_registry,
         }
     }
 
@@ -987,6 +1009,54 @@ impl IronAgent {
             })
     }
 
+    /// Register or replace a stored prompt by stable ID.
+    pub fn register_stored_prompt(
+        &self,
+        id: impl Into<String>,
+        prompt: StoredPrompt,
+    ) -> Result<(), String> {
+        self.stored_prompt_registry
+            .write()
+            .register(id.into(), prompt)
+    }
+
+    /// Unregister a stored prompt by stable ID.
+    pub fn unregister_stored_prompt(&self, id: &str) -> bool {
+        self.stored_prompt_registry.write().unregister(id)
+    }
+
+    /// List all registered stored prompts with deterministic ordering.
+    pub fn list_stored_prompts(&self) -> Vec<StoredPromptEntry> {
+        self.stored_prompt_registry.read().list()
+    }
+
+    /// Look up a registered stored prompt by stable ID.
+    pub fn get_stored_prompt(&self, id: &str) -> Option<StoredPromptEntry> {
+        self.stored_prompt_registry
+            .read()
+            .get(id)
+            .cloned()
+            .map(|prompt| StoredPromptEntry {
+                id: id.to_string(),
+                prompt,
+            })
+    }
+
+    /// Load typed stored prompts from a `ConfigStore` into the registry.
+    pub async fn load_stored_prompts(
+        &self,
+        store: &ConfigStore,
+    ) -> Result<PromptLoadReport, crate::config::ConfigError> {
+        let report = load_prompts(store).await?;
+        let mut registry = self.stored_prompt_registry.write();
+        for entry in &report.loaded {
+            registry
+                .register(entry.id.clone(), entry.prompt.clone())
+                .map_err(crate::config::ConfigError::Validation)?;
+        }
+        Ok(report)
+    }
+
     /// Establish a new connection to the agent.
     ///
     /// Returns an [`AgentConnection`] which can be used to create sessions
@@ -1009,6 +1079,7 @@ impl Clone for IronAgent {
         Self {
             runtime: self.runtime.clone(),
             profile_registry: self.profile_registry.clone(),
+            stored_prompt_registry: self.stored_prompt_registry.clone(),
         }
     }
 }
@@ -1021,6 +1092,14 @@ type AsyncPermissionHandler =
     Box<dyn Fn(PermissionRequest) -> Pin<Box<dyn std::future::Future<Output = PermissionVerdict>>>>;
 
 type SyncPermissionHandler = Rc<RefCell<Option<Box<dyn Fn(&str) -> PermissionVerdict>>>>;
+
+/// Inspectable metadata for a hidden runtime session.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HiddenSessionInfo {
+    pub session_id: SessionId,
+    pub connection_id: ConnectionId,
+    pub parent_session_id: Option<SessionId>,
+}
 
 /// A connection to an Iron agent.
 ///
@@ -1198,6 +1277,42 @@ impl AgentConnection {
         self.inner
             .runtime()
             .sessions_for_connection(self.inner.id(), true)
+    }
+
+    /// List hidden sessions visible to this connection for inspection.
+    ///
+    /// Includes hidden sessions directly owned by this connection and hidden
+    /// child sessions whose parent session is owned by this connection.
+    pub fn hidden_sessions(&self) -> Vec<HiddenSessionInfo> {
+        let runtime = self.inner.runtime();
+        let connection_id = self.inner.id();
+        runtime
+            .list_hidden_sessions()
+            .into_iter()
+            .filter(|(_, child_connection_id, parent_session_id)| {
+                *child_connection_id == connection_id
+                    || parent_session_id.and_then(|parent| runtime.get_session_connection(parent))
+                        == Some(connection_id)
+            })
+            .map(
+                |(session_id, connection_id, parent_session_id)| HiddenSessionInfo {
+                    session_id,
+                    connection_id,
+                    parent_session_id,
+                },
+            )
+            .collect()
+    }
+
+    /// List child sessions registered under a parent session owned by this connection.
+    pub fn child_sessions(&self, parent: &AgentSession) -> Result<Vec<SessionId>, RuntimeError> {
+        let owner = self.inner.runtime().get_session_connection(parent.id);
+        if owner != Some(self.inner.id()) {
+            return Err(RuntimeError::Connection(
+                "session not owned by this connection".into(),
+            ));
+        }
+        Ok(self.inner.runtime().list_child_sessions(parent.id))
     }
 
     /// Start a direct client-initiated auth flow for a plugin.

--- a/src/facade.rs
+++ b/src/facade.rs
@@ -48,6 +48,8 @@ pub enum PromptOutcome {
     Cancelled,
     /// The maximum number of turn requests was reached.
     MaxTurnRequests,
+    /// The turn stopped for a reason not recognized by this core version.
+    Unknown,
 }
 
 impl From<acp::StopReason> for PromptOutcome {
@@ -56,7 +58,7 @@ impl From<acp::StopReason> for PromptOutcome {
             acp::StopReason::EndTurn => PromptOutcome::EndTurn,
             acp::StopReason::Cancelled => PromptOutcome::Cancelled,
             acp::StopReason::MaxTurnRequests => PromptOutcome::MaxTurnRequests,
-            _ => PromptOutcome::EndTurn,
+            acp::StopReason::MaxTokens | acp::StopReason::Refusal | _ => PromptOutcome::Unknown,
         }
     }
 }
@@ -1022,7 +1024,7 @@ impl IronAgent {
 
     /// Unregister a stored prompt by stable ID.
     pub fn unregister_stored_prompt(&self, id: &str) -> bool {
-        self.stored_prompt_registry.write().unregister(id)
+        self.stored_prompt_registry.write().unregister(id.trim())
     }
 
     /// List all registered stored prompts with deterministic ordering.
@@ -1032,12 +1034,13 @@ impl IronAgent {
 
     /// Look up a registered stored prompt by stable ID.
     pub fn get_stored_prompt(&self, id: &str) -> Option<StoredPromptEntry> {
+        let normalized_id = id.trim();
         self.stored_prompt_registry
             .read()
-            .get(id)
+            .get(normalized_id)
             .cloned()
             .map(|prompt| StoredPromptEntry {
-                id: id.to_string(),
+                id: normalized_id.to_string(),
                 prompt,
             })
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,6 +167,7 @@ pub mod config;
 pub mod connection;
 pub mod context;
 pub mod debug;
+pub mod delegation;
 pub mod durable;
 pub mod embedded_python;
 pub mod ephemeral;
@@ -184,6 +185,7 @@ pub mod request_builder;
 pub mod runtime;
 pub mod schema;
 pub mod skill;
+pub mod stored_prompt;
 pub mod tool;
 pub mod transport;
 
@@ -204,6 +206,12 @@ pub use context::{
     PendingModelSwitch, SessionModelInfo, TailRetentionPolicy, TailRetentionRule, TokenUsageTotals,
     HANDOFF_DEFAULT_TARGET_TOKENS,
 };
+pub use delegation::{
+    compute_tool_catalog_digest, validate_delegation_arguments, ChildApprovalMode,
+    DelegationMetadata, DelegationOutcome, DelegationRequest, DelegationResult, SubAgentToolBase,
+    SubAgentToolPolicy, ToolPolicyDiagnostic, ToolPolicyDiagnosticReason,
+    DELEGATION_SCHEMA_VERSION,
+};
 pub use durable::{
     ContentBlock, DurableScriptRecord, DurableSession, DurableToolRecord, ScriptRecordStatus,
     SessionId, StructuredMessage, TimelineEntry, ToolRecordStatus, ToolTerminalOutcome,
@@ -222,6 +230,10 @@ pub use profile::{
 };
 pub use prompt_turn::PromptTurn;
 pub use runtime::{ConnectionId, CreateSessionOptions, IronRuntime};
+pub use stored_prompt::{
+    load_prompts, PromptLoadDiagnostic, PromptLoadIssue, PromptLoadReport, StoredPrompt,
+    StoredPromptEntry, StoredPromptRegistry, STORED_PROMPT_SCHEMA_VERSION,
+};
 pub use tool::{FunctionTool, Tool, ToolDefinition, ToolRegistry};
 
 pub use builtin::{

--- a/src/mcp/session_catalog.rs
+++ b/src/mcp/session_catalog.rs
@@ -779,11 +779,45 @@ impl SessionToolCatalog {
             });
         }
 
-        // --- Phase 2: plugin tools NOT in the catalog (unavailable) ---
+        // --- Phase 2: MCP tools NOT in the catalog (unavailable) ---
 
-        // Collect namespaced names already emitted so we don't duplicate.
-        let emitted: std::collections::HashSet<String> =
+        let mut emitted: std::collections::HashSet<String> =
             diagnostics.iter().map(|d| d.name.clone()).collect();
+
+        for server in self.mcp_registry.list_servers() {
+            let server_id = server.config.id.clone();
+            let enabled = Self::is_mcp_server_enabled_for_session(session, &server_id);
+            let namespaced_prefix = format!("mcp_{}_", server_id);
+
+            for tool_info in &server.discovered_tools {
+                let namespaced = format!("{}{}", namespaced_prefix, tool_info.name);
+                if emitted.contains(namespaced.as_str()) {
+                    continue;
+                }
+
+                let unavailable_reason = if !enabled {
+                    Some(UnavailableReason::McpServerNotEnabled)
+                } else if !server.health.is_usable() {
+                    Some(UnavailableReason::McpServerNotHealthy(server.health))
+                } else {
+                    None
+                };
+
+                diagnostics.push(ToolDiagnostic {
+                    name: namespaced,
+                    source: ToolSource::Mcp {
+                        server_id: server_id.clone(),
+                    },
+                    available: unavailable_reason.is_none(),
+                    unavailable_reason,
+                    requires_approval: true,
+                    description: tool_info.description.clone(),
+                });
+                emitted.insert(format!("mcp_{}_{}", server_id, tool_info.name));
+            }
+        }
+
+        // --- Phase 3: plugin tools NOT in the catalog (unavailable) ---
 
         for plugin in self.plugin_registry.list() {
             let plugin_id = &plugin.config.id;
@@ -867,6 +901,15 @@ impl SessionToolCatalog {
         diagnostics.retain(|d| !hidden_tools.contains(d.name.as_str()));
 
         diagnostics
+    }
+    /// Diagnostic information for a single tool name, if known.
+    ///
+    /// Returns `Some` for both available and unavailable tools; returns `None`
+    /// only when the name is not recognised at all.
+    pub fn inspect_tool(&self, session: &DurableSession, name: &str) -> Option<ToolDiagnostic> {
+        self.inspect_tools(session)
+            .into_iter()
+            .find(|diagnostic| diagnostic.name == name)
     }
 }
 

--- a/src/plugin/effective_tools.rs
+++ b/src/plugin/effective_tools.rs
@@ -105,7 +105,7 @@ impl Tool for PluginTool {
 ///
 /// Each variant captures enough context for clients and logs to produce
 /// actionable messages without needing to re-derive the cause.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum UnavailableReason {
     /// Plugin is not enabled for the current session.
     PluginNotEnabled,
@@ -122,6 +122,10 @@ pub enum UnavailableReason {
         required: Vec<String>,
         missing: Vec<String>,
     },
+    /// MCP server is not enabled for the current session.
+    McpServerNotEnabled,
+    /// MCP server is not connected/healthy.
+    McpServerNotHealthy(crate::mcp::server::McpServerHealth),
 }
 
 /// Result of canonical per-tool availability computation.

--- a/src/prompt_lifecycle.rs
+++ b/src/prompt_lifecycle.rs
@@ -67,6 +67,18 @@ pub trait PromptSink {
         &self,
         request: ApprovalRequest,
     ) -> Pin<Box<dyn std::future::Future<Output = ApprovalVerdict>>>;
+
+    /// Return the underlying client channel if this sink is backed by one.
+    ///
+    /// Used by delegation to forward child approval requests to the parent UI.
+    fn parent_client_channel(&self) -> Option<SharedClientChannel> {
+        None
+    }
+
+    /// Return the parent ACP session id used to route delegation UI events.
+    fn parent_session_acp_id(&self) -> Option<acp::SessionId> {
+        None
+    }
 }
 
 pub(crate) struct AcpPromptSink {
@@ -262,5 +274,13 @@ impl PromptSink for AcpPromptSink {
                 Err(_) => ApprovalVerdict::Denied,
             }
         })
+    }
+
+    fn parent_client_channel(&self) -> Option<SharedClientChannel> {
+        Some(self.client.clone())
+    }
+
+    fn parent_session_acp_id(&self) -> Option<acp::SessionId> {
+        Some(self.session_id.clone())
     }
 }

--- a/src/prompt_runner.rs
+++ b/src/prompt_runner.rs
@@ -1496,7 +1496,7 @@ impl PromptRunner {
         sink: &dyn PromptSink,
         call: &iron_providers::ToolCall,
     ) -> Result<crate::delegation::DelegationResult, String> {
-        let mut request = validate_delegation_arguments(&call.arguments)
+        let request = validate_delegation_arguments(&call.arguments)
             .map_err(|e| format!("invalid delegate_task arguments: {}", e))?;
 
         let parent_session_id = durable.lock().id;
@@ -1509,7 +1509,7 @@ impl PromptRunner {
             .ok_or_else(|| "delegate_task requires an ACP session id".to_string())?;
 
         let profile = self
-            .resolve_delegation_profile(durable, request.profile_id.take())
+            .resolve_delegation_profile(durable, request.profile_id.clone())
             .await?;
 
         let (result, _metadata) = self

--- a/src/prompt_runner.rs
+++ b/src/prompt_runner.rs
@@ -1,9 +1,13 @@
 use crate::config::Config;
 use crate::connection::SharedClientChannel;
+use crate::delegation::{
+    validate_delegation_arguments, ChildApprovalMode, DelegationRequest, SubAgentToolPolicy,
+};
 use crate::durable::DurableSession;
-use crate::ephemeral::EphemeralTurn;
+use crate::ephemeral::{EphemeralTurn, TurnPhase};
 use crate::mcp::SessionToolCatalog;
 use crate::plugin::rich_output::transcript_text as plugin_transcript_text;
+use crate::profile::{AgentProfile, AgentProfileId};
 use crate::prompt_lifecycle::{
     ApprovalRequest, ApprovalVerdict, PromptLifecycleEvent, PromptSink, ToolUpdateStatus,
 };
@@ -862,13 +866,19 @@ impl PromptRunner {
             );
         }
 
-        let verdict = sink
-            .request_approval(ApprovalRequest {
-                call_id: call_id.to_string(),
-                tool_name: tool_name.to_string(),
-                arguments: arguments.clone(),
-            })
-            .await;
+        let mut phase_rx = ephemeral.lock().phase_watcher();
+        let approval_fut = sink.request_approval(ApprovalRequest {
+            call_id: call_id.to_string(),
+            tool_name: tool_name.to_string(),
+            arguments: arguments.clone(),
+        });
+
+        let verdict = tokio::select! {
+            _ = phase_rx.wait_for(|phase| matches!(phase, TurnPhase::Cancelled)) => {
+                ApprovalVerdict::Cancelled
+            }
+            verdict = approval_fut => verdict,
+        };
 
         {
             let mut turn = ephemeral.lock();
@@ -1051,6 +1061,16 @@ impl PromptRunner {
             let turn_id = ephemeral.lock().turn_id.clone();
             self.execute_compress_tool(durable, sink, call, turn_id)
                 .await;
+            return;
+        }
+
+        if call.tool_name == "delegate_task" {
+            self.execute_delegate_task(durable, sink, call).await;
+            return;
+        }
+
+        if call.tool_name == "run_task" {
+            self.execute_run_task(durable, sink, call).await;
             return;
         }
 
@@ -1382,6 +1402,311 @@ impl PromptRunner {
         }
     }
 
+    async fn execute_delegate_task(
+        &self,
+        durable: &Arc<Mutex<DurableSession>>,
+        sink: &dyn PromptSink,
+        call: iron_providers::ToolCall,
+    ) {
+        let call_id = call.call_id.clone();
+        let session_id = durable.lock().id;
+
+        self.runtime.emit_debug(crate::debug::DebugEvent {
+            timestamp: chrono::Utc::now(),
+            sequence: self.runtime.next_debug_sequence(),
+            severity: crate::debug::DebugSeverity::Info,
+            scope: crate::debug::DebugScope {
+                session_id: Some(session_id),
+                tool_call_id: Some(call_id.clone()),
+                ..crate::debug::DebugScope::default()
+            },
+            payload: crate::debug::DebugPayload::Tool(
+                crate::debug::ToolDebugEvent::ExecutionStarted {
+                    tool_name: "delegate_task".to_string(),
+                    tool_source: "orchestrator".to_string(),
+                    call_id: call_id.clone(),
+                },
+            ),
+        });
+
+        {
+            let mut session = durable.lock();
+            session.start_tool_call(&call_id, "delegate_task", call.arguments.clone());
+        }
+
+        let (result_value, status) = match self.run_delegation_from_call(durable, sink, &call).await
+        {
+            Ok(result) => {
+                let value = limit_result_size(
+                    serde_json::to_value(&result)
+                        .unwrap_or(serde_json::json!({"error": "serialization failed"})),
+                );
+                {
+                    let mut session = durable.lock();
+                    session.complete_tool_call(&call_id, value.clone());
+                }
+                (value, ToolUpdateStatus::Completed)
+            }
+            Err(error) => {
+                let value = serde_json::json!({"error": error});
+                {
+                    let mut session = durable.lock();
+                    session.fail_tool_call(&call_id, value.clone());
+                }
+                (value, ToolUpdateStatus::Failed)
+            }
+        };
+
+        sink.emit(PromptLifecycleEvent::ToolCallUpdate {
+            call_id: call_id.clone(),
+            tool_name: "delegate_task".to_string(),
+            status,
+            output: Some(result_value.clone()),
+        })
+        .await;
+
+        self.runtime.emit_debug(crate::debug::DebugEvent {
+            timestamp: chrono::Utc::now(),
+            sequence: self.runtime.next_debug_sequence(),
+            severity: crate::debug::DebugSeverity::Info,
+            scope: crate::debug::DebugScope {
+                session_id: Some(session_id),
+                tool_call_id: Some(call_id.clone()),
+                ..crate::debug::DebugScope::default()
+            },
+            payload: crate::debug::DebugPayload::Tool(
+                crate::debug::ToolDebugEvent::ExecutionFinished {
+                    tool_name: "delegate_task".to_string(),
+                    call_id: call_id.clone(),
+                    status: match status {
+                        ToolUpdateStatus::Completed => "completed".to_string(),
+                        _ => "failed".to_string(),
+                    },
+                    duration_ms: None,
+                    truncated: false,
+                    reason: None,
+                },
+            ),
+        });
+    }
+
+    async fn run_delegation_from_call(
+        &self,
+        durable: &Arc<Mutex<DurableSession>>,
+        sink: &dyn PromptSink,
+        call: &iron_providers::ToolCall,
+    ) -> Result<crate::delegation::DelegationResult, String> {
+        let mut request = validate_delegation_arguments(&call.arguments)
+            .map_err(|e| format!("invalid delegate_task arguments: {}", e))?;
+
+        let parent_session_id = durable.lock().id;
+
+        let parent_client = sink
+            .parent_client_channel()
+            .ok_or_else(|| "delegate_task requires a client-backed prompt sink".to_string())?;
+        let parent_session_acp_id = sink
+            .parent_session_acp_id()
+            .ok_or_else(|| "delegate_task requires an ACP session id".to_string())?;
+
+        let profile = self
+            .resolve_delegation_profile(durable, request.profile_id.take())
+            .await?;
+
+        let (result, _metadata) = self
+            .runtime
+            .run_delegation(
+                parent_session_id,
+                Some(call.call_id.clone()),
+                request,
+                profile,
+                parent_client,
+                parent_session_acp_id,
+            )
+            .await?;
+        Ok(result)
+    }
+
+    async fn resolve_delegation_profile(
+        &self,
+        durable: &Arc<Mutex<DurableSession>>,
+        explicit_profile_id: Option<AgentProfileId>,
+    ) -> Result<AgentProfile, String> {
+        let profile_id = explicit_profile_id
+            .or_else(|| durable.lock().profile_id.clone())
+            .unwrap_or_else(|| AgentProfileId::from("default"));
+
+        let registry = self
+            .runtime
+            .profile_registry()
+            .ok_or_else(|| "profile registry not configured".to_string())?;
+        let profile = {
+            let guard = registry.read();
+            guard.get(&profile_id).cloned()
+        };
+        profile.ok_or_else(|| format!("profile '{}' not found", profile_id.as_str()))
+    }
+
+    async fn execute_run_task(
+        &self,
+        durable: &Arc<Mutex<DurableSession>>,
+        sink: &dyn PromptSink,
+        call: iron_providers::ToolCall,
+    ) {
+        let call_id = call.call_id.clone();
+        let session_id = durable.lock().id;
+
+        self.runtime.emit_debug(crate::debug::DebugEvent {
+            timestamp: chrono::Utc::now(),
+            sequence: self.runtime.next_debug_sequence(),
+            severity: crate::debug::DebugSeverity::Info,
+            scope: crate::debug::DebugScope {
+                session_id: Some(session_id),
+                tool_call_id: Some(call_id.clone()),
+                ..crate::debug::DebugScope::default()
+            },
+            payload: crate::debug::DebugPayload::Tool(
+                crate::debug::ToolDebugEvent::ExecutionStarted {
+                    tool_name: "run_task".to_string(),
+                    tool_source: "orchestrator".to_string(),
+                    call_id: call_id.clone(),
+                },
+            ),
+        });
+
+        {
+            let mut session = durable.lock();
+            session.start_tool_call(&call_id, "run_task", call.arguments.clone());
+        }
+
+        let (result_value, status) = match self.run_stored_prompt_task(durable, sink, &call).await {
+            Ok(result) => {
+                let value = limit_result_size(
+                    serde_json::to_value(&result)
+                        .unwrap_or(serde_json::json!({"error": "serialization failed"})),
+                );
+                {
+                    let mut session = durable.lock();
+                    session.complete_tool_call(&call_id, value.clone());
+                }
+                (value, ToolUpdateStatus::Completed)
+            }
+            Err(error) => {
+                let value = serde_json::json!({"error": error});
+                {
+                    let mut session = durable.lock();
+                    session.fail_tool_call(&call_id, value.clone());
+                }
+                (value, ToolUpdateStatus::Failed)
+            }
+        };
+
+        sink.emit(PromptLifecycleEvent::ToolCallUpdate {
+            call_id: call_id.clone(),
+            tool_name: "run_task".to_string(),
+            status,
+            output: Some(result_value.clone()),
+        })
+        .await;
+
+        self.runtime.emit_debug(crate::debug::DebugEvent {
+            timestamp: chrono::Utc::now(),
+            sequence: self.runtime.next_debug_sequence(),
+            severity: crate::debug::DebugSeverity::Info,
+            scope: crate::debug::DebugScope {
+                session_id: Some(session_id),
+                tool_call_id: Some(call_id.clone()),
+                ..crate::debug::DebugScope::default()
+            },
+            payload: crate::debug::DebugPayload::Tool(
+                crate::debug::ToolDebugEvent::ExecutionFinished {
+                    tool_name: "run_task".to_string(),
+                    call_id: call_id.clone(),
+                    status: match status {
+                        ToolUpdateStatus::Completed => "completed".to_string(),
+                        _ => "failed".to_string(),
+                    },
+                    duration_ms: None,
+                    truncated: false,
+                    reason: None,
+                },
+            ),
+        });
+    }
+
+    async fn run_stored_prompt_task(
+        &self,
+        durable: &Arc<Mutex<DurableSession>>,
+        sink: &dyn PromptSink,
+        call: &iron_providers::ToolCall,
+    ) -> Result<crate::delegation::DelegationResult, String> {
+        let task_id = call
+            .arguments
+            .get("task_id")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "run_task requires 'task_id'".to_string())?;
+
+        let context = call
+            .arguments
+            .get("context")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
+        let child_approval_mode = call
+            .arguments
+            .get("child_approval_mode")
+            .and_then(|v| v.as_str())
+            .and_then(|s| match s {
+                "auto_approve" => Some(ChildApprovalMode::AutoApprove),
+                "propagate_to_parent" => Some(ChildApprovalMode::PropagateToParent),
+                _ => None,
+            })
+            .unwrap_or_default();
+
+        let registry = self
+            .runtime
+            .stored_prompt_registry()
+            .ok_or_else(|| "stored prompt registry not configured".to_string())?;
+        let prompt = registry
+            .read()
+            .get(task_id)
+            .cloned()
+            .ok_or_else(|| format!("stored prompt '{}' not found", task_id))?;
+
+        let request = DelegationRequest {
+            goal: prompt.instructions,
+            context,
+            profile_id: prompt.profile,
+            requested_skills: prompt.skills,
+            max_iterations: 10,
+            child_approval_mode,
+            tool_policy: SubAgentToolPolicy::inherit_parent(),
+        };
+
+        let parent_session_id = durable.lock().id;
+        let parent_client = sink
+            .parent_client_channel()
+            .ok_or_else(|| "run_task requires a client-backed prompt sink".to_string())?;
+        let parent_session_acp_id = sink
+            .parent_session_acp_id()
+            .ok_or_else(|| "run_task requires an ACP session id".to_string())?;
+
+        let profile = self
+            .resolve_delegation_profile(durable, request.profile_id.clone())
+            .await?;
+
+        let (result, _metadata) = self
+            .runtime
+            .run_delegation(
+                parent_session_id,
+                Some(call.call_id.clone()),
+                request,
+                profile,
+                parent_client,
+                parent_session_acp_id,
+            )
+            .await?;
+        Ok(result)
+    }
     async fn execute_activate_skill(
         &self,
         durable: &Arc<Mutex<DurableSession>>,

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -16,7 +16,8 @@ use crate::{
     plugin::status::{PluginInfo, PluginStatus},
     plugin::wasm_host::WasmHost,
     profile::{
-        managed_profile_prompt_context, AgentProfile, AgentProfileProvider, ResolvedProfileProvider,
+        managed_profile_prompt_context, AgentProfile, AgentProfileId, AgentProfileProvider,
+        ResolvedProfileProvider,
     },
     provider_credential::domain::{
         ProviderAuthError, ProviderAuthResult, ProviderAuthStatus, ProviderPromptContext,
@@ -27,6 +28,7 @@ use crate::{
     skill::source::FilesystemSkillSource,
     skill::SkillOrigin,
     skill::{LoadedSkill, SkillCatalog, SkillDiagnostic},
+    stored_prompt::StoredPromptRegistry,
     tool::ToolRegistry,
 };
 use iron_providers::Provider;
@@ -72,7 +74,12 @@ struct RuntimeInner {
     debug_sequence: crate::debug::SequenceGenerator,
     builtin_tool_config: Mutex<Option<crate::builtin::BuiltinToolConfig>>,
     model_capability_registry: RwLock<crate::context::model_switch::ModelCapabilityRegistry>,
+    profile_registry: RwLock<Option<Arc<RwLock<ProfileRegistry>>>>,
+    stored_prompt_registry: RwLock<Option<Arc<RwLock<StoredPromptRegistry>>>>,
 }
+
+/// Registry of named agent profiles available for delegation and session creation.
+pub(crate) type ProfileRegistry = HashMap<AgentProfileId, AgentProfile>;
 
 struct ActivePrompt {
     ephemeral: Arc<Mutex<EphemeralTurn>>,
@@ -120,6 +127,13 @@ struct RuntimeConnection {
 /// Stable identifier for a client connection registered with the runtime.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct ConnectionId(pub u64);
+
+static CONNECTION_ID_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
+
+/// Allocate the next connection ID.
+pub fn next_connection_id() -> ConnectionId {
+    ConnectionId(CONNECTION_ID_COUNTER.fetch_add(1, std::sync::atomic::Ordering::SeqCst))
+}
 
 /// Shared runtime backing one or more `IronAgent` facade values.
 ///
@@ -238,6 +252,8 @@ impl IronRuntime {
             model_capability_registry: RwLock::new(
                 crate::context::model_switch::ModelCapabilityRegistry::new(),
             ),
+            profile_registry: RwLock::new(None),
+            stored_prompt_registry: RwLock::new(None),
         };
 
         let this = Self {
@@ -258,6 +274,8 @@ impl IronRuntime {
         }
 
         this.register_compress_tool();
+        this.register_delegate_task_tool();
+        this.register_run_task_tool();
         this.hydrate_builtin_model_capability_registry();
 
         // Emit runtime configuration debug event (new())
@@ -351,6 +369,8 @@ impl IronRuntime {
             model_capability_registry: RwLock::new(
                 crate::context::model_switch::ModelCapabilityRegistry::new(),
             ),
+            profile_registry: RwLock::new(None),
+            stored_prompt_registry: RwLock::new(None),
         };
 
         let this = Self {
@@ -371,6 +391,8 @@ impl IronRuntime {
         }
 
         this.register_compress_tool();
+        this.register_delegate_task_tool();
+        this.register_run_task_tool();
         this.hydrate_builtin_model_capability_registry();
 
         // Emit runtime configuration debug event
@@ -469,6 +491,26 @@ impl IronRuntime {
         if let Some(ref sink) = *self.debug_sink() {
             crate::debug::emit_debug(sink.as_ref(), event);
         }
+    }
+
+    /// Set the profile registry used to resolve named profiles for delegation.
+    pub fn set_profile_registry(&self, registry: Arc<RwLock<ProfileRegistry>>) {
+        *self.inner.profile_registry.write() = Some(registry);
+    }
+
+    /// Access the profile registry, if one has been set.
+    pub(crate) fn profile_registry(&self) -> Option<Arc<RwLock<ProfileRegistry>>> {
+        self.inner.profile_registry.read().clone()
+    }
+
+    /// Set the stored-prompt registry used by `run_task`.
+    pub fn set_stored_prompt_registry(&self, registry: Arc<RwLock<StoredPromptRegistry>>) {
+        *self.inner.stored_prompt_registry.write() = Some(registry);
+    }
+
+    /// Access the stored-prompt registry, if one has been set.
+    pub(crate) fn stored_prompt_registry(&self) -> Option<Arc<RwLock<StoredPromptRegistry>>> {
+        self.inner.stored_prompt_registry.read().clone()
     }
 
     /// Borrow the validated runtime configuration.
@@ -666,6 +708,99 @@ impl IronRuntime {
         let tool = crate::tool::FunctionTool::new(definition, |_args| {
             Err(crate::error::RuntimeError::tool_execution(
                 "compress must be handled by the orchestrator".to_string(),
+            ))
+        });
+        self.register_tool(tool);
+    }
+
+    /// Register the `delegate_task` model-facing tool.
+    pub fn register_delegate_task_tool(&self) {
+        use crate::tool::{FunctionTool, ToolDefinition};
+        let definition = ToolDefinition::new(
+            "delegate_task",
+            "Spawn an autonomous sub-agent to work on a task with a potentially narrower profile and tool catalog. Returns a delegation result with the child session id and final text.",
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "goal": {
+                        "type": "string",
+                        "description": "The task or goal to delegate to the sub-agent"
+                    },
+                    "context": {
+                        "type": "string",
+                        "description": "Optional additional context for the sub-agent"
+                    },
+                    "profile_id": {
+                        "type": "string",
+                        "description": "Optional profile id for the sub-agent. Defaults to the current session's profile."
+                    },
+                    "max_iterations": {
+                        "type": "integer",
+                        "description": "Maximum number of turns the sub-agent may take",
+                        "minimum": 1,
+                        "maximum": 100
+                    },
+                    "child_approval_mode": {
+                        "type": "string",
+                        "enum": ["auto_approve", "propagate_to_parent"],
+                        "description": "How tool approvals inside the child session are handled"
+                    },
+                    "tool_base": {
+                        "type": "string",
+                        "enum": ["parent_effective", "child_default"],
+                        "description": "Base catalog for the child session"
+                    },
+                    "tool_additions": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "description": "Tool names to add to the child's catalog beyond the base"
+                    },
+                    "tool_deny": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "description": "Tool names to explicitly remove from the child's catalog"
+                    }
+                },
+                "required": ["goal"]
+            }),
+        );
+        let tool = FunctionTool::new(definition, |_args| {
+            Err(crate::error::RuntimeError::tool_execution(
+                "delegate_task must be handled by the orchestrator".to_string(),
+            ))
+        });
+        self.register_tool(tool);
+    }
+
+    /// Register the `run_task` model-facing tool.
+    pub fn register_run_task_tool(&self) {
+        use crate::tool::{FunctionTool, ToolDefinition};
+        let definition = ToolDefinition::new(
+            "run_task",
+            "Run a stored prompt as an autonomous sub-agent task.",
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "task_id": {
+                        "type": "string",
+                        "description": "The id of the stored prompt/task to run"
+                    },
+                    "context": {
+                        "type": "string",
+                        "description": "Optional additional context for this run"
+                    },
+                    "child_approval_mode": {
+                        "type": "string",
+                        "enum": ["auto_approve", "propagate_to_parent"],
+                        "description": "How tool approvals inside the child session are handled"
+                    }
+                },
+                "required": ["task_id"]
+            }),
+        );
+        let tool = FunctionTool::new(definition, |_args| {
+            Err(crate::error::RuntimeError::tool_execution(
+                "run_task must be handled by the orchestrator".to_string(),
             ))
         });
         self.register_tool(tool);
@@ -1925,7 +2060,14 @@ impl IronRuntime {
 
     pub fn cancel_active_prompt(&self, session_id: SessionId) -> bool {
         let sessions = self.inner.sessions.read();
-        Self::cancel_active_prompt_locked(&sessions, session_id)
+        let children_by_parent = self.inner.children_by_parent.read();
+        let mut cancelled = Self::cancel_active_prompt_locked(&sessions, session_id);
+        for child_id in
+            Self::collect_descendants_depth_first_locked(&children_by_parent, session_id)
+        {
+            cancelled |= Self::cancel_active_prompt_locked(&sessions, child_id);
+        }
+        cancelled
     }
 
     fn cancel_active_prompt_locked(
@@ -2043,6 +2185,48 @@ impl IronRuntime {
             .filter(|(_, rs)| rs.connection_id == connection_id && (include_hidden || !rs.hidden))
             .map(|(id, _)| *id)
             .collect()
+    }
+
+    /// Create a new standalone connection.
+    ///
+    /// Delegated child sessions can use this connection while remaining linked to
+    /// the parent session through parent-child relationship tracking.
+    pub fn new_connection(&self) -> ConnectionId {
+        let id = crate::runtime::next_connection_id();
+        self.register_connection(id);
+        id
+    }
+
+    /// Create a hidden session on the given connection.
+    pub fn create_hidden_session(
+        &self,
+        connection_id: ConnectionId,
+    ) -> Result<(SessionId, Arc<Mutex<DurableSession>>), RuntimeError> {
+        self.create_session_with_options(connection_id, CreateSessionOptions { hidden: true })
+    }
+
+    /// List child session IDs registered under a parent session.
+    pub fn list_child_sessions(&self, parent_session_id: SessionId) -> Vec<SessionId> {
+        let children_by_parent = self.inner.children_by_parent.read();
+        children_by_parent
+            .get(&parent_session_id)
+            .map(|set| set.iter().copied().collect())
+            .unwrap_or_default()
+    }
+
+    /// List all hidden sessions across all connections, with optional parent.
+    pub fn list_hidden_sessions(&self) -> Vec<(SessionId, ConnectionId, Option<SessionId>)> {
+        let sessions = self.inner.sessions.read();
+        let parent_by_child = self.inner.parent_by_child.read();
+        let mut result = Vec::new();
+        for (session_id, rs) in sessions.iter() {
+            if rs.hidden {
+                let parent = parent_by_child.get(session_id).copied();
+                result.push((*session_id, rs.connection_id, parent));
+            }
+        }
+        result.sort_by_key(|(id, _, _)| id.0);
+        result
     }
 
     pub fn shutdown(&self) {

--- a/src/stored_prompt/mod.rs
+++ b/src/stored_prompt/mod.rs
@@ -90,11 +90,11 @@ impl StoredPromptRegistry {
     }
 
     pub fn unregister(&mut self, id: &str) -> bool {
-        self.prompts.remove(id).is_some()
+        self.prompts.remove(id.trim()).is_some()
     }
 
     pub fn get(&self, id: &str) -> Option<&StoredPrompt> {
-        self.prompts.get(id)
+        self.prompts.get(id.trim())
     }
 
     pub fn list(&self) -> Vec<StoredPromptEntry> {

--- a/src/stored_prompt/mod.rs
+++ b/src/stored_prompt/mod.rs
@@ -1,0 +1,217 @@
+//! Stored prompt definitions and registry.
+//!
+//! Stored prompts are named reusable task definitions persisted in the core
+//! config store. They are invoked through delegated child-session execution.
+
+use crate::config::{ConfigError, ConfigStore};
+use crate::profile::AgentProfileId;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// Schema version for typed `StoredPrompt` payloads stored in ConfigStore.
+pub const STORED_PROMPT_SCHEMA_VERSION: i64 = 1;
+
+/// A reusable prompt task definition.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct StoredPrompt {
+    /// Instructions passed as the child's goal or system prompt layer.
+    pub instructions: String,
+    /// Requested skills to activate for the child run.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub skills: Vec<String>,
+    /// Optional profile ID to use for the child run.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub profile: Option<AgentProfileId>,
+}
+
+impl StoredPrompt {
+    /// Validate invariants.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.instructions.trim().is_empty() {
+            return Err("stored prompt instructions must not be empty".to_string());
+        }
+        Ok(())
+    }
+}
+
+/// A stored prompt paired with its stable ID.
+#[derive(Debug, Clone, PartialEq)]
+pub struct StoredPromptEntry {
+    pub id: String,
+    pub prompt: StoredPrompt,
+}
+
+/// Issue category reported for a skipped prompt during `load_prompts`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PromptLoadIssue {
+    UnsupportedSchemaVersion { version: i64 },
+    InvalidPayload,
+    MissingRecord,
+}
+
+/// Per-prompt diagnostic returned by best-effort prompt loading.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PromptLoadDiagnostic {
+    pub prompt_id: String,
+    pub issue: PromptLoadIssue,
+}
+
+/// Result of loading typed stored prompts from ConfigStore.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct PromptLoadReport {
+    pub loaded: Vec<StoredPromptEntry>,
+    pub diagnostics: Vec<PromptLoadDiagnostic>,
+}
+
+/// In-memory registry of stored prompts.
+#[derive(Debug, Default)]
+pub struct StoredPromptRegistry {
+    prompts: HashMap<String, StoredPrompt>,
+}
+
+impl StoredPromptRegistry {
+    pub fn new() -> Self {
+        Self {
+            prompts: HashMap::new(),
+        }
+    }
+
+    pub fn register(&mut self, id: String, prompt: StoredPrompt) -> Result<(), String> {
+        let trimmed = id.trim();
+        if trimmed.is_empty() {
+            return Err("prompt ID must not be empty".to_string());
+        }
+        if trimmed.as_bytes().iter().any(|b| b.is_ascii_control()) {
+            return Err("prompt ID must not contain control characters".to_string());
+        }
+        prompt.validate()?;
+        self.prompts.insert(trimmed.to_string(), prompt);
+        Ok(())
+    }
+
+    pub fn unregister(&mut self, id: &str) -> bool {
+        self.prompts.remove(id).is_some()
+    }
+
+    pub fn get(&self, id: &str) -> Option<&StoredPrompt> {
+        self.prompts.get(id)
+    }
+
+    pub fn list(&self) -> Vec<StoredPromptEntry> {
+        let mut ids: Vec<&String> = self.prompts.keys().collect();
+        ids.sort();
+        ids.into_iter()
+            .map(|id| StoredPromptEntry {
+                id: id.clone(),
+                prompt: self.prompts[id].clone(),
+            })
+            .collect()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.prompts.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.prompts.len()
+    }
+}
+
+/// Load stored prompts from a ConfigStore.
+pub async fn load_prompts(store: &ConfigStore) -> Result<PromptLoadReport, ConfigError> {
+    let mut report = PromptLoadReport::default();
+    let mut ids = store.list_prompt_ids().await?;
+    ids.sort();
+
+    for id in ids {
+        let record = match store.get_prompt(&id).await? {
+            Some(record) => record,
+            None => {
+                report.diagnostics.push(PromptLoadDiagnostic {
+                    prompt_id: id,
+                    issue: PromptLoadIssue::MissingRecord,
+                });
+                continue;
+            }
+        };
+
+        if record.schema_version != STORED_PROMPT_SCHEMA_VERSION {
+            report.diagnostics.push(PromptLoadDiagnostic {
+                prompt_id: record.id,
+                issue: PromptLoadIssue::UnsupportedSchemaVersion {
+                    version: record.schema_version,
+                },
+            });
+            continue;
+        }
+
+        let prompt: StoredPrompt = match serde_json::from_value(record.payload) {
+            Ok(prompt) => prompt,
+            Err(_) => {
+                report.diagnostics.push(PromptLoadDiagnostic {
+                    prompt_id: record.id,
+                    issue: PromptLoadIssue::InvalidPayload,
+                });
+                continue;
+            }
+        };
+
+        if prompt.validate().is_err() {
+            report.diagnostics.push(PromptLoadDiagnostic {
+                prompt_id: record.id,
+                issue: PromptLoadIssue::InvalidPayload,
+            });
+            continue;
+        }
+
+        report.loaded.push(StoredPromptEntry {
+            id: record.id,
+            prompt,
+        });
+    }
+
+    Ok(report)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stored_prompt_rejects_empty_instructions() {
+        let prompt = StoredPrompt {
+            instructions: "   ".to_string(),
+            skills: Vec::new(),
+            profile: None,
+        };
+        assert!(prompt.validate().is_err());
+    }
+
+    #[test]
+    fn registry_replaces_existing() {
+        let mut reg = StoredPromptRegistry::new();
+        let prompt = StoredPrompt {
+            instructions: "do thing".to_string(),
+            skills: Vec::new(),
+            profile: None,
+        };
+        reg.register("task".to_string(), prompt.clone()).unwrap();
+        reg.register("task".to_string(), prompt).unwrap();
+        assert_eq!(reg.len(), 1);
+    }
+
+    #[test]
+    fn registry_list_is_sorted() {
+        let mut reg = StoredPromptRegistry::new();
+        let prompt = StoredPrompt {
+            instructions: "do thing".to_string(),
+            skills: Vec::new(),
+            profile: None,
+        };
+        reg.register("b".to_string(), prompt.clone()).unwrap();
+        reg.register("a".to_string(), prompt).unwrap();
+        let list = reg.list();
+        assert_eq!(list[0].id, "a");
+        assert_eq!(list[1].id, "b");
+    }
+}

--- a/tests/acp_runtime_tests.rs
+++ b/tests/acp_runtime_tests.rs
@@ -16,13 +16,18 @@ use futures::StreamExt;
 use iron_core::{
     config::ApprovalStrategy,
     facade::{PermissionVerdict, PromptEvent, PromptOutcome, ToolResultStatus},
+    profile::{
+        AgentApproval, AgentProfile, AgentProfileId, AgentProfileProvider, SkillFilter, ToolFilter,
+    },
     skill::{LoadedSkill, SkillMetadata, SkillOrigin},
     tool::{FunctionTool, ToolDefinition},
     AuthInteractionResponse, AuthInteractionResult, AuthState, Config, ConnectionId, ContentBlock,
-    ContextManagementConfig, CreateSessionOptions, DurableSession, EphemeralTurn, IronAgent,
-    IronRuntime, OAuthRequirements, PluginHealth, PluginIdentity, PluginManifest, PluginPublisher,
-    PluginSource, PluginSourceConfig, PresentationMetadata, Provider, ProviderEvent, RuntimeError,
-    SessionId, ToolAuthRequirements, ToolRecordStatus, ToolTerminalOutcome, TurnPhase,
+    ContextManagementConfig, CreateSessionOptions, DelegationOutcome, DelegationResult,
+    DurableSession, EphemeralTurn, IronAgent, IronRuntime, OAuthRequirements, PluginHealth,
+    PluginIdentity, PluginManifest, PluginPublisher, PluginSource, PluginSourceConfig,
+    PresentationMetadata, Provider, ProviderEvent, RuntimeError, SessionId, StoredPrompt,
+    SubAgentToolPolicy, ToolAuthRequirements, ToolPolicyDiagnosticReason, ToolRecordStatus,
+    ToolTerminalOutcome, TurnPhase,
 };
 use iron_providers::{InferenceRequest, ToolCall};
 use serde_json::json;
@@ -347,6 +352,411 @@ fn activate_skill_duplicate_activation_returns_lightweight_confirmation() {
         let second_payload = second_payload.unwrap();
         assert_eq!(second_payload["status"], "already_active");
         assert!(second_payload.get("content").is_none());
+    });
+}
+
+#[test]
+fn delegate_task_runs_hidden_child_and_returns_final_text() {
+    run_local(async {
+        let provider = MockProvider::with_infer_responses(vec![
+            vec![ProviderEvent::ToolCall {
+                call: ToolCall::new(
+                    "dlg1",
+                    "delegate_task",
+                    json!({
+                        "goal": "Inspect the delegated work",
+                        "context": "Keep the result short",
+                        "max_iterations": 3
+                    }),
+                ),
+            }],
+            vec![
+                ProviderEvent::Output {
+                    content: "child completed".to_string(),
+                },
+                ProviderEvent::Complete,
+            ],
+            vec![ProviderEvent::Complete],
+        ]);
+        let agent = IronAgent::new(Config::default(), provider);
+        let conn = agent.connect();
+        let session = conn.create_session().unwrap();
+        let (_handle, mut events) = session.prompt_stream("delegate it");
+
+        let mut tool_result = None;
+        while let Some(event) = events.next().await {
+            if let PromptEvent::ToolResult {
+                call_id,
+                status,
+                result,
+                ..
+            } = event.clone()
+            {
+                if call_id == "dlg1" {
+                    tool_result = Some((status, result));
+                }
+            }
+            if matches!(event, PromptEvent::Complete { .. }) {
+                break;
+            }
+        }
+
+        let (status, payload) = tool_result.expect("expected delegate_task result");
+        assert_eq!(status, ToolResultStatus::Completed);
+        let result: DelegationResult =
+            serde_json::from_value(payload.expect("expected delegate_task payload"))
+                .expect("delegate_task result should deserialize");
+        assert_eq!(result.outcome, DelegationOutcome::EndTurn);
+        assert_eq!(result.final_text.as_deref(), Some("child completed"));
+
+        let hidden = conn.hidden_sessions();
+        assert_eq!(hidden.len(), 1);
+        assert_eq!(hidden[0].session_id, result.child_session_id);
+
+        let child = agent
+            .runtime()
+            .get_session(result.child_session_id)
+            .expect("child session should remain inspectable");
+        let child = child.lock();
+        assert!(child
+            .messages
+            .iter()
+            .any(|m| { m.is_user() && m.text_content().contains("Inspect the delegated work") }));
+        assert!(child
+            .messages
+            .iter()
+            .any(|m| { m.is_user() && m.text_content().contains("Keep the result short") }));
+    });
+}
+
+fn delegate_task_child_approval_records_status(
+    verdict: PermissionVerdict,
+    expected_status: ToolRecordStatus,
+) {
+    run_local(async move {
+        let provider = MockProvider::with_infer_responses(vec![
+            vec![ProviderEvent::ToolCall {
+                call: ToolCall::new(
+                    "dlg-approval",
+                    "delegate_task",
+                    json!({"goal": "Call the risky child tool"}),
+                ),
+            }],
+            vec![
+                ProviderEvent::ToolCall {
+                    call: ToolCall::new("child-risk", "child_risky", json!({"ok": true})),
+                },
+                ProviderEvent::Complete,
+            ],
+            vec![
+                ProviderEvent::Output {
+                    content: "child done".to_string(),
+                },
+                ProviderEvent::Complete,
+            ],
+            vec![ProviderEvent::Complete],
+        ]);
+        let agent = IronAgent::new(Config::default(), provider);
+        let executions = Arc::new(AtomicUsize::new(0));
+        let exec_clone = executions.clone();
+        agent.register_tool(FunctionTool::new(
+            ToolDefinition::new("child_risky", "child_risky", json!({})).with_approval(true),
+            move |_| {
+                exec_clone.fetch_add(1, Ordering::SeqCst);
+                Ok(json!({"ok": true}))
+            },
+        ));
+        let conn = agent.connect();
+        let session = conn.create_session().unwrap();
+        let (handle, mut events) = session.prompt_stream("delegate it");
+
+        while let Some(event) = events.next().await {
+            match event {
+                PromptEvent::ApprovalRequest { ref call_id, .. } => {
+                    match verdict {
+                        PermissionVerdict::AllowOnce => handle.approve(call_id).unwrap(),
+                        PermissionVerdict::Deny => handle.deny(call_id).unwrap(),
+                        PermissionVerdict::Cancel => {
+                            handle.cancel().await;
+                        }
+                    };
+                }
+                PromptEvent::Complete { .. } => break,
+                _ => {}
+            }
+        }
+
+        let hidden = conn.hidden_sessions();
+        assert_eq!(hidden.len(), 1);
+        let child = agent.runtime().get_session(hidden[0].session_id).unwrap();
+        let records = child.lock().tool_records.clone();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].call_id, "child-risk");
+        assert_eq!(records[0].status, expected_status);
+        assert_eq!(
+            executions.load(Ordering::SeqCst),
+            usize::from(verdict == PermissionVerdict::AllowOnce)
+        );
+    });
+}
+
+#[test]
+fn delegated_child_propagated_approval_allow_is_recorded() {
+    delegate_task_child_approval_records_status(
+        PermissionVerdict::AllowOnce,
+        ToolRecordStatus::Completed,
+    );
+}
+
+#[test]
+fn delegated_child_propagated_approval_denial_is_recorded() {
+    delegate_task_child_approval_records_status(PermissionVerdict::Deny, ToolRecordStatus::Denied);
+}
+
+#[test]
+fn delegated_child_propagated_approval_cancellation_is_recorded() {
+    delegate_task_child_approval_records_status(
+        PermissionVerdict::Cancel,
+        ToolRecordStatus::Cancelled,
+    );
+}
+
+#[test]
+fn cancelling_parent_session_cancels_active_child_prompt() {
+    let rt = IronRuntime::new(Config::default(), MockProvider::default());
+    let conn = rt.new_connection();
+    let (parent_id, _) = rt.create_session(conn).unwrap();
+    let (child_id, _) = rt.create_hidden_session(conn).unwrap();
+    rt.register_child(parent_id, child_id).unwrap();
+
+    let parent_turn = rt.try_start_prompt(parent_id).unwrap();
+    let child_turn = rt.try_start_prompt(child_id).unwrap();
+
+    assert!(rt.cancel_active_prompt(parent_id));
+    assert!(parent_turn.lock().is_cancel_requested());
+    assert!(child_turn.lock().is_cancel_requested());
+}
+
+#[test]
+fn closing_parent_session_removes_child_relationships_and_sessions() {
+    let rt = IronRuntime::new(Config::default(), MockProvider::default());
+    let conn = rt.new_connection();
+    let (parent_id, _) = rt.create_session(conn).unwrap();
+    let (child_id, _) = rt.create_hidden_session(conn).unwrap();
+    rt.register_child(parent_id, child_id).unwrap();
+
+    rt.close_session(parent_id);
+
+    assert!(rt.get_session(parent_id).is_none());
+    assert!(rt.get_session(child_id).is_none());
+    assert!(rt.list_child_sessions(parent_id).is_empty());
+    assert!(rt.list_hidden_sessions().is_empty());
+}
+
+#[test]
+fn child_tool_policy_reports_inheritance_additions_filters_and_diagnostics() {
+    let rt = IronRuntime::new(Config::default(), MockProvider::default());
+    rt.register_tool(FunctionTool::simple("parent_tool", "parent_tool", |_| {
+        Ok(json!({"ok": true}))
+    }));
+    rt.register_tool(FunctionTool::simple("extra_tool", "extra_tool", |_| {
+        Ok(json!({"ok": true}))
+    }));
+    let conn = rt.new_connection();
+    let (parent_id, parent) = rt.create_session(conn).unwrap();
+    parent.lock().hidden_tools.push("extra_tool".to_string());
+
+    let inherited = rt
+        .derive_child_tool_catalog(
+            parent_id,
+            &AgentProfile {
+                name: "default".to_string(),
+                provider: AgentProfileProvider::RuntimeDefault,
+                tools: ToolFilter::Inherit,
+                skills: SkillFilter::Inherit,
+                approval: AgentApproval::PerTool,
+                identity_prompt: None,
+            },
+            &SubAgentToolPolicy {
+                deny: vec!["parent_tool".to_string()],
+                additions: vec!["extra_tool".to_string()],
+                ..SubAgentToolPolicy::inherit_parent()
+            },
+        )
+        .unwrap();
+    assert!(inherited.removed_tools.contains(&"parent_tool".to_string()));
+    assert!(inherited.added_tools.contains(&"extra_tool".to_string()));
+    assert!(inherited.unavailable_requested_additions.is_empty());
+    assert!(!inherited.digest.is_empty());
+
+    let filtered = rt
+        .derive_child_tool_catalog(
+            parent_id,
+            &AgentProfile {
+                name: "limited".to_string(),
+                provider: AgentProfileProvider::RuntimeDefault,
+                tools: ToolFilter::Allow(vec!["parent_tool".to_string()]),
+                skills: SkillFilter::Inherit,
+                approval: AgentApproval::PerTool,
+                identity_prompt: None,
+            },
+            &SubAgentToolPolicy {
+                additions: vec!["extra_tool".to_string(), "missing_tool".to_string()],
+                ..SubAgentToolPolicy::inherit_parent()
+            },
+        )
+        .unwrap();
+    assert!(filtered
+        .excluded_by_profile
+        .contains(&"extra_tool".to_string()));
+    assert!(filtered
+        .unavailable_requested_additions
+        .contains(&"missing_tool".to_string()));
+    assert!(filtered.diagnostics.iter().any(|diagnostic| {
+        diagnostic.tool_name == "extra_tool"
+            && diagnostic.reason == ToolPolicyDiagnosticReason::ExcludedByProfile
+    }));
+    assert!(filtered.diagnostics.iter().any(|diagnostic| {
+        diagnostic.tool_name == "missing_tool"
+            && diagnostic.reason == ToolPolicyDiagnosticReason::Missing
+    }));
+}
+
+#[test]
+fn child_tool_policy_diagnoses_unavailable_plugin_tool() {
+    let agent = IronAgent::new(Config::default(), MockProvider::default());
+    register_test_auth_plugin(&agent, "auth-plugin");
+    let rt = agent.runtime();
+
+    let conn = rt.new_connection();
+    let (parent_id, parent) = rt.create_session(conn).unwrap();
+    parent.lock().set_plugin_enabled("auth-plugin", true);
+
+    let result = rt
+        .derive_child_tool_catalog(
+            parent_id,
+            &AgentProfile {
+                name: "default".to_string(),
+                provider: AgentProfileProvider::RuntimeDefault,
+                tools: ToolFilter::Inherit,
+                skills: SkillFilter::Inherit,
+                approval: AgentApproval::PerTool,
+                identity_prompt: None,
+            },
+            &SubAgentToolPolicy {
+                additions: vec!["plugin_auth-plugin_gated_tool".to_string()],
+                ..SubAgentToolPolicy::inherit_parent()
+            },
+        )
+        .unwrap();
+
+    assert!(result
+        .unavailable_requested_additions
+        .contains(&"plugin_auth-plugin_gated_tool".to_string()));
+    assert!(result.diagnostics.iter().any(|diagnostic| {
+        diagnostic.tool_name == "plugin_auth-plugin_gated_tool"
+            && matches!(
+                diagnostic.reason,
+                ToolPolicyDiagnosticReason::PluginAuthRequired { .. }
+            )
+    }));
+}
+
+#[test]
+fn run_task_activates_stored_prompt_requested_skills() {
+    run_local(async {
+        let provider = MockProvider::with_infer_responses(vec![
+            vec![ProviderEvent::ToolCall {
+                call: ToolCall::new("task1", "run_task", json!({"task_id": "review-task"})),
+            }],
+            vec![ProviderEvent::Complete],
+            vec![ProviderEvent::Complete],
+        ]);
+        let agent = IronAgent::new(Config::default(), provider);
+        agent
+            .runtime()
+            .register_skill(make_skill("review", "Review code"));
+        agent
+            .register_stored_prompt(
+                "review-task",
+                StoredPrompt {
+                    instructions: "Review this change".to_string(),
+                    skills: vec!["review".to_string()],
+                    profile: None,
+                },
+            )
+            .unwrap();
+
+        let conn = agent.connect();
+        let session = conn.create_session().unwrap();
+        let (_handle, mut events) = session.prompt_stream("run it");
+
+        while let Some(event) = events.next().await {
+            if matches!(event, PromptEvent::Complete { .. }) {
+                break;
+            }
+        }
+
+        let hidden = conn.hidden_sessions();
+        assert_eq!(hidden.len(), 1);
+        let child = agent.runtime().get_session(hidden[0].session_id).unwrap();
+        assert_eq!(child.lock().list_active_skills(), vec!["review"]);
+    });
+}
+
+#[test]
+fn run_task_requested_skills_respect_profile_filter() {
+    run_local(async {
+        let provider = MockProvider::with_infer_responses(vec![
+            vec![ProviderEvent::ToolCall {
+                call: ToolCall::new("task2", "run_task", json!({"task_id": "blocked-task"})),
+            }],
+            vec![ProviderEvent::Complete],
+            vec![ProviderEvent::Complete],
+        ]);
+        let agent = IronAgent::new(Config::default(), provider);
+        let profile_id = AgentProfileId::from("limited");
+        agent
+            .register_profile(
+                profile_id.clone(),
+                AgentProfile {
+                    name: "limited".to_string(),
+                    provider: AgentProfileProvider::RuntimeDefault,
+                    tools: ToolFilter::Inherit,
+                    skills: SkillFilter::Allow(vec!["allowed".to_string()]),
+                    approval: AgentApproval::PerTool,
+                    identity_prompt: None,
+                },
+            )
+            .unwrap();
+        agent
+            .runtime()
+            .register_skill(make_skill("blocked", "Blocked"));
+        agent
+            .register_stored_prompt(
+                "blocked-task",
+                StoredPrompt {
+                    instructions: "Try blocked skill".to_string(),
+                    skills: vec!["blocked".to_string()],
+                    profile: Some(profile_id),
+                },
+            )
+            .unwrap();
+
+        let conn = agent.connect();
+        let session = conn.create_session().unwrap();
+        let (_handle, mut events) = session.prompt_stream("run it");
+
+        while let Some(event) = events.next().await {
+            if matches!(event, PromptEvent::Complete { .. }) {
+                break;
+            }
+        }
+
+        let hidden = conn.hidden_sessions();
+        assert_eq!(hidden.len(), 1);
+        let child = agent.runtime().get_session(hidden[0].session_id).unwrap();
+        assert!(child.lock().list_active_skills().is_empty());
     });
 }
 

--- a/tests/profile_tests.rs
+++ b/tests/profile_tests.rs
@@ -1,6 +1,7 @@
 use futures::stream::{self, BoxStream};
 use futures::StreamExt;
-use iron_core::config::{ConfigStore, ProfileInput};
+use iron_core::config::{ConfigStore, ProfileInput, PromptInput};
+use iron_core::STORED_PROMPT_SCHEMA_VERSION;
 use iron_core::{
     profile::{
         default_identity_prompt, normalize_profile_name, AgentApproval, AgentProfile,
@@ -14,7 +15,7 @@ use iron_core::{
         store::{InMemoryCredentialStore, ProviderCredentialStore},
         DurableCredentialStore,
     },
-    Config, IronAgent, IronRuntime, PromptOutcome,
+    Config, IronAgent, IronRuntime, PromptOutcome, StoredPrompt,
     PROFILE_SCHEMA_VERSION as EXPORTED_SCHEMA_VERSION,
 };
 use iron_providers::{InferenceRequest, Provider, ProviderEvent};
@@ -1024,4 +1025,75 @@ fn blank_identity_prompt_falls_back_to_default() {
         profile.effective_identity_prompt(),
         default_identity_prompt()
     );
+}
+
+#[test]
+fn stored_prompt_registry_crud_is_deterministic() {
+    let agent = test_agent();
+    let prompt = StoredPrompt {
+        instructions: "Review the latest changes".to_string(),
+        skills: Vec::new(),
+        profile: None,
+    };
+
+    agent
+        .register_stored_prompt("review", prompt.clone())
+        .unwrap();
+
+    assert_eq!(agent.get_stored_prompt("review").unwrap().prompt, prompt);
+    assert_eq!(agent.list_stored_prompts()[0].id, "review");
+    assert!(agent.unregister_stored_prompt("review"));
+    assert!(agent.get_stored_prompt("review").is_none());
+}
+
+#[tokio::test]
+async fn load_stored_prompts_populates_registry() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+    let prompt = StoredPrompt {
+        instructions: "Summarize this session".to_string(),
+        skills: vec!["summarizer".to_string()],
+        profile: None,
+    };
+    store
+        .set_prompt(&PromptInput {
+            id: "summary".to_string(),
+            schema_version: STORED_PROMPT_SCHEMA_VERSION,
+            payload: serde_json::to_value(&prompt).unwrap(),
+        })
+        .await
+        .unwrap();
+
+    let agent = test_agent();
+    let report = agent.load_stored_prompts(&store).await.unwrap();
+
+    assert_eq!(report.loaded.len(), 1);
+    assert_eq!(agent.get_stored_prompt("summary").unwrap().prompt, prompt);
+}
+
+#[test]
+fn connection_can_inspect_hidden_child_sessions() {
+    let agent = test_agent();
+    let conn = agent.connect();
+    let parent = conn.create_session().unwrap();
+    let (child_session_id, _) = agent.runtime().create_hidden_session(conn.id()).unwrap();
+
+    agent
+        .runtime()
+        .register_child(parent.id(), child_session_id)
+        .unwrap();
+
+    assert!(!conn.active_sessions().contains(&child_session_id));
+    assert!(conn
+        .active_sessions_include_hidden()
+        .contains(&child_session_id));
+    assert_eq!(
+        conn.child_sessions(&parent).unwrap(),
+        vec![child_session_id]
+    );
+
+    let hidden = conn.hidden_sessions();
+    assert_eq!(hidden.len(), 1);
+    assert_eq!(hidden[0].session_id, child_session_id);
+    assert_eq!(hidden[0].connection_id, conn.id());
+    assert_eq!(hidden[0].parent_session_id, Some(parent.id()));
 }


### PR DESCRIPTION
## Summary
- add delegated child-agent execution via delegate_task with hidden inspectable child sessions
- add stored prompt registry/loading and run_task invocation through delegation
- add child tool policy derivation, diagnostics, approval routing, cancellation propagation, and OpenSpec archive/spec sync

## Verification
- cargo fmt
- cargo check
- openspec validate delegated-tasks-and-stored-prompts --strict
- openspec validate delegated-task-tool --strict
- openspec validate stored-prompts --strict
- cargo test --test acp_runtime_tests
- cargo test --test profile_tests
- cargo test delegation::sink::tests

Closes #57
Closes #62

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added delegated task execution (`delegate_task`) for bounded hidden child sessions with optional profile selection.
  * Added typed stored prompts plus reusable invocation (`run_task`) with profile- and skill-aware behavior.
  * Added child tool approval routing modes (auto-approve vs propagate to parent approval workflow).
  * Added APIs to inspect hidden sessions and view delegated child session relationships.

* **Improvements**
  * Enforced policy-bounded tool catalogs with deterministic tool-policy diagnostics and digest reporting.
  * Improved cancellation propagation across parent/child sessions.
  * Enhanced MCP tool diagnostics and single-tool inspection; improved handling of unknown prompt outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->