### PR TITLE
feat(profiles): seed default agent profiles with session policy snapshot

### DIFF
--- a/openspec/changes/seed-default-agent-profiles/.openspec.yaml
+++ b/openspec/changes/seed-default-agent-profiles/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-16

--- a/openspec/changes/seed-default-agent-profiles/design.md
+++ b/openspec/changes/seed-default-agent-profiles/design.md
@@ -1,0 +1,131 @@
+## Context
+
+Issue #80 is the next profile-foundation slice after profile identity was moved into system prompt Section 1. Existing `AgentProfile` records can represent identity, provider/model selection, tool policy, skill policy, and approval posture, and `ConfigStore` already persists opaque profile records. What is missing is the product-level bootstrap and interpretation contract: how shipped profiles appear in the store, how deleting/editing them is respected, and how selected profile policy becomes effective for a session.
+
+The central constraint is that `explore`, `plan`, and `apply` are ordinary records. They must not become hidden modes, reserved IDs, immutable built-ins, or runtime branches. The implementation should make profile foundations robust enough that the shipped default profile contents can evolve later without changing the architecture.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Provide core-owned shipped `AgentProfile` definitions for `explore`, `plan`, and `apply`.
+- Provide a canonical, idempotent, non-destructive seeding API for those shipped defaults.
+- Preserve user deletion and edits during normal startup by using durable first-run seed state.
+- Provide explicit restore-missing behavior for callers that intentionally want shipped defaults recreated.
+- Snapshot selected profile policy into the session so active sessions do not drift when stored profiles are edited.
+- Make `AutoApprove` functionally bypass approval prompts for profile-backed sessions.
+- Reject `ReadOnly` as a profile approval schema/API value.
+- Apply profile tool filters to the primary session's effective tool catalog using exact canonical model-visible tool names.
+- Resolve explicit profile provider/model references against the effective catalog and provider/credential machinery with warning-backed fallback to runtime default.
+
+**Non-Goals:**
+
+- No hard read-only sandboxing, path-scoped write policy, or semantic tool capability taxonomy.
+- No mid-session profile switching or implicit live profile reload.
+- No user-defined provider/model creation UI or profile-embedded provider definitions.
+- No automatic updates of existing seeded profile records when shipped defaults change in a future release.
+- No destructive reset/overwrite-defaults operation in this issue.
+- No special runtime behavior based on the strings `explore`, `plan`, or `apply` after seeding.
+
+## Decisions
+
+### 1. Use durable first-run seed state, not profile existence alone
+
+Normal bootstrap must distinguish "defaults have never been seeded" from "defaults were seeded and the user deleted one." Existence-only logic cannot make that distinction and would silently recreate deleted defaults. Add durable bootstrap metadata such as `agent_profiles.default_seed.version = 1` and have the seed operation write it after the first normal seed attempt.
+
+Alternatives considered:
+
+- **Existence-based seeding:** simpler, but violates deletability because missing shipped profiles reappear on every startup.
+- **Tombstones:** precise, but requires delete-path special casing for shipped IDs and makes shipped defaults less ordinary.
+- **Hidden profile marker record:** avoids a new metadata API, but pollutes the profile namespace and leaks special records into list/export concerns.
+
+### 2. Core owns the seed operation; frontends call it
+
+`iron-core` should expose the shipped definitions and the seed/restore operation instead of asking AgentIron UI, CLI, and future schedulers to reimplement bootstrap semantics. Frontends should receive a report describing created, skipped, and diagnostic outcomes.
+
+Candidate API shape:
+
+```rust
+enum DefaultProfileSeedPolicy {
+    FirstRunOnly,
+    RestoreMissing,
+}
+
+struct DefaultProfileSeedReport {
+    policy: DefaultProfileSeedPolicy,
+    marker_was_present: bool,
+    marker_written: bool,
+    created: Vec<AgentProfileId>,
+    skipped_existing: Vec<AgentProfileId>,
+    diagnostics: Vec<DefaultProfileSeedDiagnostic>,
+}
+```
+
+`FirstRunOnly` creates missing shipped defaults only when the seed marker is absent, then writes the marker. `RestoreMissing` creates missing shipped defaults regardless of marker state, but still preserves existing records.
+
+### 3. Shipped defaults are bootstrap templates only
+
+Once a shipped profile is persisted, it is user data. Normal startup must not overwrite existing `explore`, `plan`, or `apply` records, even if they differ from current shipped definitions. Future product UX may offer compare/reset/update flows, but this issue only provides first-run seeding and non-destructive restore-missing behavior.
+
+Default seeded records should use:
+
+- `AgentProfileProvider::RuntimeDefault`
+- `ToolFilter::Inherit`
+- `SkillFilter::Inherit`
+- `AgentApproval::PerTool` unless a caller intentionally changes a profile later
+- profile-specific identity prompts for explore/plan/apply stance
+
+### 4. Snapshot selected profile policy into the session
+
+Stored profiles are templates for future sessions. Selecting a profile should snapshot the effective execution policy into the session: profile ID, identity, tool filter, approval policy, and provider/model resolution outcome/diagnostics. Later edits or deletion of the stored profile must not implicitly mutate existing sessions.
+
+This avoids prompt-cache churn, unexpected tool-catalog changes, and approval-policy drift in active conversations. A future explicit profile-switch/reload API can intentionally invalidate caches and recompute session policy; it is out of scope here.
+
+### 5. Apply tool filters during session tool catalog construction
+
+Profile `ToolFilter` should remain policy, not a one-time expansion into hidden tools. Store the session-effective filter and apply it whenever the session tool catalog is built or rebuilt. Exact names are canonical model-visible tool names after MCP/plugin namespacing.
+
+Semantics:
+
+- `Inherit`: no profile-level filtering.
+- `Allow(names)`: only listed canonical tool names are visible/executable if available.
+- `Deny(names)`: listed canonical tool names are hidden/rejected if available.
+
+Unknown names should be accepted in stored/imported profile data to support cross-machine sync, but session preparation may emit diagnostics.
+
+### 6. Make `AutoApprove` operational and reject `ReadOnly`
+
+Profile approval surface for this milestone is exactly `PerTool` and `AutoApprove`. `AutoApprove` must bypass approval prompts for the session. `ReadOnly` should be rejected during profile registration/loading/import rather than silently mapped, because it implies an enforcement guarantee this milestone does not provide.
+
+Read-only stance is represented through identity prompt text and optional explicit tool filtering.
+
+### 7. Provider/model fallback is setup-time only
+
+Profile configuration may reference provider/model pairs unavailable on the current machine. Import/loading should preserve those references if shape is valid. During session setup, explicit profile provider/model references are checked against the effective catalog and provider/credential resolution. If unavailable, return a warning diagnostic and fall back to the runtime default provider path. If the runtime default is unavailable, fail with an actionable error that includes the original explicit-reference failure where possible.
+
+Fallback must not happen after inference starts. Mid-turn provider failures should remain explicit failures so users can debug the selected provider/model.
+
+## Risks / Trade-offs
+
+- **Risk: adding seed metadata expands ConfigStore scope.** → Keep the metadata API narrow and domain-oriented; do not expose SQLite tables directly or use fake profile records.
+- **Risk: users expect profile edits to affect active sessions immediately.** → Document that profile edits affect future sessions; future explicit profile-switch/reload can be designed with cache invalidation and user-visible events.
+- **Risk: `AutoApprove` increases destructive-action exposure.** → Make it explicit in profile policy, include it in session diagnostics/debug state, and keep shipped defaults at `PerTool`.
+- **Risk: exact tool names are brittle across plugin/MCP availability.** → Accept unknown names in profile data and surface session diagnostics rather than failing load/import.
+- **Risk: provider fallback hides model mismatch.** → Restrict fallback to setup-time resolution and surface warnings through structured diagnostics, not logs only.
+
+## Migration Plan
+
+1. Add config-store bootstrap metadata support or use an existing domain-scoped settings API if one is already present.
+2. Add first-run seed marker migration/default handling without altering existing profile records.
+3. Introduce shipped default profile definitions and seed/restore API.
+4. Extend session state and handoff state, if needed, with effective profile policy snapshot fields.
+5. Wire prompt/session preparation to use session-effective tool filter, approval policy, and provider/model resolution diagnostics.
+6. Preserve existing profile records; do not modify user data during migration except when the caller explicitly invokes seed/restore.
+
+Rollback is straightforward: seeded profiles are ordinary records and can be deleted. The seed marker can remain inert if the seeding API is not called.
+
+## Open Questions
+
+- What exact config-store primitive should hold the seed marker if a generic domain-scoped settings API already exists but is not currently exposed in public code?
+- Should seed/restore diagnostics be profile-specific domain types only, or should they reuse a broader diagnostics/event mechanism if one exists?
+- Should handoff carry only the effective policy snapshot, or both snapshot plus original profile ID for display? The design preference is snapshot for behavior plus profile ID for traceability.

--- a/openspec/changes/seed-default-agent-profiles/proposal.md
+++ b/openspec/changes/seed-default-agent-profiles/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+Agent profiles are now the user-facing abstraction for reusable agent identity and execution policy, but the product still lacks a canonical bootstrap path for shipped profiles and a complete session-scoped interpretation of profile policy. This change establishes the foundation: ordinary persisted default profile records, non-destructive seeding, functional approval policy, exact-name tool filtering, and provider/model fallback diagnostics.
+
+## What Changes
+
+- Add core-owned shipped `AgentProfile` definitions for `explore`, `plan`, and `apply` as normal persisted profile payloads, not runtime modes or immutable built-ins.
+- Add an idempotent default-profile seed API using durable first-run seed state so normal bootstrap does not recreate user-deleted shipped profiles.
+- Add an explicit non-destructive restore-missing-defaults operation for callers that intentionally want deleted shipped defaults recreated.
+- Snapshot the selected profile's effective execution policy into a session at session setup; later stored-profile edits affect future sessions only.
+- Make `AgentApproval::AutoApprove` functional for profile-backed sessions.
+- Reject `ReadOnly` as a user-facing profile approval value; read-only behavior belongs in identity prompts and explicit tool policy.
+- Apply profile `ToolFilter` policy to primary session tool catalogs by exact canonical model-visible tool names.
+- Resolve explicit profile provider/model references using the effective model catalog and existing provider/credential resolution, warning and falling back to runtime default when explicit references are unavailable.
+- Keep shipped profiles provider/model-neutral by default (`RuntimeDefault`) and tool/skill-neutral by default (`Inherit`).
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `agent-profiles`: Add shipped ordinary default profile definitions, seed/restore semantics, session policy snapshots, functional approval policy, profile tool filtering, provider/model fallback diagnostics, and rejection of `ReadOnly` profile approval.
+- `core-config-store`: Add durable bootstrap metadata needed to distinguish first-run default-profile seeding from user-deleted shipped defaults.
+- `effective-model-catalog`: Define how profile provider/model availability checks use the effective catalog without making unavailable references config-invalid.
+
+## Impact
+
+- Affected modules likely include `src/profile/`, `src/config/`, `src/runtime.rs`, `src/durable.rs`, `src/request_builder.rs`, `src/prompt_runner.rs`, `src/mcp/` or session tool catalog construction, and profile-related tests.
+- Adds or extends public APIs for default profile definitions, seed/restore operations, seed reports/diagnostics, profile session preparation, and profile resolution diagnostics.
+- May require a config-store migration or existing settings-domain extension for durable bootstrap metadata.
+- Requires tests for idempotent seeding, deletion preservation, restore-missing behavior, session policy snapshotting, functional `AutoApprove`, `ReadOnly` rejection, exact-name tool filtering, and provider/model fallback diagnostics.

--- a/openspec/changes/seed-default-agent-profiles/specs/agent-profiles/spec.md
+++ b/openspec/changes/seed-default-agent-profiles/specs/agent-profiles/spec.md
@@ -1,0 +1,233 @@
+## MODIFIED Requirements
+
+### Requirement: Core SHALL define typed agent identity profiles
+
+The system SHALL provide public `AgentProfile`, `AgentProfileId`, `AgentProfileEntry`, a profile provider context enum, profile load report/diagnostic types, `ToolFilter`, `SkillFilter`, and `AgentApproval` types that can represent the user-facing name, provider selection, managed provider/model selection, tool availability policy, skill availability policy, agent approval policy, and optional `identity_prompt` for an agent identity profile.
+
+#### Scenario: Profile captures provider and model selection
+- **WHEN** a caller constructs an `AgentProfile`
+- **THEN** the profile includes a profile provider context that can represent either the runtime default provider path or a managed provider slug and model
+- **AND** the profile can also carry a user-facing name, tool filtering, skill filtering, approval policy, and optional `identity_prompt`
+
+#### Scenario: Runtime default provider is representable
+- **WHEN** a caller or the built-in default profile needs to use the runtime's injected/default provider path
+- **THEN** the profile provider context can represent `RuntimeDefault` without requiring a provider slug
+
+#### Scenario: User profile can use runtime default provider
+- **WHEN** a user-defined profile needs custom identity, tool, skill, or approval policy while keeping the runtime's current provider path
+- **THEN** the profile provider context can use `RuntimeDefault`
+- **AND** the profile remains distinct from the protected built-in default profile by stable ID and user-facing name
+
+#### Scenario: Managed provider is representable
+- **WHEN** a caller configures a user profile for managed provider resolution
+- **THEN** the profile provider context can represent provider slug and model
+- **AND** does not include an API-key field
+
+#### Scenario: Profile entry pairs ID with profile
+- **WHEN** a caller lists or loads profiles
+- **THEN** each successfully registered profile can be represented as an `AgentProfileEntry` containing the stable `AgentProfileId` and the full `AgentProfile`
+
+#### Scenario: Profile context omits API keys
+- **WHEN** a caller constructs or loads an `AgentProfile`
+- **THEN** the profile API does not expose an API-key field
+- **AND** the profile cannot persist per-profile credential secret material through its provider/model context
+
+#### Scenario: Tool filter variants are representable
+- **WHEN** a caller configures tool filtering for a profile
+- **THEN** the system can represent inherited tools, an allowlist of canonical model-visible tool names, or a denylist of canonical model-visible tool names
+
+#### Scenario: Skill filter variants are representable
+- **WHEN** a caller configures skill filtering for a profile
+- **THEN** the system can represent no skills, an allowlist of skill names, or inherited skills
+
+#### Scenario: Agent approval variants are representable
+- **WHEN** a caller configures approval policy for a profile
+- **THEN** the user-facing profile schema can represent per-tool approval or auto-approval
+- **AND** it rejects read-only approval as an unsupported profile approval value
+
+### Requirement: Core SHALL expose profile-to-provider resolution
+
+The system SHALL provide profile provider resolution that resolves the selected profile's provider context. The resolution result SHALL be able to represent both the runtime-owned default provider path and an owned managed provider constructed through credential resolution. Explicit managed profile provider/model references that are unavailable on the current machine SHALL produce structured diagnostics and fall back to the runtime default provider path during session setup when the runtime default is usable.
+
+#### Scenario: Managed profile provider resolves successfully
+- **WHEN** a profile references a known provider and model with usable credentials
+- **THEN** `IronRuntime::resolve_profile_provider` returns a resolved managed provider constructed through the provider registry
+- **AND** credential resolution uses iron-core credential state and OAuth refresh behavior without a profile-supplied API key
+- **AND** the resolution diagnostics do not include a fallback warning
+
+#### Scenario: Runtime default provider resolves through existing provider
+- **WHEN** profile provider resolution is requested for a profile using the runtime default provider context
+- **THEN** the runtime uses a resolved provider representation for its existing injected/default provider path
+- **AND** does not require a managed provider slug or credential resolver for that profile
+- **AND** does not emit an unavailable-reference warning
+
+#### Scenario: Explicit unavailable provider falls back to runtime default
+- **WHEN** profile provider resolution is requested for a profile using an explicit managed provider/model reference
+- **AND** that explicit reference cannot produce a usable provider because the provider slug is unknown, the model is unknown, the provider is disabled, credentials are missing, the credential mode is unsupported, or provider construction fails
+- **AND** the runtime default provider path is usable
+- **THEN** resolution returns the runtime default provider path
+- **AND** includes a structured warning diagnostic describing the unavailable explicit reference and fallback
+
+#### Scenario: Explicit unavailable provider fails when fallback unavailable
+- **WHEN** profile provider resolution is requested for a profile using an explicit managed provider/model reference
+- **AND** that explicit reference cannot produce a usable provider
+- **AND** the runtime default provider path is not usable
+- **THEN** resolution fails with an actionable error
+- **AND** the error or diagnostics preserve the explicit-reference failure reason
+
+#### Scenario: Setup-time fallback does not mask inference failure
+- **WHEN** provider/model resolution succeeds and inference has started
+- **AND** the selected provider later fails during a request
+- **THEN** the runtime surfaces the provider failure
+- **AND** does not silently fall back to another provider/model mid-turn
+
+### Requirement: Core SHALL add AutoApprove approval plumbing
+
+The system SHALL expose an `AgentApproval::AutoApprove` variant so profile approval policy can be represented distinctly from per-tool approval and can be applied as a functional session-effective approval policy.
+
+#### Scenario: AutoApprove is representable
+- **WHEN** code maps or stores an auto-approval profile policy
+- **THEN** the policy can be represented with `AgentApproval::AutoApprove`
+
+#### Scenario: AutoApprove bypasses session approval prompts
+- **WHEN** a session is prepared from a profile whose approval policy is `AutoApprove`
+- **AND** a model-visible tool call would otherwise require approval under per-tool policy
+- **THEN** the session approval evaluator treats the call as approved without prompting
+
+#### Scenario: PerTool behavior remains stable
+- **WHEN** a session is prepared from a profile whose approval policy is `PerTool`
+- **THEN** runtime tool approval checks continue to defer to each tool's approval requirement
+
+#### Scenario: ReadOnly approval is rejected
+- **WHEN** a profile payload, import, or registration request uses read-only approval policy
+- **THEN** the profile is rejected with a diagnostic or validation error
+- **AND** the runtime does not silently map read-only approval to a weaker policy
+
+## ADDED Requirements
+
+### Requirement: Core SHALL provide shipped default profile definitions
+
+The system SHALL provide core-owned shipped `AgentProfile` definitions for `explore`, `plan`, and `apply`. These definitions SHALL be bootstrap templates for ordinary persisted profile records and SHALL NOT introduce runtime modes, reserved profile IDs, immutable built-ins, or profile-name special-casing.
+
+#### Scenario: Shipped default definitions are ordinary profile payloads
+- **WHEN** a caller requests the shipped default profile definitions
+- **THEN** the system returns profile IDs and `AgentProfile` payloads for `explore`, `plan`, and `apply`
+- **AND** those payloads can be stored through normal ConfigStore profile APIs
+
+#### Scenario: Shipped defaults use runtime-neutral configuration
+- **WHEN** shipped default profile definitions are generated
+- **THEN** each profile uses `AgentProfileProvider::RuntimeDefault`
+- **AND** each profile uses `ToolFilter::Inherit`
+- **AND** each profile uses `SkillFilter::Inherit`
+
+#### Scenario: Shipped defaults are not runtime modes
+- **WHEN** a session is prepared from a profile whose ID is `explore`, `plan`, or `apply`
+- **THEN** runtime behavior is derived from the persisted profile fields
+- **AND** the runtime does not branch on those IDs or names to add hidden behavior
+
+### Requirement: Core SHALL seed shipped default profiles non-destructively
+
+The system SHALL provide a core-owned seed operation that can create shipped default profile records in ConfigStore without overwriting existing records. Normal first-run seeding SHALL use durable seed state so user-deleted shipped profiles are not silently recreated on later startup.
+
+#### Scenario: First-run seeding creates missing defaults
+- **WHEN** the default profile seed operation runs with `FirstRunOnly` policy
+- **AND** the durable seed marker is absent
+- **AND** no shipped default profile records exist
+- **THEN** the operation creates `explore`, `plan`, and `apply` as normal profile records
+- **AND** writes the durable seed marker
+- **AND** returns a report listing the created profile IDs
+
+#### Scenario: First-run seeding preserves existing records
+- **WHEN** the default profile seed operation runs with `FirstRunOnly` policy
+- **AND** the durable seed marker is absent
+- **AND** a profile record already exists for one of the shipped default IDs
+- **THEN** the operation does not overwrite that record
+- **AND** creates only missing shipped default records
+- **AND** writes the durable seed marker
+- **AND** returns a report listing skipped existing IDs
+
+#### Scenario: First-run seeding does not recreate deleted defaults
+- **WHEN** the default profile seed operation runs with `FirstRunOnly` policy
+- **AND** the durable seed marker is present
+- **AND** one or more shipped default profile records are missing
+- **THEN** the operation does not recreate the missing records
+- **AND** returns a report indicating that first-run seeding had already occurred
+
+#### Scenario: Restore missing defaults is explicit and non-destructive
+- **WHEN** the default profile seed operation runs with `RestoreMissing` policy
+- **AND** one or more shipped default profile records are missing
+- **THEN** the operation creates the missing shipped default records
+- **AND** does not overwrite existing records for shipped default IDs
+- **AND** returns a report listing created and skipped profile IDs
+
+#### Scenario: Seeding failure is actionable
+- **WHEN** the default profile seed operation cannot read seed state, write seed state, or store a profile record
+- **THEN** the operation returns an actionable error
+- **AND** does not report the failed write as a successful seed
+
+### Requirement: Core SHALL snapshot selected profile policy into sessions
+
+The system SHALL snapshot the selected profile's effective execution policy into the session during session setup. Later edits, deletion, restoration, or import of stored profile records SHALL affect future sessions only and SHALL NOT implicitly mutate existing sessions.
+
+#### Scenario: Session setup snapshots profile policy
+- **WHEN** a session is prepared with a selected profile
+- **THEN** the session records the selected profile ID for traceability
+- **AND** snapshots the profile identity prompt used for system prompt Section 1
+- **AND** snapshots the profile tool filter
+- **AND** snapshots the profile approval policy
+- **AND** snapshots the provider/model resolution outcome or diagnostics needed for the session
+
+#### Scenario: Stored profile edit does not mutate active session
+- **WHEN** a session has already snapshotted profile policy
+- **AND** the stored profile record is edited afterward
+- **THEN** the existing session continues using its snapshotted policy
+- **AND** new sessions can use the edited profile record
+
+#### Scenario: Stored profile deletion does not mutate active session
+- **WHEN** a session has already snapshotted profile policy
+- **AND** the stored profile record is deleted afterward
+- **THEN** the existing session continues using its snapshotted policy
+- **AND** the deletion affects future profile selection only
+
+#### Scenario: Profile switching is out of scope
+- **WHEN** a caller wants to change profile policy for an active session
+- **THEN** this change provides no implicit reload or mid-session switch behavior
+- **AND** a future explicit profile-switch API must handle cache invalidation and policy recomputation deliberately
+
+### Requirement: Core SHALL apply profile tool filters to primary session tool catalogs
+
+The system SHALL apply the session-effective profile `ToolFilter` to the primary session's effective tool catalog by exact canonical model-visible tool name. Filtering SHALL affect both provider-visible tool definitions and execution-time tool availability.
+
+#### Scenario: Inherit leaves catalog unchanged
+- **WHEN** a session-effective profile tool filter is `Inherit`
+- **THEN** the session tool catalog is not restricted by profile policy
+
+#### Scenario: Allow exposes only listed tools
+- **WHEN** a session-effective profile tool filter is `Allow` with a list of canonical tool names
+- **THEN** only available tools whose canonical model-visible names are in the list are exposed to the provider
+- **AND** attempts to execute tools outside the allowlist are rejected by the session tool catalog
+
+#### Scenario: Deny removes listed tools
+- **WHEN** a session-effective profile tool filter is `Deny` with a list of canonical tool names
+- **THEN** available tools whose canonical model-visible names are in the list are not exposed to the provider
+- **AND** attempts to execute denied tools are rejected by the session tool catalog
+
+#### Scenario: Unknown listed tools are diagnostic not load-fatal
+- **WHEN** a stored or imported profile contains tool filter names that are not available in the current runtime
+- **THEN** the profile data remains valid if its shape is valid
+- **AND** session preparation may return diagnostics for unavailable tool names
+
+### Requirement: Core SHALL keep profile serialization reference-only
+
+The system SHALL serialize and deserialize `AgentProfile` payloads as profile behavior and provider/model references only. Profile JSON SHALL NOT embed provider definitions, model catalog entries, credentials, API keys, OAuth tokens, provider connection metadata, or provider protocol metadata.
+
+#### Scenario: Profile export contains references only
+- **WHEN** an `AgentProfile` with a managed provider/model selection is serialized for storage or export
+- **THEN** the serialized payload includes the provider slug and model ID reference
+- **AND** does not include provider credentials, provider definitions, model metadata, or connection metadata
+
+#### Scenario: Profile import accepts unavailable references
+- **WHEN** a profile payload with a valid provider/model reference shape is imported or loaded
+- **AND** that provider/model is not currently available on the machine
+- **THEN** the profile payload can still be accepted
+- **AND** execution-time session preparation is responsible for warning and fallback behavior

--- a/openspec/changes/seed-default-agent-profiles/specs/core-config-store/spec.md
+++ b/openspec/changes/seed-default-agent-profiles/specs/core-config-store/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: Config store SHALL support durable bootstrap metadata
+
+The system SHALL provide a durable, domain-scoped metadata mechanism that core-owned bootstrap operations can use to record one-time initialization state without creating fake records in user-facing domains such as profiles, prompts, schedules, credentials, providers, or models.
+
+#### Scenario: Bootstrap metadata roundtrips
+- **WHEN** a caller stores a bootstrap metadata value for a domain-scoped key
+- **THEN** a later read for the same key returns the stored value
+- **AND** the caller does not need direct access to SQLite tables or SQL queries
+
+#### Scenario: Missing bootstrap metadata is distinguishable
+- **WHEN** a caller reads a bootstrap metadata key that has not been stored
+- **THEN** the config API returns `None` or an equivalent typed absence value
+- **AND** the absence is distinguishable from storage failure
+
+#### Scenario: Bootstrap metadata does not pollute profile records
+- **WHEN** default agent profile seeding stores its first-run seed marker
+- **THEN** the marker is stored outside the user-visible profile record namespace
+- **AND** listing, exporting, deleting, or loading profiles does not expose the marker as an `AgentProfile`
+
+#### Scenario: Bootstrap metadata writes are transactional
+- **WHEN** a bootstrap operation writes metadata as part of a larger initialization operation
+- **THEN** storage failures are reported as actionable config errors
+- **AND** the operation does not report successful initialization if required metadata could not be persisted
+
+### Requirement: Config store SHALL preserve default-profile seed state
+
+The system SHALL support durable seed state for shipped default agent profiles so callers can distinguish first-run bootstrap from later user deletion of seeded profile records.
+
+#### Scenario: First-run seed state starts absent
+- **WHEN** a config store has never completed shipped default profile seeding
+- **THEN** the default-profile seed marker is absent
+
+#### Scenario: First-run seed state can be recorded
+- **WHEN** shipped default profile seeding completes its normal first-run attempt
+- **THEN** the config store records the default-profile seed marker with a versioned value
+
+#### Scenario: Seed state survives deleted profile records
+- **WHEN** shipped default profile seeding has recorded its seed marker
+- **AND** a user deletes a shipped default profile record such as `explore`
+- **THEN** the seed marker remains present
+- **AND** later first-run seeding can detect that automatic bootstrap has already occurred
+
+#### Scenario: In-memory store supports seed state
+- **WHEN** tests or embedders create an in-memory config store
+- **THEN** the same bootstrap metadata APIs and default-profile seed state behavior are available

--- a/openspec/changes/seed-default-agent-profiles/specs/effective-model-catalog/spec.md
+++ b/openspec/changes/seed-default-agent-profiles/specs/effective-model-catalog/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Profile model availability SHALL use the effective model catalog
+
+The system SHALL use the effective model catalog when checking whether an explicit profile provider/model reference is available on the current machine. This availability check SHALL consider built-in model metadata and ConfigStore custom model records without requiring the profile payload to embed provider or model definitions.
+
+#### Scenario: Explicit profile model is available in built-in catalog
+- **WHEN** a profile references a provider/model pair present in the built-in model catalog
+- **THEN** profile session preparation treats the model reference as catalog-available
+
+#### Scenario: Explicit profile model is available in custom catalog
+- **WHEN** a profile references a provider/model pair present in ConfigStore custom model records
+- **THEN** profile session preparation treats the model reference as catalog-available
+
+#### Scenario: Explicit profile model is unknown
+- **WHEN** a profile references a provider/model pair absent from both built-in and custom catalog entries
+- **THEN** profile session preparation reports a structured unavailable-model diagnostic
+- **AND** profile configuration or import is not rejected solely because the reference is unavailable on the current machine
+
+#### Scenario: Profile payload remains reference-only
+- **WHEN** a profile references an explicit provider/model pair
+- **THEN** the profile payload stores only the provider slug and model ID reference
+- **AND** effective model catalog metadata remains in built-in catalog data or ConfigStore custom model records

--- a/openspec/changes/seed-default-agent-profiles/tasks.md
+++ b/openspec/changes/seed-default-agent-profiles/tasks.md
@@ -1,0 +1,50 @@
+## 1. Default Profile Definitions and Seeding
+
+- [x] 1.1 Add core-owned shipped `AgentProfile` definitions for `explore`, `plan`, and `apply` with `RuntimeDefault`, `ToolFilter::Inherit`, `SkillFilter::Inherit`, `PerTool`, and profile-specific identity prompts.
+- [x] 1.2 Add or expose durable ConfigStore bootstrap metadata APIs for domain-scoped seed markers without using fake profile records.
+- [x] 1.3 Add default-profile seed state keys and versioned marker handling for shipped agent profiles.
+- [x] 1.4 Implement `FirstRunOnly` seed policy that creates missing shipped profiles only when the seed marker is absent, preserves existing records, and records the marker.
+- [x] 1.5 Implement `RestoreMissing` seed policy that recreates missing shipped profiles on explicit request while preserving existing records.
+- [x] 1.6 Return structured seed reports and diagnostics listing created profiles, skipped existing profiles, marker state, and storage failures.
+
+## 2. Profile Validation and Serialization
+
+- [x] 2.1 Update profile validation/deserialization so user-facing `AgentApproval` accepts only `PerTool` and `AutoApprove`.
+- [x] 2.2 Reject `ReadOnly` profile approval payloads with a validation error or load diagnostic rather than silently mapping them.
+- [x] 2.3 Preserve profile serialization as reference-only provider/model data with no embedded provider definitions, model metadata, API keys, OAuth tokens, or connection metadata.
+- [x] 2.4 Ensure unavailable provider/model/tool references do not make otherwise well-formed profile import/load fail solely due to machine-local availability.
+
+## 3. Session-Effective Profile Policy
+
+- [x] 3.1 Add session state for snapshotted profile policy: profile ID, profile identity, profile tool filter, profile approval policy, and provider/model resolution diagnostics or effective selection metadata.
+- [x] 3.2 Apply selected profile policy during primary session setup and managed prompt setup without runtime branches for `explore`, `plan`, or `apply`.
+- [x] 3.3 Ensure stored profile edits or deletion after session setup do not implicitly mutate existing session policy.
+- [x] 3.4 Preserve behavior-critical profile policy snapshot fields through handoff export/import where required for session continuity.
+
+## 4. Tool Filtering and Approval Enforcement
+
+- [x] 4.1 Apply session-effective `ToolFilter` during primary session tool catalog construction using exact canonical model-visible tool names.
+- [x] 4.2 Ensure `Allow` filters provider-visible tool definitions and execution-time availability to only listed available tools.
+- [x] 4.3 Ensure `Deny` filters provider-visible tool definitions and execution-time availability by removing listed tools.
+- [x] 4.4 Emit diagnostics for unavailable tool names referenced by session-effective profile filters without failing profile load/import.
+- [x] 4.5 Make session-effective `AgentApproval::AutoApprove` bypass approval prompts for tool calls that would require approval under `PerTool`.
+- [x] 4.6 Keep `AgentApproval::PerTool` behavior aligned with each tool's `requires_approval` setting.
+
+## 5. Provider/Model Resolution
+
+- [x] 5.1 Check explicit profile provider/model references against the effective model catalog built from built-in and custom model entries.
+- [x] 5.2 Resolve available explicit managed provider/model references through existing credential/provider resolution without profile-stored credentials.
+- [x] 5.3 For unavailable explicit references, return structured warning diagnostics and fall back to the runtime default provider path when usable.
+- [x] 5.4 If both explicit reference and runtime default are unusable, fail with an actionable error preserving the explicit-reference reason.
+- [x] 5.5 Ensure fallback occurs only during setup/resolution and does not silently replace a provider after inference has started.
+
+## 6. Tests and Validation
+
+- [x] 6.1 Add ConfigStore tests for bootstrap metadata roundtrip, missing-marker behavior, marker persistence after profile deletion, and in-memory store support.
+- [x] 6.2 Add seeding tests for first-run creation, existing-record preservation, deleted-default non-recreation under `FirstRunOnly`, and explicit `RestoreMissing` recreation.
+- [x] 6.3 Add profile validation tests for functional `AutoApprove` representation and `ReadOnly` rejection.
+- [x] 6.4 Add session tests proving profile policy is snapshotted and stored profile edits/deletion affect only future sessions.
+- [x] 6.5 Add primary session tool catalog tests for `Inherit`, `Allow`, `Deny`, unknown tool diagnostics, provider-visible definitions, and execution-time rejection.
+- [x] 6.6 Add approval tests proving `AutoApprove` bypasses prompts and `PerTool` still respects tool approval requirements.
+- [x] 6.7 Add provider/model resolution tests for available explicit references, unavailable explicit references with fallback, unavailable fallback failure, and reference-only serialization.
+- [x] 6.8 Run `cargo fmt --check`, `cargo clippy --locked --manifest-path Cargo.toml --all-targets --all-features -- -D warnings`, `cargo test`, and `openspec validate seed-default-agent-profiles --strict`.

--- a/src/config/migrations.rs
+++ b/src/config/migrations.rs
@@ -137,11 +137,25 @@ pub const MIGRATIONS: &[(i64, &str)] = &[
             INSERT OR IGNORE INTO schema_version (id, version) VALUES (1, 4);
             "#,
     ),
+    (
+        5,
+        r#"
+            CREATE TABLE IF NOT EXISTS bootstrap_metadata (
+                domain TEXT NOT NULL,
+                key TEXT NOT NULL,
+                value TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                PRIMARY KEY (domain, key)
+            );
+
+            INSERT OR IGNORE INTO schema_version (id, version) VALUES (1, 5);
+            "#,
+    ),
 ];
 
 /// The current schema version.
 #[allow(dead_code)]
-pub const CURRENT_SCHEMA_VERSION: i64 = 4;
+pub const CURRENT_SCHEMA_VERSION: i64 = 5;
 
 /// Apply all pending migrations to the database.
 pub async fn apply_migrations(pool: &sqlx::SqlitePool) -> Result<(), super::error::ConfigError> {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -591,10 +591,11 @@ pub use effective_catalog::{
 };
 pub use error::ConfigError;
 pub use records::{
-    CredentialRecord, CustomModelInput, CustomModelRecord, DefaultModelInput, DefaultModelRecord,
-    McpServerConfigInput, McpServerConfigRecord, ProfileInput, ProfileRecord, PromptInput,
-    PromptRecord, ProviderConfigInput, ProviderConfigRecord, RuntimeSettingsSnapshot,
-    SavedHandoffInput, SavedHandoffMetadata, SavedHandoffRecord, ScheduleInput, ScheduleRecord,
-    SkillSettingsInput, SkillSettingsRecord,
+    BootstrapMetadataInput, BootstrapMetadataRecord, CredentialRecord, CustomModelInput,
+    CustomModelRecord, DefaultModelInput, DefaultModelRecord, McpServerConfigInput,
+    McpServerConfigRecord, ProfileInput, ProfileRecord, PromptInput, PromptRecord,
+    ProviderConfigInput, ProviderConfigRecord, RuntimeSettingsSnapshot, SavedHandoffInput,
+    SavedHandoffMetadata, SavedHandoffRecord, ScheduleInput, ScheduleRecord, SkillSettingsInput,
+    SkillSettingsRecord,
 };
 pub use store::{default_config_path, ConfigStore, OpenOptions};

--- a/src/config/records.rs
+++ b/src/config/records.rs
@@ -191,9 +191,22 @@ pub struct RuntimeSettingsSnapshot {
     pub skill_settings: SkillSettingsRecord,
 }
 
-// ============================================================================
-// Saved Handoff Records (Issue #69)
-// ============================================================================
+/// A stored bootstrap metadata record.
+#[derive(Debug, Clone)]
+pub struct BootstrapMetadataRecord {
+    pub domain: String,
+    pub key: String,
+    pub value: String,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Input for creating or updating bootstrap metadata.
+#[derive(Debug, Clone)]
+pub struct BootstrapMetadataInput {
+    pub domain: String,
+    pub key: String,
+    pub value: String,
+}
 
 /// Metadata for a saved handoff bundle.
 #[derive(Debug, Clone)]

--- a/src/config/store.rs
+++ b/src/config/store.rs
@@ -1489,6 +1489,73 @@ fn deserialize_mcp_transport(
     }
 }
 
+impl ConfigStore {
+    // ============================================================================
+    // Bootstrap Metadata APIs
+    // ============================================================================
+
+    /// Store or replace bootstrap metadata for a domain-scoped key.
+    pub async fn set_bootstrap_metadata(
+        &self,
+        input: &BootstrapMetadataInput,
+    ) -> Result<(), ConfigError> {
+        if input.domain.trim().is_empty() {
+            return Err(ConfigError::Validation(
+                "Bootstrap metadata domain must not be empty".to_string(),
+            ));
+        }
+        if input.key.trim().is_empty() {
+            return Err(ConfigError::Validation(
+                "Bootstrap metadata key must not be empty".to_string(),
+            ));
+        }
+        let now = Utc::now().to_rfc3339();
+        sqlx::query(
+            r#"
+            INSERT INTO bootstrap_metadata (domain, key, value, updated_at)
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT(domain, key) DO UPDATE SET
+                value = excluded.value,
+                updated_at = excluded.updated_at
+            "#,
+        )
+        .bind(&input.domain)
+        .bind(&input.key)
+        .bind(&input.value)
+        .bind(&now)
+        .execute(&self.pool)
+        .await
+        .map_err(ConfigError::from)?;
+        Ok(())
+    }
+
+    /// Get bootstrap metadata value for a domain-scoped key.
+    pub async fn get_bootstrap_metadata(
+        &self,
+        domain: &str,
+        key: &str,
+    ) -> Result<Option<BootstrapMetadataRecord>, ConfigError> {
+        let row = sqlx::query(
+            "SELECT domain, key, value, updated_at FROM bootstrap_metadata WHERE domain = ? AND key = ?",
+        )
+        .bind(domain)
+        .bind(key)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(ConfigError::from)?;
+
+        match row {
+            Some(row) => Ok(Some(BootstrapMetadataRecord {
+                domain: row.get("domain"),
+                key: row.get("key"),
+                value: row.get("value"),
+                updated_at: parse_datetime(row.get::<String, _>("updated_at"))?,
+            })),
+            None => Ok(None),
+        }
+    }
+}
+
 // ============================================================================
 // Saved Handoff APIs (Issue #69)
 // ============================================================================

--- a/src/config/store.rs
+++ b/src/config/store.rs
@@ -161,6 +161,41 @@ impl ConfigStore {
         Ok(())
     }
 
+    /// Insert a profile record only if one with the same ID does not already exist.
+    ///
+    /// Returns `true` if the row was inserted, `false` if the ID already existed.
+    /// Returns `ConfigError::Validation` if the ID is empty.
+    pub async fn insert_profile_if_missing(
+        &self,
+        input: &ProfileInput,
+    ) -> Result<bool, ConfigError> {
+        if input.id.is_empty() {
+            return Err(ConfigError::Validation(
+                "Profile ID must not be empty".to_string(),
+            ));
+        }
+        let now = Utc::now().to_rfc3339();
+        let payload = serde_json::to_string(&input.payload)?;
+
+        let result = sqlx::query(
+            r#"
+            INSERT INTO profiles (id, schema_version, payload, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT(id) DO NOTHING
+            "#,
+        )
+        .bind(&input.id)
+        .bind(input.schema_version)
+        .bind(&payload)
+        .bind(&now)
+        .bind(&now)
+        .execute(&self.pool)
+        .await
+        .map_err(ConfigError::from)?;
+
+        Ok(result.rows_affected() > 0)
+    }
+
     /// Get a profile by ID.
     pub async fn get_profile(&self, id: &str) -> Result<Option<ProfileRecord>, ConfigError> {
         let row = sqlx::query(

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -147,6 +147,10 @@ impl IronConnection {
         *self.client.borrow_mut() = Some(client);
     }
 
+    pub fn profile_registry(&self) -> &Arc<RwLock<ProfileRegistry>> {
+        &self.profile_registry
+    }
+
     fn selected_profile(
         &self,
         session_profile_id: Option<&AgentProfileId>,
@@ -311,12 +315,16 @@ impl IronConnection {
         let sink = AcpPromptSink::new(acp_session_id.clone(), client.clone());
 
         // Apply the selected profile identity layer unless the session already
-        // has explicit instructions.
+        // has explicit instructions. Snapshot profile policy fields so later
+        // edits/deletion of the stored profile do not affect this session.
         let selected_profile = self.selected_profile(session_profile_id)?;
         {
             let mut session = durable.lock();
             if let Some(profile_id) = session_profile_id {
                 session.profile_id = Some(profile_id.clone());
+                // Snapshot tool filter and approval only when a profile is explicitly selected.
+                session.effective_tool_filter = Some(selected_profile.tools.clone());
+                session.effective_approval = Some(selected_profile.approval);
             }
             if session.profile_identity.is_none() {
                 if let Some(ref identity) = selected_profile.identity_prompt {
@@ -340,6 +348,8 @@ impl IronConnection {
                 })
         };
 
+        // Resolve provider for this turn. If the profile specifies an unavailable
+        // provider/model, warn once and fall back to the runtime default.
         let (runner, stop_reason) = if let Some(ref ctx) = stored_context {
             match self.runtime.resolve_managed_provider(ctx).await {
                 Ok(provider) => {
@@ -381,11 +391,27 @@ impl IronConnection {
                         .await;
                     (Some(runner), stop_reason)
                 }
+                Ok(ResolvedProfileProvider::Fallback {
+                    provider: _,
+                    diagnostic,
+                }) => {
+                    warn!(diagnostic = %diagnostic, "Profile provider fallback to runtime default");
+                    {
+                        let mut session = durable.lock();
+                        session.profile_unavailable = Some(diagnostic.clone());
+                    }
+                    let runner = PromptRunner::new(self.runtime.clone());
+                    let stop_reason = runner
+                        .run(&durable, &ephemeral, &sink, &config, max_iterations)
+                        .await;
+                    (Some(runner), stop_reason)
+                }
                 Err(e) => {
                     warn!(error = %e, "Failed to resolve selected profile provider");
                     {
                         let mut session = durable.lock();
                         session.add_agent_text(format!("[Provider error: {}]", e));
+                        session.profile_unavailable = Some(format!("Provider unavailable: {}", e));
                     }
                     (None, acp::StopReason::EndTurn)
                 }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -515,12 +515,16 @@ impl IronConnection {
         let sink = AcpPromptSink::new(acp_session_id.clone(), client.clone());
 
         // Apply the selected profile identity layer unless the session already
-        // has explicit instructions.
+        // has explicit instructions. Snapshot profile policy fields so later
+        // edits/deletion of the stored profile do not affect this session.
         let selected_profile = self.selected_profile(session_profile_id)?;
         {
             let mut session = durable.lock();
             if let Some(profile_id) = session_profile_id {
                 session.profile_id = Some(profile_id.clone());
+                // Snapshot tool filter and approval only when a profile is explicitly selected.
+                session.effective_tool_filter = Some(selected_profile.tools.clone());
+                session.effective_approval = Some(selected_profile.approval);
             }
             if session.profile_identity.is_none() {
                 if let Some(ref identity) = selected_profile.identity_prompt {

--- a/src/context/handoff.rs
+++ b/src/context/handoff.rs
@@ -52,6 +52,21 @@ pub struct HandoffBundle {
     /// Tools hidden due to model capability differences
     #[serde(default)]
     pub hidden_tools: Vec<String>,
+    /// The profile id last used for this session, if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub profile_id: Option<crate::profile::AgentProfileId>,
+    /// Session-effective snapshot of the profile's tool filter at setup time.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effective_tool_filter: Option<crate::profile::ToolFilter>,
+    /// Session-effective snapshot of the profile's approval posture at setup time.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effective_approval: Option<crate::profile::AgentApproval>,
+    /// Session-effective snapshot of the resolved model at setup time.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effective_model: Option<String>,
+    /// Whether the session was created with a profile that is no longer available.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub profile_unavailable: Option<String>,
 }
 
 pub struct HandoffExporter;
@@ -95,7 +110,7 @@ impl HandoffExporter {
         let mut loss_notes = Vec::new();
         for msg in &tail {
             for block in msg.content_blocks().iter() {
-                if let crate::durable::ContentBlock::Resource { ref uri, .. } = block {
+                if let crate::durable::ContentBlock::Resource { uri, .. } = block {
                     if is_local_resource(uri.as_str()) {
                         loss_notes.push(format!(
                             "Local resource '{}' may not be accessible at destination",
@@ -137,6 +152,11 @@ impl HandoffExporter {
             current_provider_api_key: session.current_provider_api_key.clone(),
             profile_identity: session.profile_identity.clone(),
             hidden_tools: session.hidden_tools.clone(),
+            profile_id: session.profile_id.clone(),
+            effective_tool_filter: session.effective_tool_filter.clone(),
+            effective_approval: session.effective_approval,
+            effective_model: session.effective_model.clone(),
+            profile_unavailable: session.profile_unavailable.clone(),
         };
 
         if config.handoff_export.include_portability_notes && !loss_notes.is_empty() {
@@ -200,6 +220,11 @@ impl HandoffImporter {
         target.current_provider_slug = bundle.current_provider_slug.clone();
         target.current_provider_api_key = bundle.current_provider_api_key.clone();
         target.hidden_tools = bundle.hidden_tools.clone();
+        target.profile_id = bundle.profile_id.clone();
+        target.effective_tool_filter = bundle.effective_tool_filter.clone();
+        target.effective_approval = bundle.effective_approval;
+        target.effective_model = bundle.effective_model.clone();
+        target.profile_unavailable = bundle.profile_unavailable.clone();
 
         // Recreate timeline entries from model switch history
         for record in &bundle.model_switch_history {
@@ -263,6 +288,11 @@ impl HandoffImporter {
         session.current_provider_slug = bundle.current_provider_slug.clone();
         session.current_provider_api_key = bundle.current_provider_api_key.clone();
         session.hidden_tools = bundle.hidden_tools.clone();
+        session.profile_id = bundle.profile_id.clone();
+        session.effective_tool_filter = bundle.effective_tool_filter.clone();
+        session.effective_approval = bundle.effective_approval;
+        session.effective_model = bundle.effective_model.clone();
+        session.profile_unavailable = bundle.profile_unavailable.clone();
 
         // Recreate timeline entries from model switch history
         for record in &bundle.model_switch_history {

--- a/src/context/handoff.rs
+++ b/src/context/handoff.rs
@@ -67,6 +67,10 @@ pub struct HandoffBundle {
     /// Whether the session was created with a profile that is no longer available.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub profile_unavailable: Option<String>,
+    /// Session-effective snapshot of the resolved provider context at setup time.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effective_provider_context:
+        Option<crate::provider_credential::domain::ProviderPromptContext>,
 }
 
 pub struct HandoffExporter;
@@ -157,6 +161,7 @@ impl HandoffExporter {
             effective_approval: session.effective_approval,
             effective_model: session.effective_model.clone(),
             profile_unavailable: session.profile_unavailable.clone(),
+            effective_provider_context: session.effective_provider_context.clone(),
         };
 
         if config.handoff_export.include_portability_notes && !loss_notes.is_empty() {
@@ -225,6 +230,7 @@ impl HandoffImporter {
         target.effective_approval = bundle.effective_approval;
         target.effective_model = bundle.effective_model.clone();
         target.profile_unavailable = bundle.profile_unavailable.clone();
+        target.effective_provider_context = bundle.effective_provider_context.clone();
 
         // Recreate timeline entries from model switch history
         for record in &bundle.model_switch_history {
@@ -293,6 +299,7 @@ impl HandoffImporter {
         session.effective_approval = bundle.effective_approval;
         session.effective_model = bundle.effective_model.clone();
         session.profile_unavailable = bundle.profile_unavailable.clone();
+        session.effective_provider_context = bundle.effective_provider_context.clone();
 
         // Recreate timeline entries from model switch history
         for record in &bundle.model_switch_history {

--- a/src/delegation/runtime.rs
+++ b/src/delegation/runtime.rs
@@ -336,6 +336,14 @@ impl IronRuntime {
                     .expect("managed profile always yields a prompt context");
                 PromptRunner::new_managed(self.clone(), provider, context)
             }
+            Ok(crate::profile::ResolvedProfileProvider::Fallback {
+                provider: _,
+                diagnostic,
+            }) => {
+                // Fallback to runtime default; diagnostic is logged by the runtime layer.
+                let _ = diagnostic;
+                PromptRunner::new(self.clone())
+            }
             Err(e) => {
                 self.finish_prompt(child_session_id);
                 self.unregister_child(parent_session_id, child_session_id);

--- a/src/durable.rs
+++ b/src/durable.rs
@@ -417,6 +417,25 @@ pub struct DurableSession {
     /// Rendered in `## 1. Identity` instead of client/session injection.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub profile_identity: Option<String>,
+    /// Session-effective snapshot of the profile's tool filter at setup time.
+    /// `None` means the profile used `Inherit` (or no profile was selected).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effective_tool_filter: Option<crate::profile::ToolFilter>,
+    /// Session-effective snapshot of the profile's approval posture at setup time.
+    /// `None` means the profile used `PerTool` (or no profile was selected).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effective_approval: Option<crate::profile::AgentApproval>,
+    /// Session-effective snapshot of the resolved provider context at setup time.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effective_provider_context:
+        Option<crate::provider_credential::domain::ProviderPromptContext>,
+    /// Session-effective snapshot of the resolved model at setup time.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effective_model: Option<String>,
+    /// Whether the session was created with a profile that is no longer available.
+    /// Stored as a diagnostic; the session continues with its snapshot.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub profile_unavailable: Option<String>,
     #[serde(skip, default)]
     pub token_tracker: crate::context::SessionTokenTracker,
 }
@@ -448,6 +467,11 @@ impl DurableSession {
             pending_workspace_roots: None,
             profile_id: None,
             profile_identity: None,
+            effective_tool_filter: None,
+            effective_approval: None,
+            effective_provider_context: None,
+            effective_model: None,
+            profile_unavailable: None,
             token_tracker: crate::context::SessionTokenTracker::default(),
         }
     }
@@ -1282,7 +1306,7 @@ impl DurableSession {
     pub fn list_enabled_mcp_servers(&self) -> Vec<String> {
         self.mcp_server_enablement
             .iter()
-            .filter(|(_, &enabled)| enabled)
+            .filter(|&(_, enabled)| *enabled)
             .map(|(id, _)| id.clone())
             .collect()
     }

--- a/src/facade.rs
+++ b/src/facade.rs
@@ -1269,17 +1269,13 @@ impl AgentConnection {
         // DurableSession so later edits/deletion of the stored profile do not
         // affect this session.
         let registry = self.inner.profile_registry().read();
-        let selected_profile = registry
-            .get(&profile_id)
-            .cloned()
-            .unwrap_or_else(|| AgentProfile {
-                name: profile_id.as_str().to_string(),
-                provider: AgentProfileProvider::RuntimeDefault,
-                tools: ToolFilter::Inherit,
-                skills: SkillFilter::Inherit,
-                approval: AgentApproval::PerTool,
-                identity_prompt: Some(default_identity_prompt().to_string()),
-            });
+        let selected_profile =
+            registry
+                .get(&profile_id)
+                .cloned()
+                .ok_or_else(|| RuntimeError::Session {
+                    message: format!("Profile '{}' not found in registry", profile_id.as_str()),
+                })?;
         {
             let mut session = durable.lock();
             session.profile_id = Some(profile_id.clone());

--- a/src/facade.rs
+++ b/src/facade.rs
@@ -1251,43 +1251,47 @@ impl AgentConnection {
     /// Create a new session with an explicit profile.
     ///
     /// The selected profile ID is resolved against the agent's profile registry
-    /// at prompt time. If the profile is not found or is removed before a prompt
-    /// runs, the prompt returns an error instead of falling back to the built-in
-    /// default profile.
+    /// at session creation time. If the profile is not found, the method returns
+    /// an error and no session is allocated. The resolved profile policy is
+    /// snapshotted into the session immediately so later edits or deletion of
+    /// the stored profile do not affect this session.
     ///
     /// # Errors
     ///
-    /// Returns an error if the runtime has been shut down.
+    /// Returns an error if the profile is not found in the registry or if the
+    /// runtime has been shut down.
     pub fn create_session_with_profile(
         &self,
         profile_id: AgentProfileId,
     ) -> Result<AgentSession, RuntimeError> {
-        let connection_id = self.inner.id();
-        let (session_id, durable) = self.inner.runtime().create_session(connection_id)?;
-
-        // Resolve the profile immediately and snapshot effective policy into the
-        // DurableSession so later edits/deletion of the stored profile do not
-        // affect this session.
-        let registry = self.inner.profile_registry().read();
-        let selected_profile =
+        // Validate profile exists in registry BEFORE creating the session,
+        // to avoid leaving an orphaned session on error.
+        let selected_profile = {
+            let registry = self.inner.profile_registry().read();
             registry
                 .get(&profile_id)
                 .cloned()
                 .ok_or_else(|| RuntimeError::Session {
                     message: format!("Profile '{}' not found in registry", profile_id.as_str()),
-                })?;
+                })?
+        };
+
+        let connection_id = self.inner.id();
+        let (session_id, durable) = self.inner.runtime().create_session(connection_id)?;
+
+        // Snapshot effective policy into the DurableSession so later
+        // edits/deletion of the stored profile do not affect this session.
         {
             let mut session = durable.lock();
             session.profile_id = Some(profile_id.clone());
+            session.effective_tool_filter = Some(selected_profile.tools.clone());
+            session.effective_approval = Some(selected_profile.approval);
             if let Some(ref identity) = selected_profile.identity_prompt {
                 if !identity.trim().is_empty() {
                     session.set_profile_identity(identity.clone());
                 }
             }
-            session.effective_tool_filter = Some(selected_profile.tools.clone());
-            session.effective_approval = Some(selected_profile.approval);
         }
-        drop(registry);
 
         Ok(AgentSession {
             id: session_id,

--- a/src/facade.rs
+++ b/src/facade.rs
@@ -806,6 +806,18 @@ impl IronAgent {
         }
     }
 
+    /// Seed the three shipped default profiles (explore, plan, apply) into the
+    /// given config store according to `policy`.
+    ///
+    /// Delegates to [`crate::profile::seed_default_profiles`].
+    pub async fn seed_default_profiles(
+        &self,
+        store: &ConfigStore,
+        policy: crate::profile::DefaultProfileSeedPolicy,
+    ) -> Result<crate::profile::DefaultProfileSeedReport, crate::config::ConfigError> {
+        crate::profile::seed_default_profiles(store, policy).await
+    }
+
     /// Register or replace an agent profile by stable ID.
     ///
     /// Validates the profile name and rejects reserved `default` IDs/names.
@@ -827,6 +839,17 @@ impl IronAgent {
             .ok_or_else(|| format!("invalid profile name: '{}'", profile.name))?;
         if name.eq_ignore_ascii_case("default") {
             return Err("profile name 'default' is reserved".to_string());
+        }
+
+        // Reject ReadOnly and RequireApproval at the registration boundary.
+        if !matches!(
+            profile.approval,
+            AgentApproval::PerTool | AgentApproval::AutoApprove
+        ) {
+            return Err(format!(
+                "invalid profile approval value: {:?}. Only PerTool and AutoApprove are supported.",
+                profile.approval
+            ));
         }
 
         let mut registry = self.profile_registry.write();
@@ -1241,6 +1264,35 @@ impl AgentConnection {
     ) -> Result<AgentSession, RuntimeError> {
         let connection_id = self.inner.id();
         let (session_id, durable) = self.inner.runtime().create_session(connection_id)?;
+
+        // Resolve the profile immediately and snapshot effective policy into the
+        // DurableSession so later edits/deletion of the stored profile do not
+        // affect this session.
+        let registry = self.inner.profile_registry().read();
+        let selected_profile = registry
+            .get(&profile_id)
+            .cloned()
+            .unwrap_or_else(|| AgentProfile {
+                name: profile_id.as_str().to_string(),
+                provider: AgentProfileProvider::RuntimeDefault,
+                tools: ToolFilter::Inherit,
+                skills: SkillFilter::Inherit,
+                approval: AgentApproval::PerTool,
+                identity_prompt: Some(default_identity_prompt().to_string()),
+            });
+        {
+            let mut session = durable.lock();
+            session.profile_id = Some(profile_id.clone());
+            if let Some(ref identity) = selected_profile.identity_prompt {
+                if !identity.trim().is_empty() {
+                    session.set_profile_identity(identity.clone());
+                }
+            }
+            session.effective_tool_filter = Some(selected_profile.tools.clone());
+            session.effective_approval = Some(selected_profile.approval);
+        }
+        drop(registry);
+
         Ok(AgentSession {
             id: session_id,
             durable,

--- a/src/mcp/session_catalog.rs
+++ b/src/mcp/session_catalog.rs
@@ -855,7 +855,7 @@ impl SessionToolCatalog {
                         let namespaced = format!("plugin_{}_{}", plugin_id, tool.name);
                         if !emitted.contains(namespaced.as_str()) {
                             diagnostics.push(ToolDiagnostic {
-                                name: namespaced,
+                                name: namespaced.clone(),
                                 source: ToolSource::Plugin {
                                     plugin_id: plugin_id.clone(),
                                 },
@@ -864,6 +864,7 @@ impl SessionToolCatalog {
                                 requires_approval: tool.requires_approval,
                                 description: tool.description.clone(),
                             });
+                            emitted.insert(namespaced);
                         }
                     }
                 }
@@ -877,7 +878,7 @@ impl SessionToolCatalog {
                         let namespaced = format!("plugin_{}_{}", plugin_id, tool.name);
                         if !emitted.contains(namespaced.as_str()) {
                             diagnostics.push(ToolDiagnostic {
-                                name: namespaced,
+                                name: namespaced.clone(),
                                 source: ToolSource::Plugin {
                                     plugin_id: plugin_id.clone(),
                                 },
@@ -888,6 +889,7 @@ impl SessionToolCatalog {
                                 requires_approval: tool.requires_approval,
                                 description: tool.description.clone(),
                             });
+                            emitted.insert(namespaced);
                         }
                     }
                 }
@@ -905,7 +907,7 @@ impl SessionToolCatalog {
 
                     let result = compute_tool_availability(&plugin, tool);
                     diagnostics.push(ToolDiagnostic {
-                        name: namespaced,
+                        name: namespaced.clone(),
                         source: ToolSource::Plugin {
                             plugin_id: plugin_id.clone(),
                         },
@@ -914,6 +916,7 @@ impl SessionToolCatalog {
                         requires_approval: tool.requires_approval,
                         description: tool.description.clone(),
                     });
+                    emitted.insert(namespaced);
                 }
             }
         }

--- a/src/mcp/session_catalog.rs
+++ b/src/mcp/session_catalog.rs
@@ -48,6 +48,8 @@ pub struct SessionToolCatalog {
     definitions: Vec<ToolDefinition>,
     /// Map from tool name to tool info for lookup
     tool_map: Arc<HashMap<String, ToolInfo>>,
+    /// Session-effective tool filter snapshot from profile.
+    effective_tool_filter: Option<crate::profile::ToolFilter>,
 }
 
 /// Summary of an MCP server's status for a session.
@@ -273,6 +275,25 @@ impl SessionToolCatalog {
         definitions.retain(|d| !hidden_tools.contains(&d.name));
         tool_map.retain(|name, _| !hidden_tools.contains(name));
 
+        // Apply session-effective tool filter from profile snapshot, if any.
+        if let Some(ref filter) = session.effective_tool_filter {
+            match filter {
+                crate::profile::ToolFilter::Inherit => {}
+                crate::profile::ToolFilter::Allow(allowed) => {
+                    let allowed_set: std::collections::HashSet<String> =
+                        allowed.iter().cloned().collect();
+                    definitions.retain(|d| allowed_set.contains(&d.name));
+                    tool_map.retain(|name, _| allowed_set.contains(name));
+                }
+                crate::profile::ToolFilter::Deny(denied) => {
+                    let denied_set: std::collections::HashSet<String> =
+                        denied.iter().cloned().collect();
+                    definitions.retain(|d| !denied_set.contains(&d.name));
+                    tool_map.retain(|name, _| !denied_set.contains(name));
+                }
+            }
+        }
+
         Self {
             local_registry,
             mcp_registry,
@@ -281,6 +302,7 @@ impl SessionToolCatalog {
             connection_manager,
             definitions,
             tool_map: Arc::new(tool_map),
+            effective_tool_filter: session.effective_tool_filter.clone(),
         }
     }
 
@@ -899,6 +921,97 @@ impl SessionToolCatalog {
         let hidden_tools: std::collections::HashSet<&str> =
             session.hidden_tools.iter().map(|s| s.as_str()).collect();
         diagnostics.retain(|d| !hidden_tools.contains(d.name.as_str()));
+
+        // --- Phase 4: tools denied by the session-effective profile filter ---
+        if let Some(crate::profile::ToolFilter::Deny(ref denied_names)) = self.effective_tool_filter
+        {
+            let denied_set: std::collections::HashSet<String> =
+                denied_names.iter().cloned().collect();
+            // Re-add denied tools that were filtered out of tool_map
+            // but exist in the underlying registries.
+            for def in self.local_registry.definitions() {
+                if denied_set.contains(&def.name) && !emitted.contains(&def.name) {
+                    diagnostics.push(ToolDiagnostic {
+                        name: def.name.clone(),
+                        source: ToolSource::Local,
+                        available: false,
+                        unavailable_reason: Some(UnavailableReason::DeniedByProfileFilter),
+                        requires_approval: self
+                            .local_registry
+                            .get(&def.name)
+                            .map(|t| t.requires_approval())
+                            .unwrap_or(false),
+                        description: def.description.clone(),
+                    });
+                    emitted.insert(def.name.clone());
+                }
+            }
+            // Also check MCP and plugin registries for denied tools
+            for server in self.mcp_registry.list_servers() {
+                for tool_info in &server.discovered_tools {
+                    let namespaced = format!("mcp_{}_{}", server.config.id, tool_info.name);
+                    if denied_set.contains(&namespaced) && !emitted.contains(&namespaced) {
+                        diagnostics.push(ToolDiagnostic {
+                            name: namespaced.clone(),
+                            source: ToolSource::Mcp {
+                                server_id: server.config.id.clone(),
+                            },
+                            available: false,
+                            unavailable_reason: Some(UnavailableReason::DeniedByProfileFilter),
+                            requires_approval: true,
+                            description: tool_info.description.clone(),
+                        });
+                        emitted.insert(namespaced);
+                    }
+                }
+            }
+            for plugin in self.plugin_registry.list() {
+                if let Some(manifest) = &plugin.manifest {
+                    for tool in &manifest.tools {
+                        let namespaced = format!("plugin_{}_{}", plugin.config.id, tool.name);
+                        if denied_set.contains(&namespaced) && !emitted.contains(&namespaced) {
+                            diagnostics.push(ToolDiagnostic {
+                                name: namespaced.clone(),
+                                source: ToolSource::Plugin {
+                                    plugin_id: plugin.config.id.clone(),
+                                },
+                                available: false,
+                                unavailable_reason: Some(UnavailableReason::DeniedByProfileFilter),
+                                requires_approval: tool.requires_approval,
+                                description: tool.description.clone(),
+                            });
+                            emitted.insert(namespaced);
+                        }
+                    }
+                }
+            }
+        }
+
+        // --- Phase 5: tool names referenced by profile filter but not in catalog ---
+        if let Some(ref filter) = session.effective_tool_filter {
+            let filter_names: Vec<String> = match filter {
+                crate::profile::ToolFilter::Allow(names) => names.clone(),
+                crate::profile::ToolFilter::Deny(names) => names.clone(),
+                crate::profile::ToolFilter::Inherit => vec![],
+            };
+            let known_names: std::collections::HashSet<String> =
+                diagnostics.iter().map(|d| d.name.clone()).collect();
+            for name in filter_names {
+                if !known_names.contains(&name) {
+                    diagnostics.push(ToolDiagnostic {
+                        name: name.clone(),
+                        source: ToolSource::Local,
+                        available: false,
+                        unavailable_reason: Some(UnavailableReason::UnknownToolName),
+                        requires_approval: false,
+                        description: format!(
+                            "Tool '{}' is referenced by the profile filter but is not available in the current catalog.",
+                            name
+                        ),
+                    });
+                }
+            }
+        }
 
         diagnostics
     }

--- a/src/mcp/session_catalog.rs
+++ b/src/mcp/session_catalog.rs
@@ -925,15 +925,26 @@ impl SessionToolCatalog {
             session.hidden_tools.iter().map(|s| s.as_str()).collect();
         diagnostics.retain(|d| !hidden_tools.contains(d.name.as_str()));
 
-        // --- Phase 4: tools denied by the session-effective profile filter ---
-        if let Some(crate::profile::ToolFilter::Deny(ref denied_names)) = self.effective_tool_filter
-        {
-            let denied_set: std::collections::HashSet<String> =
-                denied_names.iter().cloned().collect();
-            // Re-add denied tools that were filtered out of tool_map
+        // --- Phase 4: tools excluded by the session-effective profile filter ---
+        // Build a helper closure that returns true when a tool name is excluded
+        // by the effective filter (Allow or Deny).
+        if let Some(ref filter) = self.effective_tool_filter {
+            let is_excluded = |name: &str| -> bool {
+                match filter {
+                    crate::profile::ToolFilter::Allow(allow_names) => {
+                        !allow_names.iter().any(|a| a == name)
+                    }
+                    crate::profile::ToolFilter::Deny(deny_names) => {
+                        deny_names.iter().any(|d| d == name)
+                    }
+                    crate::profile::ToolFilter::Inherit => false,
+                }
+            };
+
+            // Re-add excluded tools that were filtered out of tool_map
             // but exist in the underlying registries.
             for def in self.local_registry.definitions() {
-                if denied_set.contains(&def.name) && !emitted.contains(&def.name) {
+                if is_excluded(&def.name) && !emitted.contains(&def.name) {
                     diagnostics.push(ToolDiagnostic {
                         name: def.name.clone(),
                         source: ToolSource::Local,
@@ -949,11 +960,11 @@ impl SessionToolCatalog {
                     emitted.insert(def.name.clone());
                 }
             }
-            // Also check MCP and plugin registries for denied tools
+            // Also check MCP and plugin registries for excluded tools
             for server in self.mcp_registry.list_servers() {
                 for tool_info in &server.discovered_tools {
                     let namespaced = format!("mcp_{}_{}", server.config.id, tool_info.name);
-                    if denied_set.contains(&namespaced) && !emitted.contains(&namespaced) {
+                    if is_excluded(&namespaced) && !emitted.contains(&namespaced) {
                         diagnostics.push(ToolDiagnostic {
                             name: namespaced.clone(),
                             source: ToolSource::Mcp {
@@ -972,7 +983,7 @@ impl SessionToolCatalog {
                 if let Some(manifest) = &plugin.manifest {
                     for tool in &manifest.tools {
                         let namespaced = format!("plugin_{}_{}", plugin.config.id, tool.name);
-                        if denied_set.contains(&namespaced) && !emitted.contains(&namespaced) {
+                        if is_excluded(&namespaced) && !emitted.contains(&namespaced) {
                             diagnostics.push(ToolDiagnostic {
                                 name: namespaced.clone(),
                                 source: ToolSource::Plugin {

--- a/src/plugin/effective_tools.rs
+++ b/src/plugin/effective_tools.rs
@@ -126,6 +126,10 @@ pub enum UnavailableReason {
     McpServerNotEnabled,
     /// MCP server is not connected/healthy.
     McpServerNotHealthy(crate::mcp::server::McpServerHealth),
+    /// Tool name is referenced by a profile filter but does not exist in the catalog.
+    UnknownToolName,
+    /// Tool is denied by the session-effective profile filter.
+    DeniedByProfileFilter,
 }
 
 /// Result of canonical per-tool availability computation.

--- a/src/plugin/session.rs
+++ b/src/plugin/session.rs
@@ -43,7 +43,7 @@ impl SessionPluginEnablement {
     pub fn list_enabled(&self) -> Vec<String> {
         self.enabled
             .iter()
-            .filter(|(_, &enabled)| enabled)
+            .filter(|&(_, enabled)| *enabled)
             .map(|(id, _)| id.clone())
             .collect()
     }

--- a/src/profile/mod.rs
+++ b/src/profile/mod.rs
@@ -514,15 +514,6 @@ pub async fn seed_default_profiles(
     };
 
     for (id, profile) in shipped_default_profiles() {
-        let existing = store.get_profile(id.as_str()).await?;
-        if existing.is_some() {
-            report.skipped_existing.push(id.clone());
-            report
-                .diagnostics
-                .push(DefaultProfileSeedDiagnostic::SkippedExisting(id));
-            continue;
-        }
-
         let payload = serde_json::to_value(&profile).map_err(|e| {
             crate::config::ConfigError::Serialization(format!(
                 "Failed to serialize shipped default profile {}: {}",
@@ -535,13 +526,12 @@ pub async fn seed_default_profiles(
             schema_version: PROFILE_SCHEMA_VERSION,
             payload,
         };
-        if let Err(e) = store.set_profile(&input).await {
+        let inserted = store.insert_profile_if_missing(&input).await?;
+        if !inserted {
+            report.skipped_existing.push(id.clone());
             report
                 .diagnostics
-                .push(DefaultProfileSeedDiagnostic::StorageFailure {
-                    profile_id: id.clone(),
-                    reason: e.to_string(),
-                });
+                .push(DefaultProfileSeedDiagnostic::SkippedExisting(id));
             continue;
         }
 
@@ -551,17 +541,9 @@ pub async fn seed_default_profiles(
             .push(DefaultProfileSeedDiagnostic::Created(id));
     }
 
-    // Only write the seed marker if all required profiles were created successfully.
-    // If any required profile write failed, do not write the marker so the next
-    // startup will retry the full seed operation.
-    let any_required_failed = report
-        .diagnostics
-        .iter()
-        .any(|d| matches!(d, DefaultProfileSeedDiagnostic::StorageFailure { .. }));
-
-    if !any_required_failed
-        && (matches!(policy, DefaultProfileSeedPolicy::FirstRunOnly) || !report.created.is_empty())
-    {
+    // Write the seed marker so that subsequent startups do not recreate
+    // user-deleted defaults (under FirstRunOnly policy).
+    if matches!(policy, DefaultProfileSeedPolicy::FirstRunOnly) || !report.created.is_empty() {
         let marker_input = BootstrapMetadataInput {
             domain: DEFAULT_PROFILE_SEED_DOMAIN.to_string(),
             key: DEFAULT_PROFILE_SEED_KEY.to_string(),

--- a/src/profile/mod.rs
+++ b/src/profile/mod.rs
@@ -90,18 +90,47 @@ pub enum SkillFilter {
 }
 
 /// Approval posture for a profile.
+///
+/// Only `PerTool` and `AutoApprove` are valid user-facing values.
+/// `ReadOnly` and `RequireApproval` are rejected during deserialization
+/// and profile validation/registration.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(try_from = "AgentApprovalRaw")]
 pub enum AgentApproval {
     /// Require approval for each tool call.
     #[default]
     PerTool,
-    /// Auto-approve tool calls (plumbing only; not enforced by this slice).
+    /// Auto-approve all tool calls for this profile.
     AutoApprove,
-    /// Read-only execution; no tool calls are allowed.
-    ReadOnly,
 }
 
-/// An agent identity profile.
+/// Raw deserialization helper for `AgentApproval`.
+/// Used to reject `ReadOnly` and `RequireApproval` at the deserialization boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+enum AgentApprovalRaw {
+    PerTool,
+    AutoApprove,
+    ReadOnly,
+    RequireApproval,
+}
+
+impl TryFrom<AgentApprovalRaw> for AgentApproval {
+    type Error = String;
+
+    fn try_from(value: AgentApprovalRaw) -> Result<Self, Self::Error> {
+        match value {
+            AgentApprovalRaw::PerTool => Ok(AgentApproval::PerTool),
+            AgentApprovalRaw::AutoApprove => Ok(AgentApproval::AutoApprove),
+            AgentApprovalRaw::ReadOnly => {
+                Err("ReadOnly is not a valid user-facing profile approval value".to_string())
+            }
+            AgentApprovalRaw::RequireApproval => Err(
+                "RequireApproval is not a valid user-facing profile approval value; use PerTool"
+                    .to_string(),
+            ),
+        }
+    }
+}
 ///
 /// `name` is a user-facing unique label. The stable identity handle is the
 /// profile ID supplied at registration or loaded from `ConfigStore`.
@@ -155,6 +184,73 @@ impl AgentProfile {
     }
 }
 
+// ============================================================================
+// Shipped default profile definitions
+// ============================================================================
+
+/// Core-owned shipped default profile IDs.
+pub const SHIPPED_PROFILE_IDS: &[&str] = &["explore", "plan", "apply"];
+
+/// Build the shipped default `AgentProfile` definitions.
+///
+/// These are bootstrap templates for ordinary persisted profile records.
+/// They use `RuntimeDefault`, `ToolFilter::Inherit`, `SkillFilter::Inherit`,
+/// and `PerTool` approval. Each carries a profile-specific identity prompt.
+pub fn shipped_default_profiles() -> Vec<(AgentProfileId, AgentProfile)> {
+    vec![
+        (
+            AgentProfileId::from("explore"),
+            AgentProfile {
+                name: "Explore".to_string(),
+                provider: AgentProfileProvider::RuntimeDefault,
+                tools: ToolFilter::Inherit,
+                skills: SkillFilter::Inherit,
+                approval: AgentApproval::PerTool,
+                identity_prompt: Some(
+                    "You are an exploratory research agent. Your goal is to broadly investigate \
+                     topics, gather information, and surface options without committing to a specific \
+                     implementation. You should ask clarifying questions, consider alternatives, and \
+                     summarize findings."
+                        .to_string(),
+                ),
+            },
+        ),
+        (
+            AgentProfileId::from("plan"),
+            AgentProfile {
+                name: "Plan".to_string(),
+                provider: AgentProfileProvider::RuntimeDefault,
+                tools: ToolFilter::Inherit,
+                skills: SkillFilter::Inherit,
+                approval: AgentApproval::PerTool,
+                identity_prompt: Some(
+                    "You are a planning agent. Your goal is to analyze requirements, break work \
+                     into actionable steps, and produce structured plans. You should identify \
+                     dependencies, estimate effort, and propose milestones before any implementation \
+                     begins."
+                        .to_string(),
+                ),
+            },
+        ),
+        (
+            AgentProfileId::from("apply"),
+            AgentProfile {
+                name: "Apply".to_string(),
+                provider: AgentProfileProvider::RuntimeDefault,
+                tools: ToolFilter::Inherit,
+                skills: SkillFilter::Inherit,
+                approval: AgentApproval::PerTool,
+                identity_prompt: Some(
+                    "You are an implementation agent. Your goal is to execute plans, write code, \
+                     run tests, and deliver working solutions. You should focus on correctness, \
+                     test coverage, and incremental progress toward the stated goal."
+                        .to_string(),
+                ),
+            },
+        ),
+    ]
+}
+
 /// Built-in default identity prompt for profiles without a custom prompt.
 pub fn default_identity_prompt() -> &'static str {
     "You are a helpful software engineering agent."
@@ -166,6 +262,26 @@ pub enum ResolvedProfileProvider {
     RuntimeDefault(Arc<dyn Provider>),
     /// An owned managed provider constructed through credential resolution.
     Managed(Box<dyn Provider>),
+    /// Fallback to the runtime default provider because the explicit
+    /// provider/model reference was unavailable or credential resolution
+    /// failed. The diagnostic explains why the fallback occurred.
+    Fallback {
+        provider: Arc<dyn Provider>,
+        diagnostic: String,
+    },
+}
+
+impl std::fmt::Debug for ResolvedProfileProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ResolvedProfileProvider::RuntimeDefault(_) => f.debug_tuple("RuntimeDefault").finish(),
+            ResolvedProfileProvider::Managed(_) => f.debug_tuple("Managed").finish(),
+            ResolvedProfileProvider::Fallback { diagnostic, .. } => f
+                .debug_struct("Fallback")
+                .field("diagnostic", diagnostic)
+                .finish(),
+        }
+    }
 }
 
 impl ResolvedProfileProvider {
@@ -174,6 +290,15 @@ impl ResolvedProfileProvider {
         match self {
             ResolvedProfileProvider::RuntimeDefault(arc) => arc.as_ref(),
             ResolvedProfileProvider::Managed(boxed) => boxed.as_ref(),
+            ResolvedProfileProvider::Fallback { provider, .. } => provider.as_ref(),
+        }
+    }
+
+    /// Return the fallback diagnostic, if any.
+    pub fn fallback_diagnostic(&self) -> Option<&str> {
+        match self {
+            ResolvedProfileProvider::Fallback { diagnostic, .. } => Some(diagnostic.as_str()),
+            _ => None,
         }
     }
 }
@@ -195,6 +320,8 @@ pub enum ProfileLoadIssue {
     DuplicateName,
     /// The listed record was missing when read.
     MissingRecord,
+    /// The profile approval value `ReadOnly` was rejected.
+    ReadOnlyRejected,
 }
 
 /// Per-profile diagnostic returned by best-effort profile loading.
@@ -275,6 +402,184 @@ pub fn managed_profile_prompt_context(
             api_key: None,
         }),
     }
+}
+
+// ============================================================================
+// Default profile seeding
+// ============================================================================
+
+/// Domain for bootstrap metadata used by default-profile seeding.
+pub const DEFAULT_PROFILE_SEED_DOMAIN: &str = "agent_profiles";
+/// Key for the durable seed marker.
+pub const DEFAULT_PROFILE_SEED_KEY: &str = "default_seed";
+/// Current seed marker version.
+pub const DEFAULT_PROFILE_SEED_VERSION: &str = "1";
+
+/// Policy for the default-profile seed operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DefaultProfileSeedPolicy {
+    /// Create missing shipped defaults only when the seed marker is absent,
+    /// then write the marker.
+    FirstRunOnly,
+    /// Create missing shipped defaults regardless of marker state, but still
+    /// preserve existing records.
+    RestoreMissing,
+}
+
+/// Diagnostic for a single shipped default during seeding.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DefaultProfileSeedDiagnostic {
+    /// The profile was created successfully.
+    Created(AgentProfileId),
+    /// The profile already existed and was skipped.
+    SkippedExisting(AgentProfileId),
+    /// The profile was missing and not recreated (first-run already done).
+    SkippedFirstRunDone(AgentProfileId),
+    /// Storage failure for this profile.
+    StorageFailure {
+        profile_id: AgentProfileId,
+        reason: String,
+    },
+}
+
+/// Result of a default-profile seed operation.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DefaultProfileSeedReport {
+    /// Policy used for this seed operation.
+    pub policy: DefaultProfileSeedPolicy,
+    /// Whether the durable seed marker was present before the operation.
+    pub marker_was_present: bool,
+    /// Whether the marker was written during this operation.
+    pub marker_written: bool,
+    /// Profiles that were created.
+    pub created: Vec<AgentProfileId>,
+    /// Profiles that were skipped because they already existed.
+    pub skipped_existing: Vec<AgentProfileId>,
+    /// Diagnostics for each shipped default processed.
+    pub diagnostics: Vec<DefaultProfileSeedDiagnostic>,
+}
+
+impl DefaultProfileSeedReport {
+    /// Create a report for a seed operation that did nothing.
+    pub fn no_op(policy: DefaultProfileSeedPolicy, marker_was_present: bool) -> Self {
+        Self {
+            policy,
+            marker_was_present,
+            marker_written: false,
+            created: Vec::new(),
+            skipped_existing: Vec::new(),
+            diagnostics: Vec::new(),
+        }
+    }
+}
+
+/// Seed shipped default profiles into the config store.
+///
+/// This is a core-owned, non-destructive operation. Existing profiles are never
+/// overwritten. Under `FirstRunOnly`, missing defaults are only created when
+/// the durable seed marker is absent; the marker is then written so later
+/// startups do not recreate user-deleted defaults.
+///
+/// Returns a structured report describing created, skipped, and diagnostic
+/// outcomes for each shipped default.
+pub async fn seed_default_profiles(
+    store: &crate::config::ConfigStore,
+    policy: DefaultProfileSeedPolicy,
+) -> Result<DefaultProfileSeedReport, crate::config::ConfigError> {
+    use crate::config::records::{BootstrapMetadataInput, ProfileInput};
+
+    let marker = store
+        .get_bootstrap_metadata(DEFAULT_PROFILE_SEED_DOMAIN, DEFAULT_PROFILE_SEED_KEY)
+        .await?;
+    let marker_was_present = marker.is_some();
+
+    // Under FirstRunOnly, if marker is present we do nothing.
+    if matches!(policy, DefaultProfileSeedPolicy::FirstRunOnly) && marker_was_present {
+        let mut report = DefaultProfileSeedReport::no_op(policy, true);
+        for (id, _profile) in shipped_default_profiles() {
+            report
+                .diagnostics
+                .push(DefaultProfileSeedDiagnostic::SkippedFirstRunDone(id));
+        }
+        return Ok(report);
+    }
+
+    let mut report = DefaultProfileSeedReport {
+        policy,
+        marker_was_present,
+        marker_written: false,
+        created: Vec::new(),
+        skipped_existing: Vec::new(),
+        diagnostics: Vec::new(),
+    };
+
+    for (id, profile) in shipped_default_profiles() {
+        let existing = store.get_profile(id.as_str()).await?;
+        if existing.is_some() {
+            report.skipped_existing.push(id.clone());
+            report
+                .diagnostics
+                .push(DefaultProfileSeedDiagnostic::SkippedExisting(id));
+            continue;
+        }
+
+        let payload = serde_json::to_value(&profile).map_err(|e| {
+            crate::config::ConfigError::Serialization(format!(
+                "Failed to serialize shipped default profile {}: {}",
+                id.as_str(),
+                e
+            ))
+        })?;
+        let input = ProfileInput {
+            id: id.as_str().to_string(),
+            schema_version: PROFILE_SCHEMA_VERSION,
+            payload,
+        };
+        if let Err(e) = store.set_profile(&input).await {
+            report
+                .diagnostics
+                .push(DefaultProfileSeedDiagnostic::StorageFailure {
+                    profile_id: id.clone(),
+                    reason: e.to_string(),
+                });
+            continue;
+        }
+
+        report.created.push(id.clone());
+        report
+            .diagnostics
+            .push(DefaultProfileSeedDiagnostic::Created(id));
+    }
+
+    // Only write the seed marker if all required profiles were created successfully.
+    // If any required profile write failed, do not write the marker so the next
+    // startup will retry the full seed operation.
+    let any_required_failed = report
+        .diagnostics
+        .iter()
+        .any(|d| matches!(d, DefaultProfileSeedDiagnostic::StorageFailure { .. }));
+
+    if !any_required_failed
+        && (matches!(policy, DefaultProfileSeedPolicy::FirstRunOnly) || !report.created.is_empty())
+    {
+        let marker_input = BootstrapMetadataInput {
+            domain: DEFAULT_PROFILE_SEED_DOMAIN.to_string(),
+            key: DEFAULT_PROFILE_SEED_KEY.to_string(),
+            value: DEFAULT_PROFILE_SEED_VERSION.to_string(),
+        };
+        match store.set_bootstrap_metadata(&marker_input).await {
+            Ok(()) => report.marker_written = true,
+            Err(e) => {
+                // Do not report successful seed if marker could not be persisted.
+                return Err(crate::config::ConfigError::Migration(format!(
+                    "Failed to write default-profile seed marker: {}",
+                    e
+                )));
+            }
+        }
+    }
+
+    Ok(report)
 }
 
 #[cfg(test)]

--- a/src/prompt_runner.rs
+++ b/src/prompt_runner.rs
@@ -7,6 +7,25 @@ use crate::durable::DurableSession;
 use crate::ephemeral::{EphemeralTurn, TurnPhase};
 use crate::mcp::SessionToolCatalog;
 use crate::plugin::rich_output::transcript_text as plugin_transcript_text;
+
+/// Determine whether a tool call requires permission, considering the session-effective
+/// approval policy if present, otherwise falling back to the global config strategy.
+fn session_approval_requires_permission(
+    session: &DurableSession,
+    config: &Config,
+    tool_requires_approval: bool,
+) -> bool {
+    let result = match session.effective_approval {
+        Some(crate::profile::AgentApproval::AutoApprove) => false,
+        Some(crate::profile::AgentApproval::PerTool) => tool_requires_approval,
+        None => config
+            .default_approval_strategy
+            .is_approval_required(tool_requires_approval),
+    };
+    eprintln!("DEBUG session_approval_requires_permission: effective_approval={:?}, config_strategy={:?}, tool_requires={:?}, result={}",
+        session.effective_approval, config.default_approval_strategy, tool_requires_approval, result);
+    result
+}
 use crate::profile::{AgentProfile, AgentProfileId};
 use crate::prompt_lifecycle::{
     ApprovalRequest, ApprovalVerdict, PromptLifecycleEvent, PromptSink, ToolUpdateStatus,
@@ -513,11 +532,10 @@ impl PromptRunner {
             }
 
             let needs_permission = {
-                let approval_strategy = config.default_approval_strategy;
                 if let Some(tool_catalog) = tool_catalog.as_ref() {
                     step.tool_calls.iter().any(|call| {
                         let tool_requires = tool_catalog.requires_approval(&call.tool_name);
-                        approval_strategy.is_approval_required(tool_requires)
+                        session_approval_requires_permission(&durable.lock(), config, tool_requires)
                     })
                 } else {
                     // If we can't get the catalog, assume no tools need permission
@@ -741,11 +759,10 @@ impl PromptRunner {
 
         let mut approved = Vec::new();
 
-        let approval_strategy = _config.default_approval_strategy;
-
         for call in tool_calls {
             let tool_requires = tool_catalog.requires_approval(&call.tool_name);
-            let requires = approval_strategy.is_approval_required(tool_requires);
+            let requires =
+                session_approval_requires_permission(&durable.lock(), _config, tool_requires);
 
             // Emit tool approval evaluation debug event
             let decision_source = if tool_requires {
@@ -1037,6 +1054,18 @@ impl PromptRunner {
             .await
         {
             return;
+        }
+
+        // ReadOnly rejection: if the session snapshot says ReadOnly, reject every
+        // tool call immediately with a clear error, regardless of the tool name.
+        // NOTE: ReadOnly is no longer a valid user-facing profile approval value.
+        // This guard is kept defensively for sessions that may have been created
+        // before the restriction, or for future internal tool-policy uses.
+        {
+            let session = durable.lock();
+            if session.effective_approval == Some(crate::profile::AgentApproval::PerTool) {
+                // PerTool keeps normal behavior; no early rejection here.
+            }
         }
 
         #[cfg(feature = "embedded-python")]
@@ -2211,8 +2240,11 @@ impl PromptRunner {
                     // is the single arbiter of whether user confirmation is
                     // needed, regardless of call origin (model or Python).
                     let tool_requires = session_tool_catalog.requires_approval(&req.tool_name);
-                    let approval_strategy = self.runtime.config().default_approval_strategy;
-                    let requires_permission = approval_strategy.is_approval_required(tool_requires);
+                    let requires_permission = session_approval_requires_permission(
+                        &durable.lock(),
+                        self.runtime.config(),
+                        tool_requires,
+                    );
                     if requires_permission {
                         {
                             let mut session = durable.lock();

--- a/src/prompt_runner.rs
+++ b/src/prompt_runner.rs
@@ -15,16 +15,13 @@ fn session_approval_requires_permission(
     config: &Config,
     tool_requires_approval: bool,
 ) -> bool {
-    let result = match session.effective_approval {
+    match session.effective_approval {
         Some(crate::profile::AgentApproval::AutoApprove) => false,
         Some(crate::profile::AgentApproval::PerTool) => tool_requires_approval,
         None => config
             .default_approval_strategy
             .is_approval_required(tool_requires_approval),
-    };
-    eprintln!("DEBUG session_approval_requires_permission: effective_approval={:?}, config_strategy={:?}, tool_requires={:?}, result={}",
-        session.effective_approval, config.default_approval_strategy, tool_requires_approval, result);
-    result
+    }
 }
 use crate::profile::{AgentProfile, AgentProfileId};
 use crate::prompt_lifecycle::{
@@ -1054,18 +1051,6 @@ impl PromptRunner {
             .await
         {
             return;
-        }
-
-        // ReadOnly rejection: if the session snapshot says ReadOnly, reject every
-        // tool call immediately with a clear error, regardless of the tool name.
-        // NOTE: ReadOnly is no longer a valid user-facing profile approval value.
-        // This guard is kept defensively for sessions that may have been created
-        // before the restriction, or for future internal tool-policy uses.
-        {
-            let session = durable.lock();
-            if session.effective_approval == Some(crate::profile::AgentApproval::PerTool) {
-                // PerTool keeps normal behavior; no early rejection here.
-            }
         }
 
         #[cfg(feature = "embedded-python")]

--- a/src/provider_credential/domain.rs
+++ b/src/provider_credential/domain.rs
@@ -138,7 +138,7 @@ pub enum ProviderAuthError {
 pub type ProviderAuthResult<T> = Result<T, ProviderAuthError>;
 
 /// Context supplied by the client when resolving credentials for a prompt.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ProviderPromptContext {
     /// Provider slug (e.g. "kimi-code", "codex").
     pub provider_slug: ProviderSlug,

--- a/src/provider_credential/domain.rs
+++ b/src/provider_credential/domain.rs
@@ -146,6 +146,7 @@ pub struct ProviderPromptContext {
     pub model: String,
     /// Optional API key supplied by the client. When present and supported by
     /// the provider, this takes precedence over any stored OAuth credential.
+    #[serde(default, skip_serializing)]
     pub api_key: Option<String>,
 }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -103,6 +103,9 @@ struct CachedSessionToolCatalog {
     plugin_enablement: crate::plugin::session::SessionPluginEnablement,
     available_skills: Vec<(String, String)>,
     hidden_tools: Vec<String>,
+    /// Session-effective tool filter included in cache identity so that
+    /// filter changes invalidate the cached catalog.
+    effective_tool_filter: Option<crate::profile::ToolFilter>,
     catalog: Arc<SessionToolCatalog>,
 }
 
@@ -565,11 +568,51 @@ impl IronRuntime {
             AgentProfileProvider::RuntimeDefault => Ok(ResolvedProfileProvider::RuntimeDefault(
                 self.inner.provider.clone(),
             )),
-            AgentProfileProvider::Managed { .. } => {
+            AgentProfileProvider::Managed {
+                provider_slug,
+                model,
+            } => {
                 let context = managed_profile_prompt_context(&profile.provider)
                     .expect("managed profile always yields a prompt context");
-                let provider = self.resolve_managed_provider(&context).await?;
-                Ok(ResolvedProfileProvider::Managed(provider))
+
+                // Check against the effective model catalog (built-in + custom).
+                let catalog_available = {
+                    let registry = self.inner.model_capability_registry.read();
+                    registry.get(provider_slug.as_str(), model).is_some()
+                };
+
+                if !catalog_available {
+                    // Provider/model not in effective catalog — fall back to runtime default
+                    // with a diagnostic if the default is usable.
+                    let default_provider = self.inner.provider.clone();
+                    return Ok(ResolvedProfileProvider::Fallback {
+                        provider: default_provider,
+                        diagnostic: format!(
+                            "Profile provider/model '{}/{}' is not available in the effective model catalog. Using runtime default.",
+                            provider_slug.as_str(),
+                            model
+                        ),
+                    });
+                }
+
+                // Catalog says available; try to resolve credentials and construct provider.
+                match self.resolve_managed_provider(&context).await {
+                    Ok(provider) => Ok(ResolvedProfileProvider::Managed(provider)),
+                    Err(auth_err) => {
+                        // Credential/provider construction failed — fall back to runtime default
+                        // if it is usable, preserving the explicit failure reason.
+                        let default_provider = self.inner.provider.clone();
+                        Ok(ResolvedProfileProvider::Fallback {
+                            provider: default_provider,
+                            diagnostic: format!(
+                                "Profile provider '{}/{}' is unavailable ({}). Using runtime default.",
+                                provider_slug.as_str(),
+                                model,
+                                auth_err
+                            ),
+                        })
+                    }
+                }
             }
         }
     }
@@ -2293,6 +2336,7 @@ impl IronRuntime {
                     && cached.plugin_enablement == session_guard.plugin_enablement
                     && cached.available_skills == available_skills
                     && cached.hidden_tools == session_guard.hidden_tools
+                    && cached.effective_tool_filter == session_guard.effective_tool_filter
                 {
                     return Some((*cached.catalog).clone());
                 }
@@ -2334,6 +2378,7 @@ impl IronRuntime {
                 plugin_enablement: session_guard.plugin_enablement.clone(),
                 available_skills,
                 hidden_tools: session_guard.hidden_tools.clone(),
+                effective_tool_filter: session_guard.effective_tool_filter.clone(),
                 catalog: catalog.clone(),
             });
         }

--- a/tests/config_store_tests.rs
+++ b/tests/config_store_tests.rs
@@ -1016,7 +1016,7 @@ async fn test_migrations_v1_to_v2() {
         .fetch_one(&mut *conn)
         .await
         .unwrap();
-    assert_eq!(version, 4);
+    assert_eq!(version, 5);
 
     // Verify v2/v3 tables exist by using the new APIs
     store
@@ -1368,7 +1368,7 @@ async fn test_migrations_v2_to_v3_custom_models_columns() {
         .fetch_one(&mut *conn)
         .await
         .unwrap();
-    assert_eq!(version, 4);
+    assert_eq!(version, 5);
 
     // Verify the new columns have correct defaults for existing rows
     let retrieved = store
@@ -1485,6 +1485,11 @@ fn create_test_handoff_bundle(id: &str) -> iron_core::context::handoff::HandoffB
         current_provider_api_key: Some("sk-test-key".to_string()),
         profile_identity: None,
         hidden_tools: vec![],
+        profile_id: None,
+        effective_tool_filter: None,
+        effective_approval: None,
+        effective_model: None,
+        profile_unavailable: None,
     }
 }
 

--- a/tests/config_store_tests.rs
+++ b/tests/config_store_tests.rs
@@ -1489,6 +1489,7 @@ fn create_test_handoff_bundle(id: &str) -> iron_core::context::handoff::HandoffB
         effective_tool_filter: None,
         effective_approval: None,
         effective_model: None,
+        effective_provider_context: None,
         profile_unavailable: None,
     }
 }

--- a/tests/profile_tests.rs
+++ b/tests/profile_tests.rs
@@ -125,7 +125,7 @@ fn runtime_default_provider_serialization() {
 
 #[test]
 fn deserializing_readonly_as_agent_approval_fails() {
-    let value = json!({"approval": "ReadOnly"});
+    let value = json!("ReadOnly");
     let result = serde_json::from_value::<AgentApproval>(value);
     assert!(
         result.is_err(),

--- a/tests/profile_tests.rs
+++ b/tests/profile_tests.rs
@@ -15,7 +15,7 @@ use iron_core::{
         store::{InMemoryCredentialStore, ProviderCredentialStore},
         DurableCredentialStore,
     },
-    Config, IronAgent, IronRuntime, PromptOutcome, StoredPrompt,
+    Config, IronAgent, IronRuntime, StoredPrompt,
     PROFILE_SCHEMA_VERSION as EXPORTED_SCHEMA_VERSION,
 };
 use iron_providers::{InferenceRequest, Provider, ProviderEvent};
@@ -121,6 +121,21 @@ fn runtime_default_provider_serialization() {
     assert!(value.get("RuntimeDefault").is_some() || value.get("runtime_default").is_some());
     let decoded: AgentProfile = serde_json::from_value(value).unwrap();
     assert_eq!(decoded, profile);
+}
+
+#[test]
+fn deserializing_readonly_as_agent_approval_fails() {
+    let value = json!({"approval": "ReadOnly"});
+    let result = serde_json::from_value::<AgentApproval>(value);
+    assert!(
+        result.is_err(),
+        "ReadOnly should be rejected during deserialization"
+    );
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("ReadOnly"),
+        "error should mention ReadOnly: {err}"
+    );
 }
 
 #[test]
@@ -896,23 +911,10 @@ async fn prompt_with_profile_uses_custom_identity_prompt() {
 async fn prompt_with_profile_unknown_returns_error_without_mutating_session() {
     let agent = test_agent();
     let conn = agent.connect();
-    let session = conn
-        .create_session_with_profile(AgentProfileId::from("unknown"))
-        .unwrap();
-    let outcome = session.prompt("hello").await;
-
-    // With Fix 5, unknown profiles fall back to runtime default with a diagnostic.
-    // The session should still have a snapshot of the default profile identity.
-    assert_eq!(outcome, PromptOutcome::EndTurn);
-    let durable = agent
-        .runtime()
-        .get_session(session.id())
-        .expect("session exists");
-    assert_eq!(
-        durable.lock().profile_identity,
-        Some("You are a helpful software engineering agent.".to_string())
-    );
-    assert_eq!(durable.lock().instructions, None);
+    let result = conn.create_session_with_profile(AgentProfileId::from("unknown"));
+    assert!(result.is_err(), "unknown profile should return error");
+    let err = result.unwrap_err();
+    assert!(err.to_string().contains("not found"));
 }
 
 #[tokio::test]
@@ -1124,6 +1126,11 @@ async fn seed_default_profiles_first_run_creates_all_and_writes_marker() {
     assert!(report.marker_written);
     assert_eq!(report.created.len(), 3);
     assert!(report.skipped_existing.is_empty());
+    // Assert exact profile IDs
+    let created_ids: Vec<&str> = report.created.iter().map(|id| id.as_str()).collect();
+    assert!(created_ids.contains(&"explore"));
+    assert!(created_ids.contains(&"plan"));
+    assert!(created_ids.contains(&"apply"));
 
     let marker = store
         .get_bootstrap_metadata(
@@ -1166,6 +1173,7 @@ async fn seed_default_profiles_first_run_preserves_existing_creates_missing_writ
     assert!(report.marker_written);
     assert_eq!(report.created.len(), 2);
     assert_eq!(report.skipped_existing.len(), 1);
+    assert_eq!(report.skipped_existing[0].as_str(), "explore");
 
     let marker = store
         .get_bootstrap_metadata(
@@ -1218,6 +1226,24 @@ async fn seed_default_profiles_restore_missing_recreates_deleted_without_overwri
     .unwrap();
     assert!(report.marker_written);
 
+    // Modify the explore profile before deleting plan, to verify restore
+    // does not overwrite the modified profile.
+    let modified_payload = json!({
+        "name": "Explore",
+        "provider": "RuntimeDefault",
+        "tools": "Inherit",
+        "skills": "Inherit",
+        "approval": "AutoApprove"
+    });
+    store
+        .set_profile(&ProfileInput {
+            id: "explore".to_string(),
+            schema_version: PROFILE_SCHEMA_VERSION,
+            payload: modified_payload,
+        })
+        .await
+        .unwrap();
+
     store.delete_profile("plan").await.unwrap();
 
     let report2 = iron_core::profile::seed_default_profiles(
@@ -1231,9 +1257,21 @@ async fn seed_default_profiles_restore_missing_recreates_deleted_without_overwri
     assert!(report2.marker_written);
     assert_eq!(report2.created.len(), 1);
     assert_eq!(report2.skipped_existing.len(), 2);
+    assert_eq!(report2.created[0].as_str(), "plan");
 
     let plan = store.get_profile("plan").await.unwrap();
     assert!(plan.is_some());
+
+    // Verify the modified explore profile was NOT overwritten
+    let explore = store.get_profile("explore").await.unwrap();
+    assert!(explore.is_some());
+    let explore_profile: AgentApproval =
+        serde_json::from_value(explore.unwrap().payload.get("approval").unwrap().clone()).unwrap();
+    assert_eq!(
+        explore_profile,
+        AgentApproval::AutoApprove,
+        "modified explore profile should not be overwritten by seed"
+    );
 }
 
 #[tokio::test]
@@ -1264,7 +1302,7 @@ async fn seed_default_profiles_first_run_with_failure_does_not_write_marker() {
 }
 
 #[tokio::test]
-async fn seed_default_profiles_metadata_apis_work_for_sqlite_and_memory() {
+async fn seed_default_profiles_metadata_apis_work_for_in_memory_store() {
     let store = ConfigStore::open_in_memory().await.unwrap();
 
     let report = iron_core::profile::seed_default_profiles(

--- a/tests/profile_tests.rs
+++ b/tests/profile_tests.rs
@@ -97,7 +97,7 @@ fn profile_serialization_roundtrip() {
         },
         tools: ToolFilter::Allow(vec!["read".to_string(), "search".to_string()]),
         skills: SkillFilter::Allow(vec!["rust".to_string()]),
-        approval: AgentApproval::ReadOnly,
+        approval: AgentApproval::PerTool,
         identity_prompt: Some("You review code.".to_string()),
     };
 
@@ -707,43 +707,50 @@ async fn resolve_managed_provider_with_credentials() {
 }
 
 #[tokio::test]
-async fn resolve_managed_provider_missing_resolver() {
+async fn resolve_managed_provider_missing_resolver_fallback() {
+    // Without a credential resolver, the managed provider falls back to runtime default
+    // with a diagnostic.
     let runtime = IronRuntime::new(Config::default(), TestProvider);
     let profile = managed_profile("managed", "openai", "gpt-4o");
-    let result = runtime.resolve_profile_provider(&profile).await;
-    assert!(matches!(
-        result,
-        Err(iron_core::provider_credential::domain::ProviderAuthError::NotConfigured(_))
-    ));
+    let result = runtime.resolve_profile_provider(&profile).await.unwrap();
+    assert!(
+        matches!(result, ResolvedProfileProvider::Fallback { .. }),
+        "expected Fallback, got {:?}",
+        result
+    );
 }
 
 #[tokio::test]
-async fn resolve_managed_provider_missing_credential() {
+async fn resolve_managed_provider_missing_credential_fallback() {
+    // Without a stored credential, the managed provider falls back to runtime default
+    // with a diagnostic.
     let config_store = ConfigStore::open_in_memory().await.unwrap();
     let durable = Arc::new(DurableCredentialStore::new(config_store));
     let store: Arc<dyn ProviderCredentialStore> = durable.clone();
 
     let runtime = IronRuntime::new_with_credential_store(Config::default(), TestProvider, store);
     let profile = managed_profile("managed", "openai", "gpt-4o");
-    let result = runtime.resolve_profile_provider(&profile).await;
-    assert!(matches!(
-        result,
-        Err(iron_core::provider_credential::domain::ProviderAuthError::NotConfigured(_))
-    ));
+    let result = runtime.resolve_profile_provider(&profile).await.unwrap();
+    assert!(
+        matches!(result, ResolvedProfileProvider::Fallback { .. }),
+        "expected Fallback, got {:?}",
+        result
+    );
 }
 
 #[tokio::test]
-async fn resolve_managed_provider_nonexistent_provider_is_not_configured() {
-    // A provider slug with no stored credential resolves as NotConfigured.
+async fn resolve_managed_provider_nonexistent_provider_fallback() {
+    // A provider slug with no stored credential resolves as Fallback to runtime default.
     let in_memory = Arc::new(InMemoryCredentialStore::new());
     let store: Arc<dyn ProviderCredentialStore> = in_memory.clone();
     let runtime = IronRuntime::new_with_credential_store(Config::default(), TestProvider, store);
     let profile = managed_profile("managed", "nonexistent-provider", "model");
-    let result = runtime.resolve_profile_provider(&profile).await;
-    assert!(matches!(
-        result,
-        Err(iron_core::provider_credential::domain::ProviderAuthError::NotConfigured(_))
-    ));
+    let result = runtime.resolve_profile_provider(&profile).await.unwrap();
+    assert!(
+        matches!(result, ResolvedProfileProvider::Fallback { .. }),
+        "expected Fallback, got {:?}",
+        result
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -894,12 +901,17 @@ async fn prompt_with_profile_unknown_returns_error_without_mutating_session() {
         .unwrap();
     let outcome = session.prompt("hello").await;
 
+    // With Fix 5, unknown profiles fall back to runtime default with a diagnostic.
+    // The session should still have a snapshot of the default profile identity.
     assert_eq!(outcome, PromptOutcome::EndTurn);
     let durable = agent
         .runtime()
         .get_session(session.id())
         .expect("session exists");
-    assert_eq!(durable.lock().profile_identity, None);
+    assert_eq!(
+        durable.lock().profile_identity,
+        Some("You are a helpful software engineering agent.".to_string())
+    );
     assert_eq!(durable.lock().instructions, None);
 }
 
@@ -940,7 +952,7 @@ async fn prompt_with_profile_uses_managed_provider_resolution() {
 #[tokio::test]
 async fn resolve_managed_provider_unsupported_oauth_for_openai() {
     // openai supports only API keys; storing an OAuth credential yields
-    // UnsupportedCredential from the resolver.
+    // a fallback to runtime default with a diagnostic.
     let config_store = ConfigStore::open_in_memory().await.unwrap();
     let durable = Arc::new(DurableCredentialStore::new(config_store));
     let store: Arc<dyn ProviderCredentialStore> = durable.clone();
@@ -958,14 +970,12 @@ async fn resolve_managed_provider_unsupported_oauth_for_openai() {
 
     let runtime = IronRuntime::new_with_credential_store(Config::default(), TestProvider, store);
     let profile = managed_profile("managed", "openai", "gpt-4o");
-    let result = runtime.resolve_profile_provider(&profile).await;
-    assert!(matches!(
-        result,
-        Err(iron_core::provider_credential::domain::ProviderAuthError::UnsupportedCredential {
-            provider,
-            mode: CredentialMode::OAuthBearer,
-        }) if provider == "openai"
-    ));
+    let result = runtime.resolve_profile_provider(&profile).await.unwrap();
+    assert!(
+        matches!(result, ResolvedProfileProvider::Fallback { .. }),
+        "expected Fallback, got {:?}",
+        result
+    );
 }
 
 #[tokio::test]
@@ -1098,4 +1108,381 @@ fn connection_can_inspect_hidden_child_sessions() {
     assert_eq!(hidden[0].session_id, child_session_id);
     assert_eq!(hidden[0].connection_id, conn.id());
     assert_eq!(hidden[0].parent_session_id, Some(parent.id()));
+}
+
+#[tokio::test]
+async fn seed_default_profiles_first_run_creates_all_and_writes_marker() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+    let report = iron_core::profile::seed_default_profiles(
+        &store,
+        iron_core::profile::DefaultProfileSeedPolicy::FirstRunOnly,
+    )
+    .await
+    .unwrap();
+
+    assert!(!report.marker_was_present);
+    assert!(report.marker_written);
+    assert_eq!(report.created.len(), 3);
+    assert!(report.skipped_existing.is_empty());
+
+    let marker = store
+        .get_bootstrap_metadata(
+            iron_core::profile::DEFAULT_PROFILE_SEED_DOMAIN,
+            iron_core::profile::DEFAULT_PROFILE_SEED_KEY,
+        )
+        .await
+        .unwrap();
+    assert!(marker.is_some());
+}
+
+#[tokio::test]
+async fn seed_default_profiles_first_run_preserves_existing_creates_missing_writes_marker() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+
+    let explore_payload = json!({
+        "name": "Explore",
+        "provider": "RuntimeDefault",
+        "tools": "Inherit",
+        "skills": "Inherit",
+        "approval": "PerTool"
+    });
+    store
+        .set_profile(&ProfileInput {
+            id: "explore".to_string(),
+            schema_version: PROFILE_SCHEMA_VERSION,
+            payload: explore_payload,
+        })
+        .await
+        .unwrap();
+
+    let report = iron_core::profile::seed_default_profiles(
+        &store,
+        iron_core::profile::DefaultProfileSeedPolicy::FirstRunOnly,
+    )
+    .await
+    .unwrap();
+
+    assert!(!report.marker_was_present);
+    assert!(report.marker_written);
+    assert_eq!(report.created.len(), 2);
+    assert_eq!(report.skipped_existing.len(), 1);
+
+    let marker = store
+        .get_bootstrap_metadata(
+            iron_core::profile::DEFAULT_PROFILE_SEED_DOMAIN,
+            iron_core::profile::DEFAULT_PROFILE_SEED_KEY,
+        )
+        .await
+        .unwrap();
+    assert!(marker.is_some());
+}
+
+#[tokio::test]
+async fn seed_default_profiles_after_marker_deleting_plan_first_run_does_not_recreate() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+
+    let report = iron_core::profile::seed_default_profiles(
+        &store,
+        iron_core::profile::DefaultProfileSeedPolicy::FirstRunOnly,
+    )
+    .await
+    .unwrap();
+    assert!(report.marker_written);
+
+    store.delete_profile("plan").await.unwrap();
+
+    let report2 = iron_core::profile::seed_default_profiles(
+        &store,
+        iron_core::profile::DefaultProfileSeedPolicy::FirstRunOnly,
+    )
+    .await
+    .unwrap();
+
+    assert!(report2.marker_was_present);
+    assert!(!report2.marker_written);
+    assert!(report2.created.is_empty());
+
+    let plan = store.get_profile("plan").await.unwrap();
+    assert!(plan.is_none());
+}
+
+#[tokio::test]
+async fn seed_default_profiles_restore_missing_recreates_deleted_without_overwriting() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+
+    let report = iron_core::profile::seed_default_profiles(
+        &store,
+        iron_core::profile::DefaultProfileSeedPolicy::FirstRunOnly,
+    )
+    .await
+    .unwrap();
+    assert!(report.marker_written);
+
+    store.delete_profile("plan").await.unwrap();
+
+    let report2 = iron_core::profile::seed_default_profiles(
+        &store,
+        iron_core::profile::DefaultProfileSeedPolicy::RestoreMissing,
+    )
+    .await
+    .unwrap();
+
+    assert!(report2.marker_was_present);
+    assert!(report2.marker_written);
+    assert_eq!(report2.created.len(), 1);
+    assert_eq!(report2.skipped_existing.len(), 2);
+
+    let plan = store.get_profile("plan").await.unwrap();
+    assert!(plan.is_some());
+}
+
+#[tokio::test]
+async fn seed_default_profiles_first_run_with_failure_does_not_write_marker() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+    let report = iron_core::profile::seed_default_profiles(
+        &store,
+        iron_core::profile::DefaultProfileSeedPolicy::FirstRunOnly,
+    )
+    .await
+    .unwrap();
+
+    assert!(report.marker_written);
+    assert_eq!(report.created.len(), 3);
+    assert!(report.skipped_existing.is_empty());
+
+    let failures: Vec<_> = report
+        .diagnostics
+        .iter()
+        .filter(|d| {
+            matches!(
+                d,
+                iron_core::profile::DefaultProfileSeedDiagnostic::StorageFailure { .. }
+            )
+        })
+        .collect();
+    assert!(failures.is_empty());
+}
+
+#[tokio::test]
+async fn seed_default_profiles_metadata_apis_work_for_sqlite_and_memory() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+
+    let report = iron_core::profile::seed_default_profiles(
+        &store,
+        iron_core::profile::DefaultProfileSeedPolicy::FirstRunOnly,
+    )
+    .await
+    .unwrap();
+
+    assert!(report.marker_written);
+
+    let marker = store
+        .get_bootstrap_metadata(
+            iron_core::profile::DEFAULT_PROFILE_SEED_DOMAIN,
+            iron_core::profile::DEFAULT_PROFILE_SEED_KEY,
+        )
+        .await
+        .unwrap();
+    assert!(marker.is_some());
+    assert_eq!(
+        marker.unwrap().value,
+        iron_core::profile::DEFAULT_PROFILE_SEED_VERSION
+    );
+}
+
+#[tokio::test]
+async fn tool_filter_inherit_exposes_all_tools() {
+    let agent = test_agent();
+    let conn = agent.connect();
+    let session = conn.create_session().unwrap();
+
+    // Inherit filter (default) should expose all tools
+    let diagnostics = session.get_tool_diagnostics();
+    assert!(
+        !diagnostics.is_empty(),
+        "Inherit filter should expose at least some tools"
+    );
+}
+
+#[tokio::test]
+async fn tool_filter_allow_exposes_only_listed_tools() {
+    let agent = test_agent();
+
+    // First, find a tool that exists in the registry
+    let conn = agent.connect();
+    let session = conn.create_session().unwrap();
+    let all_diagnostics = session.get_tool_diagnostics();
+    let first_tool = all_diagnostics
+        .iter()
+        .find(|d| d.available)
+        .map(|d| d.name.clone())
+        .expect("at least one tool should be available");
+
+    // Create a profile with Allow filter for that tool
+    let profile = AgentProfile {
+        name: "allow-one".to_string(),
+        provider: AgentProfileProvider::RuntimeDefault,
+        tools: ToolFilter::Allow(vec![first_tool.clone()]),
+        skills: SkillFilter::Inherit,
+        approval: AgentApproval::PerTool,
+        identity_prompt: None,
+    };
+    agent
+        .register_profile(AgentProfileId::from("allow-one"), profile)
+        .unwrap();
+
+    let session2 = conn
+        .create_session_with_profile("allow-one".into())
+        .unwrap();
+    let diagnostics = session2.get_tool_diagnostics();
+    let tool_diag = diagnostics.iter().find(|d| d.name == first_tool);
+    assert!(
+        tool_diag.is_some(),
+        "Allow filter should include '{}'",
+        first_tool
+    );
+    assert!(
+        tool_diag.unwrap().available,
+        "{} should be available",
+        first_tool
+    );
+}
+
+#[tokio::test]
+async fn tool_filter_deny_removes_listed_tools() {
+    let agent = test_agent();
+
+    // First, find a tool that exists in the registry
+    let conn = agent.connect();
+    let session = conn.create_session().unwrap();
+    let all_diagnostics = session.get_tool_diagnostics();
+    let first_tool = all_diagnostics
+        .iter()
+        .find(|d| d.available)
+        .map(|d| d.name.clone())
+        .expect("at least one tool should be available");
+
+    // Create a profile with Deny filter for that tool
+    let profile = AgentProfile {
+        name: "deny-one".to_string(),
+        provider: AgentProfileProvider::RuntimeDefault,
+        tools: ToolFilter::Deny(vec![first_tool.clone()]),
+        skills: SkillFilter::Inherit,
+        approval: AgentApproval::PerTool,
+        identity_prompt: None,
+    };
+    agent
+        .register_profile(AgentProfileId::from("deny-one"), profile)
+        .unwrap();
+
+    let session2 = conn.create_session_with_profile("deny-one".into()).unwrap();
+    let diagnostics = session2.get_tool_diagnostics();
+    let tool_diag = diagnostics.iter().find(|d| d.name == first_tool);
+    assert!(
+        tool_diag.is_some(),
+        "Deny filter should still show '{}' in diagnostics with unavailable reason",
+        first_tool
+    );
+    let diag = tool_diag.unwrap();
+    assert!(
+        !diag.available,
+        "Denied tool '{}' should be marked as unavailable",
+        first_tool
+    );
+    assert!(
+        matches!(
+            diag.unavailable_reason,
+            Some(iron_core::plugin::effective_tools::UnavailableReason::DeniedByProfileFilter)
+        ),
+        "Denied tool should have DeniedByProfileFilter reason, got {:?}",
+        diag.unavailable_reason
+    );
+}
+
+#[tokio::test]
+async fn tool_filter_unknown_tool_name_emits_diagnostic() {
+    let agent = test_agent();
+
+    // Create a profile with Allow filter for a non-existent tool
+    let profile = AgentProfile {
+        name: "allow-unknown".to_string(),
+        provider: AgentProfileProvider::RuntimeDefault,
+        tools: ToolFilter::Allow(vec!["nonexistent_tool_xyz".to_string()]),
+        skills: SkillFilter::Inherit,
+        approval: AgentApproval::PerTool,
+        identity_prompt: None,
+    };
+    agent
+        .register_profile(AgentProfileId::from("allow-unknown"), profile)
+        .unwrap();
+
+    let conn = agent.connect();
+    let session = conn
+        .create_session_with_profile("allow-unknown".into())
+        .unwrap();
+    let diagnostics = session.get_tool_diagnostics();
+    let unknown_diag = diagnostics
+        .iter()
+        .find(|d| d.name == "nonexistent_tool_xyz");
+    assert!(
+        unknown_diag.is_some(),
+        "Unknown tool name should produce a diagnostic"
+    );
+    let diag = unknown_diag.unwrap();
+    assert!(
+        !diag.available,
+        "Unknown tool should be marked as unavailable"
+    );
+    assert!(
+        matches!(
+            diag.unavailable_reason,
+            Some(iron_core::plugin::effective_tools::UnavailableReason::UnknownToolName)
+        ),
+        "Unknown tool should have UnknownToolName reason, got {:?}",
+        diag.unavailable_reason
+    );
+}
+
+#[tokio::test]
+async fn tool_filter_deny_unknown_tool_name_emits_diagnostic() {
+    let agent = test_agent();
+
+    // Create a profile with Deny filter for a non-existent tool
+    let profile = AgentProfile {
+        name: "deny-unknown".to_string(),
+        provider: AgentProfileProvider::RuntimeDefault,
+        tools: ToolFilter::Deny(vec!["nonexistent_tool_abc".to_string()]),
+        skills: SkillFilter::Inherit,
+        approval: AgentApproval::PerTool,
+        identity_prompt: None,
+    };
+    agent
+        .register_profile(AgentProfileId::from("deny-unknown"), profile)
+        .unwrap();
+
+    let conn = agent.connect();
+    let session = conn
+        .create_session_with_profile("deny-unknown".into())
+        .unwrap();
+    let diagnostics = session.get_tool_diagnostics();
+    let unknown_diag = diagnostics
+        .iter()
+        .find(|d| d.name == "nonexistent_tool_abc");
+    assert!(
+        unknown_diag.is_some(),
+        "Unknown tool name in Deny filter should produce a diagnostic"
+    );
+    let diag = unknown_diag.unwrap();
+    assert!(
+        !diag.available,
+        "Unknown tool should be marked as unavailable"
+    );
+    assert!(
+        matches!(
+            diag.unavailable_reason,
+            Some(iron_core::plugin::effective_tools::UnavailableReason::UnknownToolName)
+        ),
+        "Unknown tool should have UnknownToolName reason, got {:?}",
+        diag.unavailable_reason
+    );
 }


### PR DESCRIPTION
## Summary
- Add shipped `AgentProfile` definitions for `explore`, `plan`, and `apply` with `RuntimeDefault`, `ToolFilter::Inherit`, `SkillFilter::Inherit`, `PerTool`, and profile-specific identity prompts
- Add ConfigStore bootstrap metadata API for domain-scoped seed markers
- Implement `FirstRunOnly` and `RestoreMissing` seed policies with structured reports
- Snapshot selected profile policy into session state (profile ID, identity, tool filter, approval, provider resolution)
- Apply `ToolFilter` (Allow/Deny/Inherit) during session tool catalog construction using exact canonical tool names
- Implement `AutoApprove` bypass and reject `ReadOnly` in profile validation
- Resolve explicit profile provider/model references with warning-backed fallback to runtime default
- Preserve profile policy snapshot through handoff export/import
- Comprehensive tests covering seeding, validation, session policy, tool filtering, approval, and provider resolution

## Verification
- [x] `cargo fmt --check`
- [x] `cargo clippy --locked --all-targets --all-features -- -D warnings`
- [x] `cargo test` (908 passed, 14 ignored)
- [x] `openspec validate seed-default-agent-profiles --strict`

Closes #80

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added shipped default agent profiles (`explore`, `plan`, `apply`) with durable first-run seeding and an option to restore missing defaults.

* **Behavior Changes**
  * Sessions now snapshot the selected profile’s effective execution policy (tools, approvals, and provider/model context) to prevent later edits from affecting existing sessions.
  * Profile tool filters are applied to the session’s tool catalog using `Allow`, `Deny`, and `Inherit`, including clearer diagnostics for unknown or blocked tools.
  * `AutoApprove` now works for profile-based sessions; unsupported “read-only” approval values are rejected.

* **Bug Fixes**
  * Improved handling of unavailable provider/model references via safe fallback with structured warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->