### PR TITLE
feat(provider-profiles): load store-backed provider profiles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,16 +28,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aegis"
-version = "0.9.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e07d39d15384924b35b70d7b8fa1f9a2934101dd3fa4722ede163cc4f9b7b960"
-dependencies = [
- "cc",
- "softaes",
-]
-
-[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -49,24 +39,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "aes-gcm"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
-dependencies = [
- "aead",
- "aes",
- "cipher",
- "ctr",
- "ghash",
- "subtle",
-]
-
-[[package]]
 name = "agent-client-protocol"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efba6592048ef8a9ac97de8d79b2d9933d8ac4d94f7a2de102348fed0c61103"
+checksum = "794aea8f191be00ab10233745d49b49f53be6a3f4d7fe540f681aebc535c5415"
 dependencies = [
  "agent-client-protocol-derive",
  "agent-client-protocol-schema",
@@ -74,8 +50,7 @@ dependencies = [
  "blocking",
  "futures",
  "futures-concurrency",
- "jsonrpcmsg",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "schemars 1.2.1",
  "serde",
  "serde_json",
@@ -86,9 +61,9 @@ dependencies = [
 
 [[package]]
 name = "agent-client-protocol-derive"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d176a10d4cb06e0262a738c3c5bf21ff0968db13a666e31cbca94a3d3d72e7c"
+checksum = "83ffd930c0d668152ce6d591189f324835d46031eabecb51ada3619ad7e2a278"
 dependencies = [
  "quote",
  "syn",
@@ -96,9 +71,9 @@ dependencies = [
 
 [[package]]
 name = "agent-client-protocol-schema"
-version = "0.13.6"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c290bfa00c6b52339db66f8e9cf711d5f08530800529f7d619ff24d6cba253d0"
+checksum = "b4e7eb6f1e554741f621ae4abb046d4fbb3cb88541bc599693ae7f9aa30b72eb"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -146,96 +121,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
 
 [[package]]
-name = "android-native-keyring-store"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c6349ddff23194f8fdce2ea8849380f5a4868c1648965b70e801e104cba9b3"
-dependencies = [
- "base64",
- "jni 0.21.1",
- "keyring-core",
- "log",
- "ndk-context",
- "regex",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "tracing",
-]
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "anstream"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle"
-version = "1.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
-
-[[package]]
-name = "anstyle-parse"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "3.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
-dependencies = [
- "anstyle",
- "once_cell_polyfill",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "antithesis_sdk"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08410fcac93669a476c006cd6c4512ac1e2b30fd117231a5d55d8a2c76599b82"
-dependencies = [
- "libc",
- "libloading",
- "linkme",
- "once_cell",
- "rand 0.8.6",
- "rustc_version_runtime",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -260,21 +151,6 @@ name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
-
-[[package]]
-name = "arc-swap"
-version = "1.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
-name = "assoc"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfdc70193dadb9d7287fa4b633f15f90c876915b31f6af17da307fc59c9859a8"
 
 [[package]]
 name = "async-broadcast"
@@ -518,42 +394,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "bigdecimal"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d6867f1565b3aad85681f1015055b087fcfd840d6aeee6eee7f2da317603695"
-dependencies = [
- "autocfg",
- "libm",
- "num-bigint",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "bindgen"
-version = "0.69.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
-dependencies = [
- "bitflags",
- "cexpr",
- "clang-sys",
- "itertools 0.12.1",
- "lazy_static",
- "lazycell",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 1.1.0",
- "shlex 1.3.0",
- "syn",
- "which",
-]
-
-[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -588,9 +428,9 @@ dependencies = [
 
 [[package]]
 name = "bitvec"
-version = "1.0.1"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
 dependencies = [
  "funty",
  "radium",
@@ -645,15 +485,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
 
 [[package]]
-name = "branches"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e426eb5cc1900033930ec955317b302e68f19f326cc7bb0c8a86865a826cdf0c"
-dependencies = [
- "rustc_version",
-]
-
-[[package]]
 name = "bs58"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -693,20 +524,6 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
-dependencies = [
- "bytemuck_derive",
-]
-
-[[package]]
-name = "bytemuck_derive"
-version = "1.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "byteorder"
@@ -716,9 +533,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "cap-fs-ext"
@@ -824,29 +641,14 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.64"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex 2.0.1",
-]
-
-[[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
-
-[[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
+ "shlex",
 ]
 
 [[package]]
@@ -860,12 +662,6 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
-
-[[package]]
-name = "cfg_block"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18758054972164c3264f7c8386f5fc6da6114cb46b619fd365d4e3b2dc3ae487"
 
 [[package]]
 name = "chacha20"
@@ -928,57 +724,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading",
-]
-
-[[package]]
-name = "clap"
-version = "4.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
-dependencies = [
- "clap_builder",
- "clap_derive",
-]
-
-[[package]]
-name = "clap_builder"
-version = "4.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
-dependencies = [
- "anstream",
- "anstyle",
- "clap_lex",
- "strsim",
-]
-
-[[package]]
-name = "clap_derive"
-version = "4.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "clap_lex"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
-
-[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1007,12 +752,6 @@ name = "collection_literals"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2550f75b8cfac212855f6b1885455df8eaee8fe8e246b647d69146142e016084"
-
-[[package]]
-name = "colorchoice"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -1175,7 +914,7 @@ dependencies = [
  "log",
  "pulley-interpreter",
  "regalloc2",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "serde",
  "smallvec",
  "target-lexicon",
@@ -1273,15 +1012,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
-name = "crc32c"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
-dependencies = [
- "rustc_version",
-]
-
-[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1295,15 +1025,6 @@ name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
-dependencies = [
- "crossbeam-utils",
-]
 
 [[package]]
 name = "crossbeam-deque"
@@ -1334,16 +1055,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-skiplist"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df29de440c58ca2cc6e587ec3d22347551a32435fbde9d2bff64e78a9ffa151b"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1367,15 +1078,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
-]
-
-[[package]]
-name = "ctr"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
-dependencies = [
- "cipher",
 ]
 
 [[package]]
@@ -1422,84 +1124,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "dashmap"
-version = "6.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
- "serde",
-]
-
-[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
-
-[[package]]
-name = "db-keystore"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a1b2f1087c32a26a8c6c7d89eb80b50c33d8466e2431ea2a8345c969cded18"
-dependencies = [
- "anyhow",
- "clap",
- "futures",
- "keyring-core",
- "log",
- "regex",
- "serde",
- "serde_json",
- "turso",
- "uuid",
- "zeroize",
-]
-
-[[package]]
-name = "dbus"
-version = "0.9.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b942602992bb7acfd1f51c49811c58a610ef9181b6e66f3e519d79b540a3bf73"
-dependencies = [
- "libc",
- "libdbus-sys",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "dbus-secret-service"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
-dependencies = [
- "aes",
- "block-padding",
- "cbc",
- "dbus",
- "fastrand",
- "hkdf 0.12.4",
- "num",
- "once_cell",
- "openssl",
- "sha2 0.10.9",
- "zeroize",
-]
-
-[[package]]
-name = "dbus-secret-service-keyring-store"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21d8f54da401bb5eb2a4d873ac4b359f4a599df2ca8634bb5b8c045e5ee78757"
-dependencies = [
- "dbus-secret-service",
- "keyring-core",
-]
 
 [[package]]
 name = "debugid"
@@ -1516,7 +1144,6 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -1724,25 +1351,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_filter"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
-dependencies = [
- "log",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
-dependencies = [
- "env_filter",
- "log",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1857,12 +1465,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fallible-iterator"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
-
-[[package]]
 name = "fancy-regex"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1882,17 +1484,6 @@ dependencies = [
  "bit-set",
  "regex-automata",
  "regex-syntax",
-]
-
-[[package]]
-name = "fastbloom"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7f34442dbe69c60fe8eaf58a8cafff81a1f278816d8ab4db255b3bef4ac3c4"
-dependencies = [
- "getrandom 0.3.4",
- "libm",
- "siphasher",
 ]
 
 [[package]]
@@ -1970,30 +1561,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -2170,40 +1740,10 @@ checksum = "25234f20a3ec0a962a61770cfe39ecf03cb529a6e474ad8cff025ed497eda557"
 dependencies = [
  "bitflags",
  "debugid",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "serde",
  "serde_derive",
  "serde_json",
-]
-
-[[package]]
-name = "genawaiter"
-version = "0.99.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c86bd0361bcbde39b13475e6e36cb24c329964aa2611be285289d1e4b751c1a0"
-dependencies = [
- "genawaiter-macro",
-]
-
-[[package]]
-name = "genawaiter-macro"
-version = "0.99.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b32dfe1fdfc0bbde1f22a5da25355514b5e450c33a6af6770884c8750aedfbc"
-
-[[package]]
-name = "generator"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3b854b0e584ead1a33f18b2fcad7cf7be18b3875c78816b753639aa501513ae"
-dependencies = [
- "cc",
- "cfg-if",
- "libc",
- "log",
- "rustversion",
- "windows-link",
- "windows-result",
 ]
 
 [[package]]
@@ -2247,7 +1787,7 @@ version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
 dependencies = [
- "unicode-width 0.2.2",
+ "unicode-width",
 ]
 
 [[package]]
@@ -2279,26 +1819,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
- "wasip2",
- "wasip3",
-]
-
-[[package]]
-name = "ghash"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
-dependencies = [
- "opaque-debug",
- "polyval",
 ]
 
 [[package]]
@@ -2371,9 +1899,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2405,28 +1933,13 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-
-[[package]]
-name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash 0.1.5",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash 0.2.0",
+ "foldhash",
  "serde",
  "serde_core",
 ]
@@ -2512,15 +2025,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
  "digest 0.11.3",
-]
-
-[[package]]
-name = "home"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
-dependencies = [
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2841,15 +2345,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71dd52191aae121e8611f1e8dc3e324dd0dd1dee1e6dd91d10ee07a3cfb4d9d8"
 
 [[package]]
-name = "intrusive-collections"
-version = "0.9.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "189d0897e4cbe8c75efedf3502c18c887b05046e59d28404d4d8e46cbc4d1e86"
-dependencies = [
- "memoffset",
-]
-
-[[package]]
 name = "io-extras"
 version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2864,17 +2359,6 @@ name = "io-lifetimes"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
-
-[[package]]
-name = "io-uring"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d09b98f7eace8982db770e4408e7470b028ce513ac28fecdc6bf4c30fe92b62"
-dependencies = [
- "bitflags",
- "cfg-if",
- "libc",
-]
 
 [[package]]
 name = "ipnet"
@@ -2903,7 +2387,6 @@ dependencies = [
  "iron-providers",
  "jsonschema",
  "keyring",
- "keyring-core",
  "monty",
  "num-bigint",
  "num-traits",
@@ -2930,9 +2413,9 @@ dependencies = [
 
 [[package]]
 name = "iron-providers"
-version = "0.2.10"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "631e29cec429f604c797728c283280325fd11b10c5bf4e495ca15018003ab6e3"
+checksum = "291056958be0bcb78a71b3a7fc00e7e77ea3d5f045127d0a6be17bb84b2c799d"
 dependencies = [
  "async-stream",
  "base64",
@@ -2955,21 +2438,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "is_terminal_polyfill"
-version = "1.70.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
-name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
 ]
 
 [[package]]
@@ -3024,22 +2492,6 @@ dependencies = [
 
 [[package]]
 name = "jni"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
-dependencies = [
- "cesu8",
- "cfg-if",
- "combine",
- "jni-sys 0.3.1",
- "log",
- "thiserror 1.0.69",
- "walkdir",
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "jni"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
@@ -3047,7 +2499,7 @@ dependencies = [
  "cfg-if",
  "combine",
  "jni-macros",
- "jni-sys 0.4.1",
+ "jni-sys",
  "log",
  "simd_cesu8",
  "thiserror 2.0.18",
@@ -3066,15 +2518,6 @@ dependencies = [
  "rustc_version",
  "simd_cesu8",
  "syn",
-]
-
-[[package]]
-name = "jni-sys"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
-dependencies = [
- "jni-sys 0.4.1",
 ]
 
 [[package]]
@@ -3118,16 +2561,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonrpcmsg"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d833a15225c779251e13929203518c2ff26e2fe0f322d584b213f4f4dad37bd"
-dependencies = [
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "jsonschema"
 version = "0.46.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3158,20 +2591,12 @@ dependencies = [
 
 [[package]]
 name = "keyring"
-version = "4.0.1"
+version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9933a54d9cdbab06776a617dfd0cbc320407e04402eb51bfbf7a5e1f583b5e"
+checksum = "4ee5140534876dd3450719b506cfbb77397e640910fc39b6e7011c133291e15a"
 dependencies = [
- "android-native-keyring-store",
  "apple-native-keyring-store",
- "base64",
- "clap",
- "db-keystore",
- "dbus-secret-service-keyring-store",
  "keyring-core",
- "linux-keyutils-keyring-store",
- "rpassword",
- "rprompt",
  "windows-native-keyring-store",
  "zbus-secret-service-keyring-store",
 ]
@@ -3182,13 +2607,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb1e621458ca9c51aa110bd0339d4751a056b9576bf1253aee1aa560dda0fc9d"
 dependencies = [
- "chrono",
- "dashmap",
  "log",
- "regex",
- "ron",
- "serde",
- "uuid",
 ]
 
 [[package]]
@@ -3198,16 +2617,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "leb128"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cc46bac87ef8093eed6f272babb833b6443374399985ac8ed28471ee0918545"
+checksum = "c83bff1d572d6b9aeef67ddfc8448e4a3737909cb28e81f97c791b9018703e52"
 
 [[package]]
 name = "leb128fmt"
@@ -3247,39 +2660,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
-name = "libdbus-sys"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
-dependencies = [
- "cc",
- "pkg-config",
-]
-
-[[package]]
-name = "libloading"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
-dependencies = [
- "cfg-if",
- "windows-link",
-]
-
-[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
-name = "libmimalloc-sys"
-version = "0.1.49"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "libredox"
@@ -3299,46 +2683,6 @@ dependencies = [
  "cc",
  "pkg-config",
  "vcpkg",
-]
-
-[[package]]
-name = "linkme"
-version = "0.3.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83272d46373fb8decca684579ac3e7c8f3d71d4cc3aa693df8759e260ae41cf"
-dependencies = [
- "linkme-impl",
-]
-
-[[package]]
-name = "linkme-impl"
-version = "0.3.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d59e20403c7d08fe62b4376edfe5c7fb2ef1e6b1465379686d0f21c8df444b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "linux-keyutils"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83270a18e9f90d0707c41e9f35efada77b64c0e6f3f1810e71c8368a864d5590"
-dependencies = [
- "bitflags",
- "libc",
-]
-
-[[package]]
-name = "linux-keyutils-keyring-store"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39fbed79f71dc21eb21d3d07c0e908a3c58ff9a1fdbf5cf44230fb3deb6d994b"
-dependencies = [
- "keyring-core",
- "linux-keyutils",
 ]
 
 [[package]]
@@ -3373,19 +2717,6 @@ name = "log"
 version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
-
-[[package]]
-name = "loom"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
-dependencies = [
- "cfg-if",
- "generator",
- "scoped-tls",
- "tracing",
- "tracing-subscriber",
-]
 
 [[package]]
 name = "lru-slab"
@@ -3490,47 +2821,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
 
 [[package]]
-name = "miette"
-version = "7.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
-dependencies = [
- "cfg-if",
- "miette-derive",
- "unicode-width 0.1.14",
-]
-
-[[package]]
-name = "miette-derive"
-version = "7.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "mimalloc"
-version = "0.1.52"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
-dependencies = [
- "libmimalloc-sys",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -3563,7 +2857,7 @@ dependencies = [
  "fancy-regex 0.17.0",
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
- "itertools 0.14.0",
+ "itertools",
  "jiter",
  "libm",
  "monty-macros",
@@ -3590,22 +2884,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "ndk-context"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -3722,69 +3000,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
-name = "once_cell_polyfill"
-version = "1.70.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-
-[[package]]
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
-name = "openssl"
-version = "0.10.81"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-src"
-version = "300.6.1+3.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.117"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
-dependencies = [
- "cc",
- "libc",
- "openssl-src",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "option-ext"
@@ -3818,21 +3043,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
-name = "owo-colors"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
-
-[[package]]
-name = "pack1"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b7bb0ecf2e447b1f20ee94ee79ef6eed1e9d4b3c36ce1903b9dea3bf205523"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3860,12 +3070,6 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
-
-[[package]]
-name = "pastey"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "percent-encoding"
@@ -3990,18 +3194,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "polyval"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "opaque-debug",
- "universal-hash",
-]
-
-[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4042,16 +3234,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
-]
-
-[[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
 ]
 
 [[package]]
@@ -4100,7 +3282,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn",
@@ -4200,7 +3382,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "rustls",
  "socket2",
  "thiserror 2.0.18",
@@ -4221,7 +3403,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.4",
  "ring",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -4322,7 +3504,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20 0.10.0",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
 
@@ -4371,30 +3553,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
-name = "rand_pcg"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
-dependencies = [
- "rand_core 0.6.4",
-]
-
-[[package]]
 name = "rand_xoshiro"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
 dependencies = [
  "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rapidhash"
-version = "4.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
-dependencies = [
- "rustversion",
 ]
 
 [[package]]
@@ -4495,7 +3659,7 @@ dependencies = [
  "bumpalo",
  "hashbrown 0.17.1",
  "log",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "smallvec",
 ]
 
@@ -4606,61 +3770,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "roaring"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dedc5658c6ecb3bdb5ef5f3295bb9253f42dcf3fd1402c03f6b1f7659c3c4a9"
-dependencies = [
- "bytemuck",
- "byteorder",
-]
-
-[[package]]
-name = "ron"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4147b952f3f819eca0e99527022f7d6a8d05f111aeb0a62960c74eb283bec8fc"
-dependencies = [
- "bitflags",
- "once_cell",
- "serde",
- "serde_derive",
- "typeid",
- "unicode-ident",
-]
-
-[[package]]
-name = "rpassword"
-version = "7.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2da316a15f47e3d053de9cb2c439650bd8fa4aaeb9365f2e5f27f492ff73c196"
-dependencies = [
- "libc",
- "rtoolbox",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rprompt"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69abf524bb9ccb7c071f7231441288d74b48d176cb309eb00e6f77d186c6e035"
-dependencies = [
- "rtoolbox",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rtoolbox"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50a0e551c1e27e1731aba276dbeaeac73f53c7cd34d1bda485d02bd1e0f36844"
-dependencies = [
- "libc",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "ruff_python_ast"
 version = "0.0.0"
 source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
@@ -4674,7 +3783,7 @@ dependencies = [
  "ruff_python_trivia",
  "ruff_source_file",
  "ruff_text_size",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "thin-vec",
  "thiserror 2.0.18",
 ]
@@ -4692,7 +3801,7 @@ dependencies = [
  "ruff_python_ast",
  "ruff_python_trivia",
  "ruff_text_size",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "static_assertions",
  "thin-vec",
  "unicode-ident",
@@ -4714,7 +3823,7 @@ name = "ruff_python_trivia"
 version = "0.0.0"
 source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
 dependencies = [
- "itertools 0.14.0",
+ "itertools",
  "ruff_source_file",
  "ruff_text_size",
  "unicode-ident",
@@ -4745,12 +3854,6 @@ checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
@@ -4761,16 +3864,6 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver",
-]
-
-[[package]]
-name = "rustc_version_runtime"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dd18cd2bae1820af0b6ad5e54f4a51d0f3fcc53b05f845675074efcc7af071d"
-dependencies = [
- "rustc_version",
  "semver",
 ]
 
@@ -4856,7 +3949,7 @@ checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
- "jni 0.22.4",
+ "jni",
  "log",
  "once_cell",
  "rustls",
@@ -4953,12 +4046,6 @@ dependencies = [
  "serde_derive_internals",
  "syn",
 ]
-
-[[package]]
-name = "scoped-tls"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -5065,6 +4152,7 @@ version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -5149,12 +4237,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1_smol"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
-
-[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5193,35 +4275,9 @@ checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
-
-[[package]]
-name = "shuttle"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab17edba38d63047f46780cf7360acf7467fec2c048928689a5c1dd1c2b4e31"
-dependencies = [
- "assoc",
- "bitvec",
- "cfg-if",
- "generator",
- "hex",
- "owo-colors",
- "rand 0.8.6",
- "rand_core 0.6.4",
- "rand_pcg",
- "scoped-tls",
- "smallvec",
- "tracing",
-]
 
 [[package]]
 name = "signal-hook-registry"
@@ -5254,15 +4310,6 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
-
-[[package]]
-name = "simsimd"
-version = "6.5.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4fb3bc3cdce07a7d7d4caa4c54f8aa967f6be41690482b54b24100a2253fa70"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "siphasher"
@@ -5304,12 +4351,6 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "softaes"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45e14297decde697ddf377c25752aead0927d5cfc89c2684d2af96901a4ceeea"
 
 [[package]]
 name = "speedate"
@@ -5537,15 +4578,6 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
-dependencies = [
- "strum_macros 0.26.4",
-]
-
-[[package]]
-name = "strum"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
@@ -5560,19 +4592,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
  "strum_macros 0.28.0",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn",
 ]
 
 [[package]]
@@ -5606,16 +4625,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
-name = "symlink"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
-
-[[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5698,7 +4711,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -5770,12 +4783,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -5785,15 +4797,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
 dependencies = [
  "num-conv",
  "time-core",
@@ -6017,19 +5029,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-appender"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
-dependencies = [
- "crossbeam-channel",
- "symlink",
- "thiserror 2.0.18",
- "time",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "tracing-attributes"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6086,206 +5085,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "turso"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "832bb70436d4b4d3ed45285c5c6abd62328d5e2486297b32cf2b0812abeba6d4"
-dependencies = [
- "mimalloc",
- "thiserror 2.0.18",
- "tracing",
- "tracing-subscriber",
- "turso_core",
- "turso_sdk_kit",
- "turso_sync_sdk_kit",
-]
-
-[[package]]
-name = "turso_core"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba8ef95330369724a1829b20dc1b728d644eaeb051891971b5d2b5617337a84b"
-dependencies = [
- "aegis",
- "aes",
- "aes-gcm",
- "antithesis_sdk",
- "arc-swap",
- "bigdecimal",
- "bitflags",
- "branches",
- "bumpalo",
- "bytemuck",
- "cfg_aliases",
- "cfg_block",
- "chrono",
- "crc32c",
- "crossbeam-skiplist",
- "either",
- "fallible-iterator",
- "fastbloom",
- "hex",
- "intrusive-collections",
- "io-uring",
- "libc",
- "libloading",
- "libm",
- "loom",
- "miette",
- "num-bigint",
- "num-traits",
- "pack1",
- "parking_lot",
- "pastey",
- "polling",
- "rand 0.9.4",
- "rapidhash",
- "regex",
- "regex-syntax",
- "roaring",
- "rustc-hash 2.1.2",
- "rustix 1.1.4",
- "ryu",
- "serde_json",
- "shuttle",
- "simsimd",
- "smallvec",
- "strum 0.26.3",
- "strum_macros 0.26.4",
- "tempfile",
- "thiserror 2.0.18",
- "tracing",
- "tracing-subscriber",
- "turso_ext",
- "turso_macros",
- "turso_parser",
- "twox-hash",
- "uncased",
- "uuid",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "turso_ext"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a47927d766b9ae7e3adf092d5e150dce80533615edc502641797878f190080"
-dependencies = [
- "chrono",
- "getrandom 0.4.2",
- "turso_macros",
-]
-
-[[package]]
-name = "turso_macros"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0cdc6ae079c61aa21a89b595a4d0e19d9d848a2658542252e82f930c57c3d87"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "turso_parser"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b94707e5605411cddbd5a1bd6cc2d6b72181b02223b36b37ba350ed6b71877"
-dependencies = [
- "bitflags",
- "memchr",
- "miette",
- "strum 0.26.3",
- "strum_macros 0.26.4",
- "thiserror 2.0.18",
- "turso_macros",
-]
-
-[[package]]
-name = "turso_sdk_kit"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12a86ce113e5dcedeaad7809d9fa1dc00f837f40ccd8012ac1d2144c57672a34"
-dependencies = [
- "bindgen",
- "env_logger",
- "parking_lot",
- "tracing",
- "tracing-appender",
- "tracing-subscriber",
- "turso_core",
- "turso_sdk_kit_macros",
-]
-
-[[package]]
-name = "turso_sdk_kit_macros"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fca6ee03a3dc5a48a7a63ddd2c8f41aa7bb5195eb96f6a29831447c8cb3d841a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "turso_sync_engine"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c58fe60f17b694f91bd278e93aceca10fb340950f6a8f1aedef11c28b50c4b8"
-dependencies = [
- "base64",
- "bytes",
- "genawaiter",
- "http",
- "libc",
- "prost",
- "roaring",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "tracing",
- "turso_core",
- "turso_parser",
- "uuid",
-]
-
-[[package]]
-name = "turso_sync_sdk_kit"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4512c7b28bb3bc09be1ba480ee60234ed9bbeb6686c9348323589ffcec504b93"
-dependencies = [
- "bindgen",
- "env_logger",
- "genawaiter",
- "parking_lot",
- "tracing",
- "tracing-appender",
- "tracing-subscriber",
- "turso_core",
- "turso_sdk_kit",
- "turso_sdk_kit_macros",
- "turso_sync_engine",
-]
-
-[[package]]
-name = "twox-hash"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
-dependencies = [
- "rand 0.9.4",
-]
-
-[[package]]
-name = "typeid"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
-
-[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6300,15 +5099,6 @@ dependencies = [
  "memoffset",
  "tempfile",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "uncased"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
-dependencies = [
- "version_check",
 ]
 
 [[package]]
@@ -6349,12 +5139,6 @@ name = "unicode-segmentation"
 version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -6466,21 +5250,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
-name = "utf8parse"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
 name = "uuid"
 version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "serde_core",
- "sha1_smol",
  "wasm-bindgen",
 ]
 
@@ -6575,16 +5352,7 @@ version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -6665,16 +5433,6 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.244.0",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.245.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9dca005e69bf015e45577e415b9af8c67e8ee3c0e38b5b0add5aa92581ed5c"
@@ -6694,18 +5452,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap 2.14.0",
- "wasm-encoder 0.244.0",
- "wasmparser 0.244.0",
-]
-
-[[package]]
 name = "wasm-streams"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6716,18 +5462,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap 2.14.0",
- "semver",
 ]
 
 [[package]]
@@ -6881,7 +5615,7 @@ dependencies = [
  "syn",
  "wasmtime-internal-component-util",
  "wasmtime-internal-wit-bindgen",
- "wit-parser 0.245.1",
+ "wit-parser",
 ]
 
 [[package]]
@@ -6915,7 +5649,7 @@ dependencies = [
  "cranelift-frontend",
  "cranelift-native",
  "gimli",
- "itertools 0.14.0",
+ "itertools",
  "log",
  "object",
  "pulley-interpreter",
@@ -7019,7 +5753,7 @@ dependencies = [
  "bitflags",
  "heck",
  "indexmap 2.14.0",
- "wit-parser 0.245.1",
+ "wit-parser",
 ]
 
 [[package]]
@@ -7040,7 +5774,7 @@ dependencies = [
  "bumpalo",
  "leb128fmt",
  "memchr",
- "unicode-width 0.2.2",
+ "unicode-width",
  "wasm-encoder 0.252.0",
 ]
 
@@ -7075,32 +5809,20 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
-]
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix 0.38.44",
 ]
 
 [[package]]
@@ -7285,15 +6007,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -7326,21 +6039,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -7378,12 +6076,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -7396,12 +6088,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -7411,12 +6097,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7444,12 +6124,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -7459,12 +6133,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -7480,12 +6148,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -7495,12 +6157,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -7541,97 +6197,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser 0.244.0",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap 2.14.0",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap 2.14.0",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder 0.244.0",
- "wasm-metadata",
- "wasmparser 0.244.0",
- "wit-parser 0.244.0",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.14.0",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser 0.244.0",
-]
 
 [[package]]
 name = "wit-parser"
@@ -7821,20 +6389,6 @@ name = "zeroize"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.32"
 edition = "2021"
 authors = ["Paul Mooring"]
 license = "Apache-2.0"
-rust-version = "1.95"
+rust-version = "1.96"
 description = "Core AgentIron loop, session state, and tool registry"
 readme = "README.md"
 repository = "https://github.com/AgentIron/iron-core"
@@ -16,7 +16,7 @@ exclude = [
 ]
 
 [dependencies]
-iron-providers = "0.2.9"
+iron-providers = "0.2.12"
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["compat"] }
 serde = { version = "1", features = ["derive"] }
@@ -29,7 +29,7 @@ pin-project = "1.1.13"
 parking_lot = "0.12"
 
 # ACP SDK
-agent-client-protocol = "0.14"
+agent-client-protocol = "0.15"
 async-trait = "0.1"
 uuid = { version = "1", features = ["v4"] }
 
@@ -59,8 +59,7 @@ grep-regex = "0.1"
 # Config store dependencies
 sqlx = { version = "0.9", features = ["runtime-tokio", "sqlite", "migrate", "chrono"] }
 directories = "6"
-keyring = "4"
-keyring-core = "1"
+keyring = "4.1.1"
 secret-service = { version = "5", features = ["rt-tokio-crypto-rust"] }
 base64 = "0.22"
 rand = "0.10"

--- a/openspec/changes/archive/2026-06-20-store-backed-provider-profiles/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-20-store-backed-provider-profiles/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-20

--- a/openspec/changes/archive/2026-06-20-store-backed-provider-profiles/design.md
+++ b/openspec/changes/archive/2026-06-20-store-backed-provider-profiles/design.md
@@ -1,0 +1,114 @@
+## Context
+
+`iron-core` currently depends on `iron-providers` for provider definitions and constructs fresh `ProviderRegistry::default()` instances in several paths. That registry contains built-in provider profiles compiled into `iron-providers`. `iron-core` already owns durable configuration for agent profiles, provider runtime config, custom models, and provider credentials, but it has no durable representation for custom provider profiles or user overrides to built-in provider profiles.
+
+The intended direction is that `iron-providers` remains a provider protocol/profile library and does not own persistent storage. `iron-core` owns loading from `ConfigStore`, validation, import/export, and construction of an effective registry for runtime use.
+
+This change assumes an `iron-providers` release that exposes `ProviderProfile` serialization and profile-level `provider_guidance` suitable for storage and prompt composition.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Persist non-secret custom provider profiles and explicit built-in overrides in `iron-core`'s durable config store.
+- Leave built-in provider profiles compiled into `iron-providers` and available without a config store.
+- Build an effective provider registry by starting from `iron-providers` built-ins and applying persisted custom/override provider profiles.
+- Use the effective provider registry for managed provider construction, provider guidance, known provider slug discovery, and credential support.
+- Provide import/export APIs for provider profile JSON without storing credentials or frontend-specific preferences.
+- Preserve existing behavior for callers that do not use durable provider profile storage.
+
+**Non-Goals:**
+
+- No persistent storage inside `iron-providers`.
+- No automatic seeding of built-in provider profiles into the config database.
+- No migration of existing `provider_configs`, `custom_models`, `credentials`, or `profiles` rows into provider profile rows.
+- No UI for managing provider profiles.
+- No credential material, OAuth token state, API keys, starred models, or app-specific display preferences inside provider profile payloads.
+- No live reload of active sessions when provider profile records change.
+
+## Decisions
+
+### 1. Persist only custom profiles and explicit overrides
+
+The config store will not mirror every built-in provider profile into SQLite. Built-ins stay in `iron-providers`; persisted provider profile rows represent user-owned additions or replacements.
+
+Alternatives considered:
+
+- **Seed all built-ins into SQLite:** makes all definitions data-backed, but creates update/delete semantics for built-ins and duplicates source of truth across crate releases and user data.
+- **Store only custom slugs, disallow overrides:** simpler, but prevents fixing or adapting built-in provider metadata locally.
+- **Store custom profiles and overrides:** keeps built-ins code-owned while allowing users to add or replace definitions deliberately.
+
+### 2. `iron-core` owns the store boundary and registry loading
+
+The provider profile storage abstraction belongs in `iron-core` because `iron-core` owns `ConfigStore` and already depends on `iron-providers`. `iron-providers` should not depend on `iron-core` to load profiles.
+
+The effective registry construction should follow this shape:
+
+```text
+ProviderRegistry::default()
+        |
+        v
+apply persisted provider profiles from ConfigStore
+        |
+        v
+Effective provider registry used by runtime paths
+```
+
+Alternatives considered:
+
+- **Define `ProfileStore` in `iron-providers`:** enables `ProviderRegistry::load_from_store`, but pushes async storage concerns into a library that otherwise has no persistence backend.
+- **Define the trait in `iron-core` and call it from `iron-providers`:** creates an invalid dependency direction.
+- **Create a bridge crate:** keeps dependencies clean but is unnecessary until multiple crates need the same persistence abstraction.
+
+### 3. Use typed ConfigStore APIs and a separate table
+
+Provider profiles will use a dedicated config-store domain rather than the existing `profiles` table. The existing `profiles` table stores `AgentProfile` records; overloading it would make export/list/delete semantics ambiguous.
+
+The stored record should include slug, schema version or payload version, serialized provider profile JSON, source metadata, and timestamps. A `builtin` flag is not necessary for rows if built-ins are not seeded, but an `override`/`source` distinction can be represented through record metadata if callers need diagnostics.
+
+Alternatives considered:
+
+- **Reuse `profiles`:** rejected because it conflates agent identity/policy with provider protocol metadata.
+- **Use `provider_configs`:** rejected because provider configs intentionally exclude provider protocol metadata owned by `iron-providers`.
+
+### 4. Runtime should use a shared effective registry
+
+Registry construction should happen at runtime setup or explicit settings reload, not repeatedly during prompt building or provider construction. This allows request building, managed provider resolution, provider auth support, and known-provider discovery to share one effective view.
+
+Active sessions should keep using their runtime-effective registry until a future explicit reload/switch mechanism is designed. Stored profile edits should affect future registry construction or explicit reloads, not mutate an in-flight request unexpectedly.
+
+### 5. Credential support should be profile-driven where possible
+
+Credential support should derive from the selected/effective `ProviderProfile` credential auth metadata instead of hardcoded slug lists. Existing OAuth metadata for provider-specific device-code flows can remain provider-specific until those flows are also represented declaratively.
+
+This allows imported/custom provider profiles to advertise API-key, OAuth bearer, or no-auth support consistently with provider construction.
+
+### 6. Provider guidance comes from the effective provider profile
+
+Provider-specific prompt guidance should be resolved from the effective provider profile for the configured or session-selected provider. Manual `prompt_composition.provider_guidance` remains fallback behavior when no provider profile guidance is available.
+
+This removes the current built-in-only throwaway registry lookup during prompt composition and lets persisted overrides/custom profiles affect the provider guidance section.
+
+## Risks / Trade-offs
+
+- **Risk: persisted overrides can break provider construction.** -> Validate imported/stored provider profile shape before accepting it and surface actionable errors during registry loading.
+- **Risk: built-in release updates are hidden by stale overrides.** -> Treat overrides as explicit user data; expose diagnostics listing overridden built-in slugs so callers can review them.
+- **Risk: runtime registry reload semantics become surprising.** -> Scope this change to startup/explicit load paths and avoid implicit live reload for active sessions.
+- **Risk: credential support remains partly hardcoded for OAuth flows.** -> Derive generic support from profiles now, while keeping provider-specific OAuth device metadata as a separate known limitation.
+- **Risk: custom provider profiles reference models absent from the effective model catalog.** -> Provider profile validity should not require model availability; custom model/default validation remains the effective catalog's job.
+
+## Migration Plan
+
+1. Add a config-store migration for provider profile records without modifying existing rows.
+2. Add typed ConfigStore APIs for provider profile CRUD/list/import/export support.
+3. Add an `iron-core` effective provider registry loader that starts from `ProviderRegistry::default()` and applies persisted records.
+4. Wire runtime-managed provider construction, provider guidance lookup, known provider slug discovery, and credential support to the effective registry.
+5. Preserve fallback behavior when no durable store or no persisted provider profiles are available.
+
+Rollback is straightforward because the new table contains only optional user additions/overrides. If the loader is not used, built-in-only provider behavior remains available through `ProviderRegistry::default()`.
+
+## Open Questions
+
+- Should provider profile import accept only one profile JSON document at a time, or also support bundles?
+- Should overrides require an explicit `allow_override` option, or is replacing an existing slug always acceptable through the provider profile APIs?
+- What exact `iron-providers` version should this change require for `provider_guidance` support?

--- a/openspec/changes/archive/2026-06-20-store-backed-provider-profiles/proposal.md
+++ b/openspec/changes/archive/2026-06-20-store-backed-provider-profiles/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+Provider profile definitions are currently sourced only from `iron-providers` built-ins, while user/provider customization in `iron-core` is split across runtime provider configs, custom models, and credentials. This prevents `iron-core` from loading user-defined provider endpoints or user overrides from the durable config store, and causes prompt/provider resolution paths to repeatedly construct throwaway built-in registries.
+
+## What Changes
+
+- Add core-owned durable storage APIs for provider profile overrides and custom provider profiles.
+- Keep built-in provider profiles compiled into `iron-providers`; the config store persists only custom profiles and explicit user overrides.
+- Add an `iron-core` provider profile store/loading boundary that can merge persisted profiles into an effective `ProviderRegistry` without requiring `iron-providers` to own persistence.
+- Use the effective provider registry for provider construction, provider slug discovery, provider credential support, and provider-specific prompt guidance.
+- Support import/export of non-secret provider profile JSON through core-owned validation and storage APIs.
+- Preserve existing built-in provider behavior when no provider profile store is configured or no overrides/custom profiles exist.
+
+## Capabilities
+
+### New Capabilities
+- `provider-profiles`: Defines durable custom/override provider profile behavior, registry merge semantics, import/export rules, and effective provider profile lookup.
+
+### Modified Capabilities
+- `core-config-store`: Add typed non-secret provider profile storage APIs and schema migration support.
+- `provider-credential-orchestration`: Derive provider credential support from the effective provider profile registry instead of hardcoded provider slugs where possible.
+- `effective-model-catalog`: Validate provider slugs against built-ins plus persisted custom/override provider profiles when storing custom models or defaults.
+- `dynamic-system-prompt-templating`: Resolve provider-specific guidance from the effective provider profile selected for the session/request instead of a fresh built-in-only registry.
+
+## Impact
+
+- Affected modules likely include `src/config/`, `src/provider_credential/`, `src/runtime.rs`, `src/request_builder.rs`, prompt composition tests, config store tests, and runtime/provider credential tests.
+- Requires an `iron-providers` version that exposes `ProviderProfile` serialization and `provider_guidance` data suitable for core-owned persistence/loading.
+- Adds public `iron-core` APIs for provider profile storage/loading/import/export while preserving the existing injected-provider and built-in registry paths.
+- Does not move SQLite or other persistent storage into `iron-providers`.

--- a/openspec/changes/archive/2026-06-20-store-backed-provider-profiles/specs/core-config-store/spec.md
+++ b/openspec/changes/archive/2026-06-20-store-backed-provider-profiles/specs/core-config-store/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Config store SHALL support provider profile records
+The config store SHALL provide typed async CRUD APIs for non-secret provider profile records keyed by provider slug. Provider profile records SHALL be stored separately from `AgentProfile` records and provider runtime configuration records.
+
+Provider profile records SHALL include the provider slug, serialized provider profile payload, store-maintained timestamps, and optional source metadata useful for import diagnostics.
+
+#### Scenario: Provider profile record roundtrips
+- **WHEN** a caller stores a provider profile record with a valid slug and payload
+- **THEN** the caller can retrieve the same provider profile record by slug
+- **AND** the returned record includes store-maintained timestamps
+
+#### Scenario: Provider profile records list deterministically
+- **WHEN** a caller lists provider profile records
+- **THEN** the system returns persisted provider profile records in deterministic order
+- **AND** built-in provider profiles that were not explicitly persisted are not returned as config-store rows
+
+#### Scenario: Provider profile record is deleted
+- **WHEN** a caller deletes a provider profile record by slug
+- **THEN** subsequent read-by-slug calls return `Ok(None)` unless the API explicitly requires existence
+- **AND** deleting the row does not remove compiled-in built-in provider behavior
+
+### Requirement: Config schema SHALL migrate provider profile storage
+The config store schema migrations SHALL create durable storage for provider profile records when opening an older or empty database.
+
+#### Scenario: Empty database opens with provider profile storage
+- **WHEN** the config store opens an empty database
+- **THEN** migrations create the provider profile storage required by the provider profile APIs
+- **AND** no built-in provider profile rows are inserted by default
+
+#### Scenario: Older database opens with provider profile migration
+- **WHEN** the config store opens a database created before provider profile storage existed
+- **THEN** pending migrations add provider profile storage without changing existing profile, prompt, credential, provider config, custom model, or schedule rows

--- a/openspec/changes/archive/2026-06-20-store-backed-provider-profiles/specs/dynamic-system-prompt-templating/spec.md
+++ b/openspec/changes/archive/2026-06-20-store-backed-provider-profiles/specs/dynamic-system-prompt-templating/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: Provider guidance SHALL resolve from the effective provider profile
+Provider-specific guidance in the canonical `Provider-Specific Guidance` section SHALL be resolved from the effective provider profile for the selected provider when profile guidance is available.
+
+The system SHALL NOT construct a fresh built-in-only registry during request prompt composition when an effective provider registry or selected effective provider profile is available.
+
+#### Scenario: Built-in provider guidance renders
+- **WHEN** a provider request is built for a built-in provider with provider guidance
+- **THEN** that guidance appears in `## 7. Provider-Specific Guidance`
+- **AND** the canonical section order remains unchanged
+
+#### Scenario: Custom provider guidance renders
+- **WHEN** a provider request is built for a custom provider profile with provider guidance
+- **THEN** the custom profile guidance appears in `## 7. Provider-Specific Guidance`
+- **AND** no other prompt section ownership changes
+
+#### Scenario: Override provider guidance wins
+- **WHEN** a persisted provider profile override supplies guidance for a built-in provider slug
+- **THEN** prompt composition uses the override guidance for that slug
+- **AND** it does not use stale built-in-only guidance from a throwaway registry
+
+#### Scenario: Missing provider guidance falls back to manual guidance
+- **WHEN** no effective provider profile guidance is available for the selected provider
+- **THEN** prompt composition uses manually configured provider guidance when present
+- **AND** otherwise renders the provider guidance section empty according to existing prompt composition behavior

--- a/openspec/changes/archive/2026-06-20-store-backed-provider-profiles/specs/effective-model-catalog/spec.md
+++ b/openspec/changes/archive/2026-06-20-store-backed-provider-profiles/specs/effective-model-catalog/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Provider slug validation SHALL consider effective provider profiles
+Provider slug validation for custom models and default model settings SHALL consider provider slugs from built-in provider profiles plus persisted custom/override provider profiles loaded into the effective provider registry.
+
+#### Scenario: Custom model references custom provider profile
+- **WHEN** a caller stores a custom model for a provider slug supplied by a persisted custom provider profile
+- **THEN** provider slug validation succeeds for that provider slug
+- **AND** the custom model can participate in the effective model catalog
+
+#### Scenario: Custom model references unknown provider slug
+- **WHEN** a caller stores a custom model for a provider slug that is neither built-in nor present in persisted provider profiles
+- **THEN** validation fails with an actionable unknown-provider error
+
+#### Scenario: Provider profile override keeps slug valid
+- **WHEN** a persisted provider profile overrides a built-in provider slug
+- **THEN** that provider slug remains valid for custom model and default model validation

--- a/openspec/changes/archive/2026-06-20-store-backed-provider-profiles/specs/provider-credential-orchestration/spec.md
+++ b/openspec/changes/archive/2026-06-20-store-backed-provider-profiles/specs/provider-credential-orchestration/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: Provider credential support SHALL use effective provider profile metadata
+Provider credential orchestration SHALL derive API-key, OAuth bearer, and no-auth support from the effective provider profile metadata when a profile is available for the provider slug.
+
+Provider-specific OAuth device-code metadata MAY remain specialized, but generic credential-mode support used for provider invocation SHALL not rely solely on hardcoded built-in slug lists.
+
+#### Scenario: Custom profile supports API-key credentials
+- **WHEN** credential orchestration resolves credentials for a custom provider profile that supports API-key authentication
+- **THEN** API-key credentials are accepted for that provider
+- **AND** provider invocation uses the auth strategy declared by the effective provider profile
+
+#### Scenario: Effective profile supports OAuth bearer credentials
+- **WHEN** credential orchestration resolves credentials for an effective provider profile that supports OAuth bearer authentication
+- **THEN** stored OAuth bearer credentials are considered usable for that provider
+- **AND** unsupported credential modes are rejected with an actionable unsupported-credential error
+
+#### Scenario: Effective profile supports no-auth invocation
+- **WHEN** credential orchestration resolves credentials for an effective provider profile that supports no-auth invocation
+- **THEN** the provider can be constructed without requiring API-key or OAuth credential material
+
+#### Scenario: No effective profile metadata is available
+- **WHEN** credential orchestration cannot find effective provider profile metadata for a provider slug
+- **THEN** credential resolution returns an actionable unsupported-provider or unsupported-credential outcome
+- **AND** it does not silently assume all credential modes are supported

--- a/openspec/changes/archive/2026-06-20-store-backed-provider-profiles/specs/provider-profiles/spec.md
+++ b/openspec/changes/archive/2026-06-20-store-backed-provider-profiles/specs/provider-profiles/spec.md
@@ -1,0 +1,62 @@
+## ADDED Requirements
+
+### Requirement: Core SHALL build an effective provider registry from built-ins plus persisted profiles
+`iron-core` SHALL provide a way to construct an effective provider registry by starting with the built-in `iron-providers` registry and applying persisted custom provider profiles and explicit provider profile overrides from the core config store.
+
+Persisted provider profiles SHALL override built-in profiles with the same slug. Persisted provider profiles with new slugs SHALL be added alongside built-ins.
+
+#### Scenario: Empty provider profile store preserves built-ins
+- **WHEN** the effective provider registry is built with no persisted provider profile records
+- **THEN** built-in provider profiles from `iron-providers` remain available
+- **AND** no config-store rows are required for built-in providers
+
+#### Scenario: Custom provider profile is added
+- **WHEN** the config store contains a valid provider profile whose slug does not match a built-in provider
+- **THEN** the effective provider registry includes that custom provider profile
+- **AND** callers can resolve the custom provider by slug
+
+#### Scenario: Persisted profile overrides built-in
+- **WHEN** the config store contains a valid provider profile whose slug matches a built-in provider
+- **THEN** the effective provider registry uses the persisted profile for that slug
+- **AND** other built-in profiles remain available
+
+### Requirement: Provider profile records SHALL be non-secret provider protocol metadata
+Provider profile records SHALL contain provider protocol metadata needed to construct provider connections and prompt guidance. Provider profile records SHALL NOT contain API keys, OAuth tokens, refresh tokens, user credential state, starred models, or app-specific display preferences.
+
+#### Scenario: Provider profile is stored
+- **WHEN** a caller stores a provider profile record
+- **THEN** the accepted payload contains only non-secret provider metadata
+- **AND** provider credentials remain stored through provider credential APIs
+
+#### Scenario: Provider profile payload contains credential material
+- **WHEN** a caller imports or stores a provider profile payload containing credential secret material
+- **THEN** the operation fails with an actionable validation error
+- **AND** no provider profile record is persisted from that payload
+
+### Requirement: Core SHALL support provider profile import and export
+`iron-core` SHALL support importing and exporting provider profile JSON using the `iron-providers` profile schema supported by the compiled dependency version.
+
+Imported provider profiles SHALL be validated before persistence. Exported provider profiles SHALL exclude credentials and runtime-only state.
+
+#### Scenario: Valid provider profile JSON imports
+- **WHEN** a caller imports valid provider profile JSON
+- **THEN** the profile is stored as a custom profile or explicit override keyed by its slug
+- **AND** the stored profile can be loaded into the effective provider registry
+
+#### Scenario: Invalid provider profile JSON is rejected
+- **WHEN** a caller imports malformed JSON or a payload that does not satisfy provider profile validation
+- **THEN** the import operation returns a validation error
+- **AND** no partial provider profile record is stored
+
+#### Scenario: Provider profile exports
+- **WHEN** a caller exports a persisted provider profile by slug
+- **THEN** the exported JSON contains the stored provider profile metadata
+- **AND** the exported JSON does not include provider credential material
+
+### Requirement: Effective provider registry SHALL be usable without durable storage
+Callers that do not configure durable provider profile storage SHALL retain built-in-only provider behavior.
+
+#### Scenario: Runtime has no provider profile store
+- **WHEN** a runtime or test constructs provider behavior without a config-backed provider profile store
+- **THEN** built-in providers remain available through the default `iron-providers` registry
+- **AND** no custom provider profiles or overrides are required

--- a/openspec/changes/archive/2026-06-20-store-backed-provider-profiles/tasks.md
+++ b/openspec/changes/archive/2026-06-20-store-backed-provider-profiles/tasks.md
@@ -1,0 +1,46 @@
+## 1. Dependency and Schema Foundation
+
+- [x] 1.1 Upgrade `iron-providers` to the release that exposes serializable `ProviderProfile` data with `provider_guidance` support.
+- [x] 1.2 Add a config-store migration for a provider profile records table without seeding built-in provider rows.
+- [x] 1.3 Add provider profile record/input types with slug, payload, source metadata, and timestamps.
+- [x] 1.4 Add typed `ConfigStore` CRUD/list APIs for provider profile records.
+- [x] 1.5 Add config-store tests for migration, roundtrip, deterministic listing, deletion, and preservation of existing config rows.
+
+## 2. Provider Profile Store and Import/Export
+
+- [x] 2.1 Add an `iron-core` provider profile store/loading boundary backed by `ConfigStore`.
+- [x] 2.2 Validate provider profile payloads before persistence, including rejecting credential secret material.
+- [x] 2.3 Implement import from provider profile JSON into the provider profile store.
+- [x] 2.4 Implement export of persisted provider profile JSON by slug.
+- [x] 2.5 Add tests for valid import, invalid import, override import, custom profile import, and credential-material rejection.
+
+## 3. Effective Provider Registry
+
+- [x] 3.1 Add effective provider registry construction that starts from `ProviderRegistry::default()` and applies persisted provider profiles.
+- [x] 3.2 Ensure custom persisted slugs are added alongside built-ins.
+- [x] 3.3 Ensure persisted profiles with built-in slugs override the built-in profile for that slug only.
+- [x] 3.4 Add runtime/config APIs or builders needed to load and share the effective provider registry.
+- [x] 3.5 Add tests proving built-in fallback, custom profile resolution, and override precedence.
+
+## 4. Runtime and Prompt Integration
+
+- [x] 4.1 Use the effective provider registry for managed provider construction instead of constructing fresh built-in-only registries.
+- [x] 4.2 Use the effective provider profile for provider-specific prompt guidance resolution.
+- [x] 4.3 Preserve manual provider guidance fallback when no effective provider profile guidance is available.
+- [x] 4.4 Update provider slug discovery to include built-ins plus persisted custom/override provider profiles.
+- [x] 4.5 Add tests for built-in guidance, custom profile guidance, override guidance, and manual guidance fallback.
+
+## 5. Credential and Model-Catalog Integration
+
+- [x] 5.1 Derive generic provider credential support from effective provider profile credential auth metadata.
+- [x] 5.2 Preserve provider-specific OAuth device-code metadata for existing V1 OAuth flows.
+- [x] 5.3 Validate custom model/default provider slugs against built-ins plus persisted provider profiles.
+- [x] 5.4 Add tests for API-key, OAuth bearer, no-auth, and unsupported credential support derived from profile metadata.
+- [x] 5.5 Add tests for custom model validation with custom provider profiles and unknown provider slugs.
+
+## 6. Verification
+
+- [x] 6.1 Run `cargo fmt --check`.
+- [x] 6.2 Run `cargo clippy --locked --manifest-path Cargo.toml --all-targets --all-features -- -D warnings`.
+- [x] 6.3 Run `cargo test`.
+- [x] 6.4 Run `openspec validate store-backed-provider-profiles --strict`.

--- a/openspec/specs/core-config-store/spec.md
+++ b/openspec/specs/core-config-store/spec.md
@@ -1,9 +1,7 @@
 ## Purpose
 
 Define the durable, core-owned AgentIron configuration store used for profiles, prompts, schedules, domain-scoped opaque settings, and encrypted provider credentials.
-
 ## Requirements
-
 ### Requirement: Core exposes a durable config module
 
 The system SHALL provide a public `iron_core::config` module for durable AgentIron configuration owned by `iron-core`.
@@ -439,3 +437,36 @@ The SQLite-backed config store SHALL add a compiled-in migration for saved hando
 - **WHEN** an in-memory config store is created for tests or embedders
 - **THEN** the same compiled-in saved handoff migration is applied
 - **AND** saved handoff CRUD APIs are available without user configuration files
+
+### Requirement: Config store SHALL support provider profile records
+The config store SHALL provide typed async CRUD APIs for non-secret provider profile records keyed by provider slug. Provider profile records SHALL be stored separately from `AgentProfile` records and provider runtime configuration records.
+
+Provider profile records SHALL include the provider slug, serialized provider profile payload, store-maintained timestamps, and optional source metadata useful for import diagnostics.
+
+#### Scenario: Provider profile record roundtrips
+- **WHEN** a caller stores a provider profile record with a valid slug and payload
+- **THEN** the caller can retrieve the same provider profile record by slug
+- **AND** the returned record includes store-maintained timestamps
+
+#### Scenario: Provider profile records list deterministically
+- **WHEN** a caller lists provider profile records
+- **THEN** the system returns persisted provider profile records in deterministic order
+- **AND** built-in provider profiles that were not explicitly persisted are not returned as config-store rows
+
+#### Scenario: Provider profile record is deleted
+- **WHEN** a caller deletes a provider profile record by slug
+- **THEN** subsequent read-by-slug calls return `Ok(None)` unless the API explicitly requires existence
+- **AND** deleting the row does not remove compiled-in built-in provider behavior
+
+### Requirement: Config schema SHALL migrate provider profile storage
+The config store schema migrations SHALL create durable storage for provider profile records when opening an older or empty database.
+
+#### Scenario: Empty database opens with provider profile storage
+- **WHEN** the config store opens an empty database
+- **THEN** migrations create the provider profile storage required by the provider profile APIs
+- **AND** no built-in provider profile rows are inserted by default
+
+#### Scenario: Older database opens with provider profile migration
+- **WHEN** the config store opens a database created before provider profile storage existed
+- **THEN** pending migrations add provider profile storage without changing existing profile, prompt, credential, provider config, custom model, or schedule rows
+

--- a/openspec/specs/dynamic-system-prompt-templating/spec.md
+++ b/openspec/specs/dynamic-system-prompt-templating/spec.md
@@ -106,3 +106,29 @@ Provider/model-specific system prompting from `iron-providers` SHALL appear only
 - **WHEN** the selected profile identity content differs from the cached prompt inputs
 - **THEN** the system prompt fingerprint changes
 - **AND** the next rendered system prompt reflects the new identity section content
+
+### Requirement: Provider guidance SHALL resolve from the effective provider profile
+Provider-specific guidance in the canonical `Provider-Specific Guidance` section SHALL be resolved from the effective provider profile for the selected provider when profile guidance is available.
+
+The system SHALL NOT construct a fresh built-in-only registry during request prompt composition when an effective provider registry or selected effective provider profile is available.
+
+#### Scenario: Built-in provider guidance renders
+- **WHEN** a provider request is built for a built-in provider with provider guidance
+- **THEN** that guidance appears in `## 7. Provider-Specific Guidance`
+- **AND** the canonical section order remains unchanged
+
+#### Scenario: Custom provider guidance renders
+- **WHEN** a provider request is built for a custom provider profile with provider guidance
+- **THEN** the custom profile guidance appears in `## 7. Provider-Specific Guidance`
+- **AND** no other prompt section ownership changes
+
+#### Scenario: Override provider guidance wins
+- **WHEN** a persisted provider profile override supplies guidance for a built-in provider slug
+- **THEN** prompt composition uses the override guidance for that slug
+- **AND** it does not use stale built-in-only guidance from a throwaway registry
+
+#### Scenario: Missing provider guidance falls back to manual guidance
+- **WHEN** no effective provider profile guidance is available for the selected provider
+- **THEN** prompt composition uses manually configured provider guidance when present
+- **AND** otherwise renders the provider guidance section empty according to existing prompt composition behavior
+

--- a/openspec/specs/effective-model-catalog/spec.md
+++ b/openspec/specs/effective-model-catalog/spec.md
@@ -1,9 +1,7 @@
 ## Purpose
 
 Define the runtime model catalog that merges built-in provider model metadata with ConfigStore custom model records for capability lookup, default model validation, and model-switch planning.
-
 ## Requirements
-
 ### Requirement: The runtime SHALL provide an effective model catalog merging built-in and custom model metadata
 
 The system SHALL provide an `EffectiveModelCatalog` that merges built-in provider model metadata with ConfigStore custom model records into a unified queryable view. The catalog SHALL be a runtime-only structure built by loading built-in metadata and ConfigStore snapshot data.
@@ -92,3 +90,20 @@ When validating default model selection in the runtime settings snapshot, the sy
 #### Scenario: Default model is unknown
 - **WHEN** the default model is set to a provider/model combination that does not exist in either built-in or custom entries
 - **THEN** validation returns an actionable error
+
+### Requirement: Provider slug validation SHALL consider effective provider profiles
+Provider slug validation for custom models and default model settings SHALL consider provider slugs from built-in provider profiles plus persisted custom/override provider profiles loaded into the effective provider registry.
+
+#### Scenario: Custom model references custom provider profile
+- **WHEN** a caller stores a custom model for a provider slug supplied by a persisted custom provider profile
+- **THEN** provider slug validation succeeds for that provider slug
+- **AND** the custom model can participate in the effective model catalog
+
+#### Scenario: Custom model references unknown provider slug
+- **WHEN** a caller stores a custom model for a provider slug that is neither built-in nor present in persisted provider profiles
+- **THEN** validation fails with an actionable unknown-provider error
+
+#### Scenario: Provider profile override keeps slug valid
+- **WHEN** a persisted provider profile overrides a built-in provider slug
+- **THEN** that provider slug remains valid for custom model and default model validation
+

--- a/openspec/specs/provider-credential-orchestration/spec.md
+++ b/openspec/specs/provider-credential-orchestration/spec.md
@@ -1,9 +1,7 @@
 ## Purpose
 
 Define how `iron-core` resolves, persists, refreshes, reports, and disconnects provider credentials while preserving provider-safe boundaries and durable credential storage semantics.
-
 ## Requirements
-
 ### Requirement: Core SHALL support core-owned provider credential storage
 
 `iron-core` SHALL define and provide provider credential storage for provider OAuth/API-key credential material through the core config store, while preserving the existing credential store boundary for tests, in-memory operation, and future alternate backends.
@@ -272,3 +270,28 @@ The system SHALL NOT silently fall back to storing provider credential payloads 
 #### Scenario: API-key provider auth failure
 - **WHEN** an API-key-backed provider invocation fails with an auth error
 - **THEN** `iron-core` SHALL NOT attempt OAuth refresh retry for that invocation
+
+### Requirement: Provider credential support SHALL use effective provider profile metadata
+Provider credential orchestration SHALL derive API-key, OAuth bearer, and no-auth support from the effective provider profile metadata when a profile is available for the provider slug.
+
+Provider-specific OAuth device-code metadata MAY remain specialized, but generic credential-mode support used for provider invocation SHALL not rely solely on hardcoded built-in slug lists.
+
+#### Scenario: Custom profile supports API-key credentials
+- **WHEN** credential orchestration resolves credentials for a custom provider profile that supports API-key authentication
+- **THEN** API-key credentials are accepted for that provider
+- **AND** provider invocation uses the auth strategy declared by the effective provider profile
+
+#### Scenario: Effective profile supports OAuth bearer credentials
+- **WHEN** credential orchestration resolves credentials for an effective provider profile that supports OAuth bearer authentication
+- **THEN** stored OAuth bearer credentials are considered usable for that provider
+- **AND** unsupported credential modes are rejected with an actionable unsupported-credential error
+
+#### Scenario: Effective profile supports no-auth invocation
+- **WHEN** credential orchestration resolves credentials for an effective provider profile that supports no-auth invocation
+- **THEN** the provider can be constructed without requiring API-key or OAuth credential material
+
+#### Scenario: No effective profile metadata is available
+- **WHEN** credential orchestration cannot find effective provider profile metadata for a provider slug
+- **THEN** credential resolution returns an actionable unsupported-provider or unsupported-credential outcome
+- **AND** it does not silently assume all credential modes are supported
+

--- a/openspec/specs/provider-profiles/spec.md
+++ b/openspec/specs/provider-profiles/spec.md
@@ -1,0 +1,66 @@
+# provider-profiles Specification
+
+## Purpose
+TBD - created by archiving change store-backed-provider-profiles. Update Purpose after archive.
+## Requirements
+### Requirement: Core SHALL build an effective provider registry from built-ins plus persisted profiles
+`iron-core` SHALL provide a way to construct an effective provider registry by starting with the built-in `iron-providers` registry and applying persisted custom provider profiles and explicit provider profile overrides from the core config store.
+
+Persisted provider profiles SHALL override built-in profiles with the same slug. Persisted provider profiles with new slugs SHALL be added alongside built-ins.
+
+#### Scenario: Empty provider profile store preserves built-ins
+- **WHEN** the effective provider registry is built with no persisted provider profile records
+- **THEN** built-in provider profiles from `iron-providers` remain available
+- **AND** no config-store rows are required for built-in providers
+
+#### Scenario: Custom provider profile is added
+- **WHEN** the config store contains a valid provider profile whose slug does not match a built-in provider
+- **THEN** the effective provider registry includes that custom provider profile
+- **AND** callers can resolve the custom provider by slug
+
+#### Scenario: Persisted profile overrides built-in
+- **WHEN** the config store contains a valid provider profile whose slug matches a built-in provider
+- **THEN** the effective provider registry uses the persisted profile for that slug
+- **AND** other built-in profiles remain available
+
+### Requirement: Provider profile records SHALL be non-secret provider protocol metadata
+Provider profile records SHALL contain provider protocol metadata needed to construct provider connections and prompt guidance. Provider profile records SHALL NOT contain API keys, OAuth tokens, refresh tokens, user credential state, starred models, or app-specific display preferences.
+
+#### Scenario: Provider profile is stored
+- **WHEN** a caller stores a provider profile record
+- **THEN** the accepted payload contains only non-secret provider metadata
+- **AND** provider credentials remain stored through provider credential APIs
+
+#### Scenario: Provider profile payload contains credential material
+- **WHEN** a caller imports or stores a provider profile payload containing credential secret material
+- **THEN** the operation fails with an actionable validation error
+- **AND** no provider profile record is persisted from that payload
+
+### Requirement: Core SHALL support provider profile import and export
+`iron-core` SHALL support importing and exporting provider profile JSON using the `iron-providers` profile schema supported by the compiled dependency version.
+
+Imported provider profiles SHALL be validated before persistence. Exported provider profiles SHALL exclude credentials and runtime-only state.
+
+#### Scenario: Valid provider profile JSON imports
+- **WHEN** a caller imports valid provider profile JSON
+- **THEN** the profile is stored as a custom profile or explicit override keyed by its slug
+- **AND** the stored profile can be loaded into the effective provider registry
+
+#### Scenario: Invalid provider profile JSON is rejected
+- **WHEN** a caller imports malformed JSON or a payload that does not satisfy provider profile validation
+- **THEN** the import operation returns a validation error
+- **AND** no partial provider profile record is stored
+
+#### Scenario: Provider profile exports
+- **WHEN** a caller exports a persisted provider profile by slug
+- **THEN** the exported JSON contains the stored provider profile metadata
+- **AND** the exported JSON does not include provider credential material
+
+### Requirement: Effective provider registry SHALL be usable without durable storage
+Callers that do not configure durable provider profile storage SHALL retain built-in-only provider behavior.
+
+#### Scenario: Runtime has no provider profile store
+- **WHEN** a runtime or test constructs provider behavior without a config-backed provider profile store
+- **THEN** built-in providers remain available through the default `iron-providers` registry
+- **AND** no custom provider profiles or overrides are required
+

--- a/openspec/specs/provider-profiles/spec.md
+++ b/openspec/specs/provider-profiles/spec.md
@@ -1,7 +1,7 @@
 # provider-profiles Specification
 
 ## Purpose
-TBD - created by archiving change store-backed-provider-profiles. Update Purpose after archive.
+Define durable custom/override provider profile storage, effective registry merge semantics, import/export rules, and credential/model-catalog integration for store-backed provider profiles in `iron-core`.
 ## Requirements
 ### Requirement: Core SHALL build an effective provider registry from built-ins plus persisted profiles
 `iron-core` SHALL provide a way to construct an effective provider registry by starting with the built-in `iron-providers` registry and applying persisted custom provider profiles and explicit provider profile overrides from the core config store.

--- a/src/config/key_source.rs
+++ b/src/config/key_source.rs
@@ -23,11 +23,7 @@ impl OsKeyringKeySource {
 
 impl KeySource for OsKeyringKeySource {
     async fn get_key(&self) -> Result<[u8; 32], ConfigError> {
-        keyring::use_native_store(false).map_err(|e| {
-            ConfigError::KeyUnavailable(format!("Failed to initialize keyring: {}", e))
-        })?;
-
-        let entry = keyring_core::Entry::new(&self.service, &self.account)
+        let entry = keyring::Entry::new(&self.service, &self.account)
             .map_err(|e| ConfigError::KeyUnavailable(format!("Failed to access keyring: {}", e)))?;
 
         match entry.get_password() {
@@ -44,7 +40,7 @@ impl KeySource for OsKeyringKeySource {
                 key.copy_from_slice(&decoded);
                 Ok(key)
             }
-            Err(keyring_core::Error::NoEntry) => {
+            Err(keyring::Error::NoEntry) => {
                 // Generate a new key
                 let key = super::crypto::XChaCha20Poly1305Cipher::generate_key();
                 let encoded =

--- a/src/config/migrations.rs
+++ b/src/config/migrations.rs
@@ -151,11 +151,25 @@ pub const MIGRATIONS: &[(i64, &str)] = &[
             INSERT OR IGNORE INTO schema_version (id, version) VALUES (1, 5);
             "#,
     ),
+    (
+        6,
+        r#"
+            CREATE TABLE IF NOT EXISTS provider_profiles (
+                slug TEXT PRIMARY KEY,
+                profile_json TEXT NOT NULL,
+                source TEXT,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+
+            INSERT OR IGNORE INTO schema_version (id, version) VALUES (1, 6);
+            "#,
+    ),
 ];
 
 /// The current schema version.
 #[allow(dead_code)]
-pub const CURRENT_SCHEMA_VERSION: i64 = 5;
+pub const CURRENT_SCHEMA_VERSION: i64 = 6;
 
 /// Apply all pending migrations to the database.
 pub async fn apply_migrations(pool: &sqlx::SqlitePool) -> Result<(), super::error::ConfigError> {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -594,8 +594,8 @@ pub use records::{
     BootstrapMetadataInput, BootstrapMetadataRecord, CredentialRecord, CustomModelInput,
     CustomModelRecord, DefaultModelInput, DefaultModelRecord, McpServerConfigInput,
     McpServerConfigRecord, ProfileInput, ProfileRecord, PromptInput, PromptRecord,
-    ProviderConfigInput, ProviderConfigRecord, RuntimeSettingsSnapshot, SavedHandoffInput,
-    SavedHandoffMetadata, SavedHandoffRecord, ScheduleInput, ScheduleRecord, SkillSettingsInput,
-    SkillSettingsRecord,
+    ProviderConfigInput, ProviderConfigRecord, ProviderProfileInput, ProviderProfileRecord,
+    RuntimeSettingsSnapshot, SavedHandoffInput, SavedHandoffMetadata, SavedHandoffRecord,
+    ScheduleInput, ScheduleRecord, SkillSettingsInput, SkillSettingsRecord,
 };
 pub use store::{default_config_path, ConfigStore, OpenOptions};

--- a/src/config/records.rs
+++ b/src/config/records.rs
@@ -236,3 +236,21 @@ pub struct SavedHandoffInput {
     pub name: String,
     pub bundle: crate::context::handoff::HandoffBundle,
 }
+
+/// A stored provider profile record (non-secret provider protocol metadata).
+#[derive(Debug, Clone)]
+pub struct ProviderProfileRecord {
+    pub slug: String,
+    pub profile_json: String,
+    pub source: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Input for creating or updating a stored provider profile.
+#[derive(Debug, Clone)]
+pub struct ProviderProfileInput {
+    pub slug: String,
+    pub profile_json: String,
+    pub source: Option<String>,
+}

--- a/src/config/store.rs
+++ b/src/config/store.rs
@@ -686,7 +686,8 @@ impl ConfigStore {
         Ok(())
     }
 
-    /// Return the union of built-in provider slugs and persisted provider config slugs.
+    /// Return the union of built-in provider slugs, persisted custom/override
+    /// provider profile slugs, and persisted provider config slugs.
     pub async fn known_provider_slugs(
         &self,
     ) -> Result<std::collections::HashSet<String>, ConfigError> {
@@ -696,6 +697,11 @@ impl ConfigStore {
         let registry = iron_providers::ProviderRegistry::default();
         for slug in registry.slugs() {
             slugs.insert(slug.to_string());
+        }
+
+        // Persisted custom/override provider profiles
+        for record in self.list_provider_profiles().await? {
+            slugs.insert(record.slug);
         }
 
         // Persisted provider configs
@@ -1799,6 +1805,103 @@ impl ConfigStore {
             .map_err(ConfigError::from)?;
 
         Ok(())
+    }
+
+    // ============================================================================
+    // Provider Profile APIs
+    // ============================================================================
+
+    /// Store or replace a provider profile record.
+    ///
+    /// Returns `ConfigError::Validation` if the slug is empty.
+    pub async fn set_provider_profile(
+        &self,
+        input: &ProviderProfileInput,
+    ) -> Result<(), ConfigError> {
+        if input.slug.trim().is_empty() {
+            return Err(ConfigError::Validation(
+                "Provider profile slug must not be empty".to_string(),
+            ));
+        }
+        let now = Utc::now().to_rfc3339();
+
+        sqlx::query(
+            r#"
+            INSERT INTO provider_profiles (slug, profile_json, source, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT(slug) DO UPDATE SET
+                profile_json = excluded.profile_json,
+                source = excluded.source,
+                updated_at = excluded.updated_at
+            "#,
+        )
+        .bind(&input.slug)
+        .bind(&input.profile_json)
+        .bind(&input.source)
+        .bind(&now)
+        .bind(&now)
+        .execute(&self.pool)
+        .await
+        .map_err(ConfigError::from)?;
+
+        Ok(())
+    }
+
+    /// Get a provider profile record by slug.
+    pub async fn get_provider_profile(
+        &self,
+        slug: &str,
+    ) -> Result<Option<ProviderProfileRecord>, ConfigError> {
+        let row = sqlx::query(
+            "SELECT slug, profile_json, source, created_at, updated_at FROM provider_profiles WHERE slug = ?",
+        )
+        .bind(slug)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(ConfigError::from)?;
+
+        match row {
+            Some(row) => Ok(Some(ProviderProfileRecord {
+                slug: row.get("slug"),
+                profile_json: row.get("profile_json"),
+                source: row.get("source"),
+                created_at: parse_datetime(row.get::<String, _>("created_at"))?,
+                updated_at: parse_datetime(row.get::<String, _>("updated_at"))?,
+            })),
+            None => Ok(None),
+        }
+    }
+
+    /// Delete a provider profile record by slug.
+    pub async fn delete_provider_profile(&self, slug: &str) -> Result<(), ConfigError> {
+        sqlx::query("DELETE FROM provider_profiles WHERE slug = ?")
+            .bind(slug)
+            .execute(&self.pool)
+            .await
+            .map_err(ConfigError::from)?;
+        Ok(())
+    }
+
+    /// List all stored provider profile records, ordered by slug.
+    pub async fn list_provider_profiles(&self) -> Result<Vec<ProviderProfileRecord>, ConfigError> {
+        let rows = sqlx::query(
+            "SELECT slug, profile_json, source, created_at, updated_at FROM provider_profiles ORDER BY slug ASC",
+        )
+        .fetch_all(&self.pool)
+        .await
+        .map_err(ConfigError::from)?;
+
+        rows.into_iter()
+            .map(|row| {
+                Ok(ProviderProfileRecord {
+                    slug: row.get("slug"),
+                    profile_json: row.get("profile_json"),
+                    source: row.get("source"),
+                    created_at: parse_datetime(row.get::<String, _>("created_at"))?,
+                    updated_at: parse_datetime(row.get::<String, _>("updated_at"))?,
+                })
+            })
+            .collect()
     }
 }
 

--- a/src/config/store.rs
+++ b/src/config/store.rs
@@ -699,9 +699,15 @@ impl ConfigStore {
             slugs.insert(slug.to_string());
         }
 
-        // Persisted custom/override provider profiles
+        // Persisted custom/override provider profiles (only valid ones)
         for record in self.list_provider_profiles().await? {
-            slugs.insert(record.slug);
+            if let Ok(profile) =
+                crate::provider_profile::validation::validate_provider_profile(&record.profile_json)
+            {
+                if profile.slug == record.slug {
+                    slugs.insert(record.slug);
+                }
+            }
         }
 
         // Persisted provider configs
@@ -1813,7 +1819,9 @@ impl ConfigStore {
 
     /// Store or replace a provider profile record.
     ///
-    /// Returns `ConfigError::Validation` if the slug is empty.
+    /// Validates the profile payload and enforces slug consistency.
+    /// Returns `ConfigError::Validation` if the slug is empty, the payload
+    /// is invalid, or the payload slug does not match the record slug.
     pub async fn set_provider_profile(
         &self,
         input: &ProviderProfileInput,
@@ -1822,6 +1830,14 @@ impl ConfigStore {
             return Err(ConfigError::Validation(
                 "Provider profile slug must not be empty".to_string(),
             ));
+        }
+        let profile =
+            crate::provider_profile::validation::validate_provider_profile(&input.profile_json)?;
+        if profile.slug != input.slug {
+            return Err(ConfigError::Validation(format!(
+                "Provider profile slug mismatch: record slug '{}' != payload slug '{}'",
+                input.slug, profile.slug
+            )));
         }
         let now = Utc::now().to_rfc3339();
 

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -7,7 +7,7 @@ use crate::prompt_lifecycle::AcpPromptSink;
 use crate::prompt_runner::PromptRunner;
 use crate::provider_credential::domain::ProviderPromptContext;
 use crate::runtime::{ConnectionId, IronRuntime};
-use agent_client_protocol::schema as acp;
+use agent_client_protocol::schema::v1 as acp;
 use parking_lot::RwLock;
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -242,7 +242,10 @@ impl IronConnection {
         info!("ACP initialize from client");
 
         let caps = acp::AgentCapabilities::default();
-        Ok(acp::InitializeResponse::new(acp::ProtocolVersion::V1).agent_capabilities(caps))
+        Ok(
+            acp::InitializeResponse::new(agent_client_protocol::schema::ProtocolVersion::V1)
+                .agent_capabilities(caps),
+        )
     }
 
     pub async fn handle_authenticate(

--- a/src/delegation/mod.rs
+++ b/src/delegation/mod.rs
@@ -119,16 +119,18 @@ pub enum DelegationOutcome {
     Unknown,
 }
 
-impl From<agent_client_protocol::schema::StopReason> for DelegationOutcome {
-    fn from(reason: agent_client_protocol::schema::StopReason) -> Self {
+impl From<agent_client_protocol::schema::v1::StopReason> for DelegationOutcome {
+    fn from(reason: agent_client_protocol::schema::v1::StopReason) -> Self {
         match reason {
-            agent_client_protocol::schema::StopReason::EndTurn => DelegationOutcome::EndTurn,
-            agent_client_protocol::schema::StopReason::Cancelled => DelegationOutcome::Cancelled,
-            agent_client_protocol::schema::StopReason::MaxTurnRequests => {
+            agent_client_protocol::schema::v1::StopReason::EndTurn => DelegationOutcome::EndTurn,
+            agent_client_protocol::schema::v1::StopReason::Cancelled => {
+                DelegationOutcome::Cancelled
+            }
+            agent_client_protocol::schema::v1::StopReason::MaxTurnRequests => {
                 DelegationOutcome::MaxTurnRequests
             }
-            agent_client_protocol::schema::StopReason::MaxTokens
-            | agent_client_protocol::schema::StopReason::Refusal
+            agent_client_protocol::schema::v1::StopReason::MaxTokens
+            | agent_client_protocol::schema::v1::StopReason::Refusal
             | _ => DelegationOutcome::Unknown,
         }
     }

--- a/src/delegation/runtime.rs
+++ b/src/delegation/runtime.rs
@@ -12,7 +12,7 @@ use crate::profile::AgentProfile;
 use crate::prompt_runner::PromptRunner;
 use crate::runtime::IronRuntime;
 use crate::tool::ToolDefinition;
-use agent_client_protocol::schema as acp;
+use agent_client_protocol::schema::v1 as acp;
 use std::collections::{HashMap, HashSet};
 
 use crate::mcp::session_catalog::ToolSource;

--- a/src/delegation/sink.rs
+++ b/src/delegation/sink.rs
@@ -5,7 +5,7 @@ use crate::delegation::ChildApprovalMode;
 use crate::prompt_lifecycle::{
     ApprovalRequest, ApprovalVerdict, PromptLifecycleEvent, PromptSink, ToolUpdateStatus,
 };
-use agent_client_protocol::schema as acp;
+use agent_client_protocol::schema::v1 as acp;
 use std::pin::Pin;
 
 /// A prompt sink for a delegated child session.

--- a/src/durable.rs
+++ b/src/durable.rs
@@ -1,4 +1,4 @@
-use agent_client_protocol::schema as acp;
+use agent_client_protocol::schema::v1 as acp;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::{btree_map::Entry, BTreeMap, BTreeSet, HashMap};

--- a/src/facade.rs
+++ b/src/facade.rs
@@ -22,7 +22,7 @@ use crate::{
     },
     tool::Tool,
 };
-use agent_client_protocol::schema as acp;
+use agent_client_protocol::schema::v1 as acp;
 use futures::Stream;
 use iron_providers::Provider;
 use parking_lot::{Mutex, RwLock};
@@ -816,6 +816,19 @@ impl IronAgent {
         policy: crate::profile::DefaultProfileSeedPolicy,
     ) -> Result<crate::profile::DefaultProfileSeedReport, crate::config::ConfigError> {
         crate::profile::seed_default_profiles(store, policy).await
+    }
+
+    /// Load persisted provider profiles from the config store into the runtime's
+    /// effective provider registry.
+    ///
+    /// Built-in provider profiles are preserved; persisted profiles with the
+    /// same slug override built-ins, and persisted profiles with new slugs are
+    /// added. Credential resolver support maps are also updated.
+    pub async fn load_provider_profiles(
+        &self,
+        store: &ConfigStore,
+    ) -> Result<(), crate::config::ConfigError> {
+        self.runtime.load_provider_profiles(store).await
     }
 
     /// Register or replace an agent profile by stable ID.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,6 +181,7 @@ pub mod prompt_lifecycle;
 pub mod prompt_runner;
 pub mod prompt_turn;
 pub mod provider_credential;
+pub mod provider_profile;
 pub mod request_builder;
 pub mod runtime;
 pub mod schema;

--- a/src/prompt_lifecycle.rs
+++ b/src/prompt_lifecycle.rs
@@ -1,5 +1,5 @@
 use crate::connection::{notification, SharedClientChannel};
-use agent_client_protocol::schema as acp;
+use agent_client_protocol::schema::v1 as acp;
 use std::pin::Pin;
 
 pub enum PromptLifecycleEvent {

--- a/src/prompt_runner.rs
+++ b/src/prompt_runner.rs
@@ -29,7 +29,7 @@ use crate::prompt_lifecycle::{
 };
 use crate::provider_credential::ProviderPromptContext;
 use crate::runtime::IronRuntime;
-use agent_client_protocol::schema as acp;
+use agent_client_protocol::schema::v1 as acp;
 use futures::StreamExt;
 use iron_providers::{Provider, ProviderError, ProviderEvent};
 use parking_lot::Mutex;
@@ -195,6 +195,8 @@ impl PromptRunner {
                 drop(session);
 
                 let tool_registry = self.runtime.tool_registry();
+                let effective_provider_guidance =
+                    self.runtime.resolve_effective_provider_guidance();
                 let mut snapshot = {
                     let session = durable.lock();
                     crate::context::ActiveContextAccountant::estimate_snapshot(
@@ -264,6 +266,7 @@ impl PromptRunner {
                             workspace_roots: Some(&workspace_roots),
                             effective_model: effective_model.as_deref(),
                             profile_identity: profile_identity.as_deref(),
+                            effective_provider_guidance: effective_provider_guidance.as_deref(),
                         },
                         tool_catalog.definitions(),
                     )
@@ -281,6 +284,7 @@ impl PromptRunner {
                             workspace_roots: Some(&workspace_roots),
                             effective_model: effective_model.as_deref(),
                             profile_identity: profile_identity.as_deref(),
+                            effective_provider_guidance: effective_provider_guidance.as_deref(),
                         },
                         &tool_registry,
                     )

--- a/src/provider_credential/resolver.rs
+++ b/src/provider_credential/resolver.rs
@@ -12,7 +12,7 @@ use crate::provider_credential::domain::{
 use crate::provider_credential::durable_store::FallibleCredentialStore;
 use crate::provider_credential::oauth::{refresh_access_token, v1_oauth_metadata};
 use crate::provider_credential::store::DynCredentialStore;
-use iron_providers::ProviderCredential;
+use iron_providers::{CredentialKind, ProviderCredential, ProviderProfile};
 use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -29,23 +29,12 @@ pub struct CredentialSupport {
     pub oauth_bearer: bool,
 }
 
-/// Resolves provider credentials for a prompt from stored state and optional
-/// client-supplied API keys.
+/// Build the V1 credential support map from known built-in provider profiles.
 ///
-/// When a [`FallibleCredentialStore`] is provided, durable store errors are
-/// surfaced as [`ProviderAuthError::StoreError`] rather than being silently
-/// treated as missing credentials.
-pub struct CredentialResolver {
-    store: DynCredentialStore,
-    fallible_store: Option<Arc<dyn FallibleCredentialStore>>,
-    support_map: HashMap<String, CredentialSupport>,
-    http_client: reqwest::Client,
-    status_overrides: Mutex<HashMap<String, ProviderAuthStatus>>,
-}
-
+/// This reflects the credential support of the built-in profiles registered
+/// by `iron-providers::ProviderRegistry::register_builtins()`.
 fn build_v1_support_map() -> HashMap<String, CredentialSupport> {
     let mut map = HashMap::new();
-    // Hardcoded V1 support based on iron-providers built-in profiles.
     // kimi-code supports both API key (x-api-key) and OAuthBearer.
     map.insert(
         "kimi-code".to_string(),
@@ -81,6 +70,42 @@ fn build_v1_support_map() -> HashMap<String, CredentialSupport> {
     map
 }
 
+/// Resolves provider credentials for a prompt from stored state and optional
+/// client-supplied API keys.
+///
+/// When a [`FallibleCredentialStore`] is provided, durable store errors are
+/// surfaced as [`ProviderAuthError::StoreError`] rather than being silently
+/// treated as missing credentials.
+pub struct CredentialResolver {
+    store: DynCredentialStore,
+    fallible_store: Option<Arc<dyn FallibleCredentialStore>>,
+    support_map: Mutex<HashMap<String, CredentialSupport>>,
+    http_client: reqwest::Client,
+    status_overrides: Mutex<HashMap<String, ProviderAuthStatus>>,
+}
+
+/// Build a credential support map by scanning provider profiles.
+///
+/// For each profile, API-key support is derived from whether any
+/// `credential_auth` entry declares [`CredentialKind::ApiKey`], and OAuth
+/// bearer support is derived from whether any entry declares
+/// [`CredentialKind::OAuthBearer`].
+fn build_support_map_from_profiles(
+    profiles: &[ProviderProfile],
+) -> HashMap<String, CredentialSupport> {
+    let mut map = HashMap::new();
+    for profile in profiles {
+        map.insert(
+            profile.slug.to_lowercase(),
+            CredentialSupport {
+                api_key: profile.supports_credential(CredentialKind::ApiKey),
+                oauth_bearer: profile.supports_credential(CredentialKind::OAuthBearer),
+            },
+        );
+    }
+    map
+}
+
 impl CredentialResolver {
     /// Create a new resolver with the given store.
     ///
@@ -90,7 +115,7 @@ impl CredentialResolver {
         Self {
             store,
             fallible_store: None,
-            support_map: build_v1_support_map(),
+            support_map: Mutex::new(build_v1_support_map()),
             http_client: reqwest::Client::new(),
             status_overrides: Mutex::new(HashMap::new()),
         }
@@ -108,7 +133,7 @@ impl CredentialResolver {
         Self {
             store,
             fallible_store: Some(fallible),
-            support_map: build_v1_support_map(),
+            support_map: Mutex::new(build_v1_support_map()),
             http_client: reqwest::Client::new(),
             status_overrides: Mutex::new(HashMap::new()),
         }
@@ -123,12 +148,25 @@ impl CredentialResolver {
 
     fn support_for(&self, slug: &str) -> CredentialSupport {
         self.support_map
+            .lock()
             .get(&slug.to_lowercase())
             .cloned()
             .unwrap_or(CredentialSupport {
                 api_key: true,
                 oauth_bearer: true,
             })
+    }
+
+    /// Merge credential support derived from additional provider profiles.
+    ///
+    /// Called by the runtime after loading persisted custom/override provider
+    /// profiles. Entries for the same slug replace any previous mapping.
+    pub fn merge_support_from_profiles(&self, profiles: &[ProviderProfile]) {
+        let updates = build_support_map_from_profiles(profiles);
+        let mut map = self.support_map.lock();
+        for (slug, support) in updates {
+            map.insert(slug, support);
+        }
     }
 
     /// Resolve a credential for the given prompt context.

--- a/src/provider_credential/resolver.rs
+++ b/src/provider_credential/resolver.rs
@@ -157,16 +157,18 @@ impl CredentialResolver {
             })
     }
 
-    /// Merge credential support derived from additional provider profiles.
+    /// Rebuild credential support from built-ins plus the given profiles.
     ///
     /// Called by the runtime after loading persisted custom/override provider
-    /// profiles. Entries for the same slug replace any previous mapping.
+    /// profiles. The support map is rebuilt from V1 built-ins first, then
+    /// the provided profiles are applied on top so that removed profiles
+    /// do not leave stale support entries.
     pub fn merge_support_from_profiles(&self, profiles: &[ProviderProfile]) {
-        let updates = build_support_map_from_profiles(profiles);
-        let mut map = self.support_map.lock();
-        for (slug, support) in updates {
-            map.insert(slug, support);
+        let mut rebuilt = build_v1_support_map();
+        for (slug, support) in build_support_map_from_profiles(profiles) {
+            rebuilt.insert(slug, support);
         }
+        *self.support_map.lock() = rebuilt;
     }
 
     /// Resolve a credential for the given prompt context.

--- a/src/provider_profile/mod.rs
+++ b/src/provider_profile/mod.rs
@@ -1,0 +1,16 @@
+//! Store-backed provider profile management.
+//!
+//! This module provides durable storage, validation, import/export, and
+//! effective registry construction for provider profiles. Built-in provider
+//! profiles remain compiled into `iron-providers`; persisted rows in the config
+//! store represent only custom profiles and explicit overrides.
+
+pub mod registry;
+pub mod store;
+pub mod validation;
+
+pub use registry::build_effective_registry;
+pub use store::{
+    export_provider_profile, import_provider_profile, DurableProfileStore, ProfileStore,
+};
+pub use validation::validate_provider_profile;

--- a/src/provider_profile/registry.rs
+++ b/src/provider_profile/registry.rs
@@ -1,0 +1,121 @@
+//! Effective provider registry construction.
+//!
+//! Builds a [`ProviderRegistry`] by starting with built-in profiles from
+//! `iron-providers` and applying persisted custom/override provider profiles
+//! from the config store.
+
+use crate::config::{ConfigError, ConfigStore};
+use iron_providers::{ProviderProfile, ProviderRegistry};
+
+/// Build an effective provider registry from built-ins plus persisted profiles.
+///
+/// Starts with [`ProviderRegistry::default()` (which loads all built-in
+/// profiles) and applies each persisted provider profile. Persisted profiles
+/// with built-in slugs override the built-in; persisted profiles with new slugs
+/// are added alongside built-ins.
+///
+/// Invalid stored profiles are skipped with a warning rather than failing the
+/// entire operation.
+pub async fn build_effective_registry(
+    store: &ConfigStore,
+) -> Result<ProviderRegistry, ConfigError> {
+    let mut registry = ProviderRegistry::default();
+
+    let records = store.list_provider_profiles().await?;
+    for record in records {
+        match serde_json::from_str::<ProviderProfile>(&record.profile_json) {
+            Ok(profile) => {
+                let slug = profile.slug.clone();
+                registry.register(profile);
+                tracing::debug!(slug = %slug, "Applied persisted provider profile to effective registry");
+            }
+            Err(e) => {
+                tracing::warn!(
+                    slug = %record.slug,
+                    error = %e,
+                    "Failed to deserialize stored provider profile; skipping"
+                );
+            }
+        }
+    }
+
+    Ok(registry)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use iron_providers::{ApiFamily, ProviderProfile};
+
+    #[tokio::test]
+    async fn empty_store_preserves_builtins() {
+        let store = ConfigStore::open_in_memory().await.unwrap();
+        let registry = build_effective_registry(&store).await.unwrap();
+
+        // Built-in providers should be available
+        assert!(registry.slugs().contains(&"openai"));
+        assert!(registry.slugs().contains(&"anthropic"));
+    }
+
+    #[tokio::test]
+    async fn custom_profile_is_added() {
+        let store = ConfigStore::open_in_memory().await.unwrap();
+
+        let profile = ProviderProfile::new(
+            "my-custom",
+            ApiFamily::Completions,
+            "https://custom.example.com",
+        );
+        let json = serde_json::to_string(&profile).unwrap();
+        import_test_profile(&store, "my-custom", &json).await;
+
+        let registry = build_effective_registry(&store).await.unwrap();
+        assert!(registry.slugs().contains(&"my-custom"));
+    }
+
+    #[tokio::test]
+    async fn override_replaces_builtin() {
+        let store = ConfigStore::open_in_memory().await.unwrap();
+
+        let profile = ProviderProfile::new(
+            "openai",
+            ApiFamily::Messages,
+            "https://custom.openai.example",
+        )
+        .with_provider_guidance("Custom OpenAI guidance.");
+        let json = serde_json::to_string(&profile).unwrap();
+        import_test_profile(&store, "openai", &json).await;
+
+        let registry = build_effective_registry(&store).await.unwrap();
+        let fragment = registry.system_prompt_fragment("openai").unwrap();
+        assert_eq!(fragment, "Custom OpenAI guidance.");
+    }
+
+    #[tokio::test]
+    async fn invalid_profile_skipped() {
+        let store = ConfigStore::open_in_memory().await.unwrap();
+
+        // Insert invalid JSON directly (bypassing validation)
+        let input = crate::config::ProviderProfileInput {
+            slug: "bad-profile".to_string(),
+            profile_json: "{not valid}".to_string(),
+            source: None,
+        };
+        store.set_provider_profile(&input).await.unwrap();
+
+        let registry = build_effective_registry(&store).await.unwrap();
+        // Built-ins should still be present
+        assert!(registry.slugs().contains(&"openai"));
+        // Invalid profile should not be present
+        assert!(!registry.slugs().contains(&"bad-profile"));
+    }
+
+    async fn import_test_profile(store: &ConfigStore, slug: &str, json: &str) {
+        let input = crate::config::ProviderProfileInput {
+            slug: slug.to_string(),
+            profile_json: json.to_string(),
+            source: None,
+        };
+        store.set_provider_profile(&input).await.unwrap();
+    }
+}

--- a/src/provider_profile/registry.rs
+++ b/src/provider_profile/registry.rs
@@ -25,6 +25,14 @@ pub async fn build_effective_registry(
     for record in records {
         match serde_json::from_str::<ProviderProfile>(&record.profile_json) {
             Ok(profile) => {
+                if profile.slug != record.slug {
+                    tracing::warn!(
+                        row_slug = %record.slug,
+                        payload_slug = %profile.slug,
+                        "Stored provider profile slug mismatch; skipping"
+                    );
+                    continue;
+                }
                 let slug = profile.slug.clone();
                 registry.register(profile);
                 tracing::debug!(slug = %slug, "Applied persisted provider profile to effective registry");
@@ -95,13 +103,17 @@ mod tests {
     async fn invalid_profile_skipped() {
         let store = ConfigStore::open_in_memory().await.unwrap();
 
-        // Insert invalid JSON directly (bypassing validation)
-        let input = crate::config::ProviderProfileInput {
-            slug: "bad-profile".to_string(),
-            profile_json: "{not valid}".to_string(),
-            source: None,
-        };
-        store.set_provider_profile(&input).await.unwrap();
+        // Insert invalid JSON directly via SQL (bypassing set_provider_profile validation)
+        sqlx::query(
+            "INSERT INTO provider_profiles (slug, profile_json, source, created_at, updated_at) VALUES (?, ?, NULL, ?, ?)",
+        )
+        .bind("bad-profile")
+        .bind("{not valid}")
+        .bind("2026-01-01T00:00:00Z")
+        .bind("2026-01-01T00:00:00Z")
+        .execute(store.pool())
+        .await
+        .unwrap();
 
         let registry = build_effective_registry(&store).await.unwrap();
         // Built-ins should still be present

--- a/src/provider_profile/store.rs
+++ b/src/provider_profile/store.rs
@@ -1,0 +1,121 @@
+//! Provider profile store boundary and ConfigStore-backed implementation.
+//!
+//! Provides import/export of provider profile JSON through the core config
+//! store. The trait mirrors the pattern used by `ProviderCredentialStore`:
+//! `iron-core` defines the boundary, clients provide concrete implementations.
+
+use crate::config::{ConfigError, ConfigStore, ProviderProfileInput};
+use async_trait::async_trait;
+
+/// Async boundary for provider profile storage.
+///
+/// Implementations are provided by the core config store. Clients that do not
+/// configure durable storage can use built-in-only provider behavior without
+/// implementing this trait.
+#[async_trait]
+pub trait ProfileStore: Send + Sync {
+    /// Get a stored provider profile by slug, if any.
+    async fn get(&self, slug: &str) -> Option<String>;
+
+    /// Store or replace a provider profile payload by slug.
+    async fn set(&self, slug: &str, profile_json: &str, source: Option<&str>);
+
+    /// Remove a stored provider profile by slug.
+    async fn remove(&self, slug: &str);
+
+    /// List all stored provider profile slugs.
+    async fn list_slugs(&self) -> Vec<String>;
+}
+
+/// ConfigStore-backed provider profile store.
+///
+/// Wraps a [`ConfigStore`] to provide the [`ProfileStore`] boundary. Profile
+/// payloads are validated before persistence.
+pub struct DurableProfileStore {
+    store: ConfigStore,
+}
+
+impl DurableProfileStore {
+    /// Create a new durable profile store from a [`ConfigStore`].
+    pub fn new(store: ConfigStore) -> Self {
+        Self { store }
+    }
+}
+
+#[async_trait]
+impl ProfileStore for DurableProfileStore {
+    async fn get(&self, slug: &str) -> Option<String> {
+        match self.store.get_provider_profile(slug).await {
+            Ok(Some(record)) => Some(record.profile_json),
+            Ok(None) => None,
+            Err(e) => {
+                tracing::warn!(slug = %slug, error = %e, "Durable profile store get failed");
+                None
+            }
+        }
+    }
+
+    async fn set(&self, slug: &str, profile_json: &str, source: Option<&str>) {
+        let input = ProviderProfileInput {
+            slug: slug.to_string(),
+            profile_json: profile_json.to_string(),
+            source: source.map(|s| s.to_string()),
+        };
+        if let Err(e) = self.store.set_provider_profile(&input).await {
+            tracing::warn!(slug = %slug, error = %e, "Durable profile store set failed");
+        }
+    }
+
+    async fn remove(&self, slug: &str) {
+        if let Err(e) = self.store.delete_provider_profile(slug).await {
+            tracing::warn!(slug = %slug, error = %e, "Durable profile store remove failed");
+        }
+    }
+
+    async fn list_slugs(&self) -> Vec<String> {
+        match self.store.list_provider_profiles().await {
+            Ok(records) => records.into_iter().map(|r| r.slug).collect(),
+            Err(e) => {
+                tracing::warn!(error = %e, "Durable profile store list_slugs failed");
+                Vec::new()
+            }
+        }
+    }
+}
+
+/// Import a provider profile from JSON into the config store.
+///
+/// Validates the payload (including rejecting credential secret material),
+/// deserializes it to extract the slug, and persists the validated JSON.
+///
+/// Returns the slug of the imported profile on success.
+pub async fn import_provider_profile(
+    store: &ConfigStore,
+    json: &str,
+    source: Option<&str>,
+) -> Result<String, ConfigError> {
+    let profile = super::validation::validate_provider_profile(json)?;
+    let slug = profile.slug.clone();
+    let input = ProviderProfileInput {
+        slug: slug.clone(),
+        profile_json: serde_json::to_string(&profile)
+            .map_err(|e| ConfigError::Serialization(e.to_string()))?,
+        source: source.map(|s| s.to_string()),
+    };
+    store.set_provider_profile(&input).await?;
+    Ok(slug)
+}
+
+/// Export a persisted provider profile as JSON by slug.
+///
+/// Returns `None` if no profile is stored for the slug. The exported JSON
+/// contains only non-secret provider profile metadata.
+pub async fn export_provider_profile(
+    store: &ConfigStore,
+    slug: &str,
+) -> Result<Option<String>, ConfigError> {
+    match store.get_provider_profile(slug).await? {
+        Some(record) => Ok(Some(record.profile_json)),
+        None => Ok(None),
+    }
+}

--- a/src/provider_profile/validation.rs
+++ b/src/provider_profile/validation.rs
@@ -1,0 +1,136 @@
+//! Validation for provider profile payloads before persistence.
+//!
+//! Provider profile records must contain only non-secret provider protocol
+//! metadata. This module deserializes raw JSON into a [`ProviderProfile`]
+//! and rejects payloads that contain credential secret material.
+
+use crate::config::ConfigError;
+use iron_providers::ProviderProfile;
+
+/// Field names that indicate credential secret material.
+///
+/// If any of these appear as top-level keys in the JSON payload, the profile
+/// is rejected. [`ProviderProfile`] itself does not have fields for these,
+/// but callers may supply extra keys in the raw JSON that serde ignores.
+///
+/// Note: `credential_auth` is legitimate provider metadata (which credential
+/// *kinds* are supported), not secret material, and is not forbidden.
+const FORBIDDEN_SECRET_FIELDS: &[&str] = &[
+    "api_key",
+    "access_token",
+    "refresh_token",
+    "id_token",
+    "password",
+    "secret",
+];
+
+/// Deserialize and validate a provider profile JSON payload.
+///
+/// Returns the deserialized [`ProviderProfile`] on success, or a
+/// [`ConfigError::Validation`] if the payload is malformed or contains
+/// credential secret material.
+pub fn validate_provider_profile(json: &str) -> Result<ProviderProfile, ConfigError> {
+    // First, check for forbidden secret fields before deserialization.
+    let value: serde_json::Value =
+        serde_json::from_str(json).map_err(|e| ConfigError::Deserialization(e.to_string()))?;
+
+    if let serde_json::Value::Object(ref map) = value {
+        for key in map.keys() {
+            let lower = key.to_lowercase();
+            if FORBIDDEN_SECRET_FIELDS.iter().any(|f| lower.contains(f)) {
+                return Err(ConfigError::Validation(format!(
+                    "Provider profile payload must not contain field '{}' (credential secret material is not allowed)",
+                    key
+                )));
+            }
+        }
+    }
+
+    // Deserialize into ProviderProfile to validate structure.
+    let profile: ProviderProfile = serde_json::from_value(value).map_err(|e| {
+        ConfigError::Deserialization(format!("Failed to deserialize provider profile: {}", e))
+    })?;
+
+    // Slug must be non-empty.
+    if profile.slug.trim().is_empty() {
+        return Err(ConfigError::Validation(
+            "Provider profile slug must not be empty".to_string(),
+        ));
+    }
+
+    // Base URL must be non-empty.
+    if profile.base_url.trim().is_empty() {
+        return Err(ConfigError::Validation(
+            "Provider profile base_url must not be empty".to_string(),
+        ));
+    }
+
+    Ok(profile)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use iron_providers::{ApiFamily, ProviderProfile};
+
+    #[test]
+    fn valid_profile_passes_validation() {
+        let profile = ProviderProfile::new(
+            "my-provider",
+            ApiFamily::Completions,
+            "https://api.example.com/v1",
+        );
+        let json = serde_json::to_string(&profile).unwrap();
+        let validated = validate_provider_profile(&json).unwrap();
+        assert_eq!(validated.slug, "my-provider");
+    }
+
+    #[test]
+    fn profile_with_api_key_field_rejected() {
+        let json = r#"{"slug":"test","family":"Completions","base_url":"https://example.com","credential_auth":[],"default_headers":{},"purpose":"General","quirks":{},"api_key":"sk-secret"}"#;
+        let result = validate_provider_profile(json);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(matches!(err, ConfigError::Validation(_)));
+    }
+
+    #[test]
+    fn profile_with_access_token_rejected() {
+        let json = r#"{"slug":"test","family":"Completions","base_url":"https://example.com","credential_auth":[],"default_headers":{},"purpose":"General","quirks":{},"access_token":"tok-xyz"}"#;
+        let result = validate_provider_profile(json);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn malformed_json_rejected() {
+        let result = validate_provider_profile("{not valid json}");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn empty_slug_rejected() {
+        let json = r#"{"slug":"","family":"Completions","base_url":"https://example.com","credential_auth":[],"default_headers":{},"purpose":"General","quirks":{}}"#;
+        let result = validate_provider_profile(json);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn empty_base_url_rejected() {
+        let json = r#"{"slug":"test","family":"Completions","base_url":"","credential_auth":[],"default_headers":{},"purpose":"General","quirks":{}}"#;
+        let result = validate_provider_profile(json);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn profile_with_provider_guidance_passes() {
+        let profile =
+            ProviderProfile::new("custom", ApiFamily::Messages, "https://api.example.com")
+                .with_provider_guidance("Use this provider carefully.");
+        let json = serde_json::to_string(&profile).unwrap();
+        let validated = validate_provider_profile(&json).unwrap();
+        assert_eq!(
+            validated.provider_guidance.as_deref(),
+            Some("Use this provider carefully.")
+        );
+    }
+}

--- a/src/request_builder.rs
+++ b/src/request_builder.rs
@@ -22,6 +22,10 @@ pub struct EffectiveToolRequestContext<'a> {
     /// Selected profile identity prompt for the executing agent profile.
     /// When present and non-empty, this is rendered in `## 1. Identity`.
     pub profile_identity: Option<&'a str>,
+    /// Effective provider guidance resolved from the effective provider
+    /// profile. When present, this overrides the built-in registry lookup
+    /// for `## 7. Provider-Specific Guidance`.
+    pub effective_provider_guidance: Option<&'a str>,
 }
 
 struct ComposedInstructionInputs<'a> {
@@ -32,6 +36,7 @@ struct ComposedInstructionInputs<'a> {
     context_pressure: crate::context::ContextPressure,
     workspace_roots: Option<&'a [std::path::PathBuf]>,
     profile_identity: Option<&'a str>,
+    effective_provider_guidance: Option<&'a str>,
 }
 
 /// Build an inference request using an effective tool view.
@@ -86,6 +91,7 @@ pub fn build_inference_request_with_effective_tools(
             context_pressure: context.context_pressure,
             workspace_roots: context.workspace_roots,
             profile_identity: context.profile_identity,
+            effective_provider_guidance: context.effective_provider_guidance,
         },
     );
     if !composed.is_empty() {
@@ -114,6 +120,7 @@ pub fn build_inference_request(
             workspace_roots: None,
             effective_model: None,
             profile_identity: None,
+            effective_provider_guidance: None,
         },
         tool_registry,
     )
@@ -139,6 +146,7 @@ pub fn build_inference_request_with_context(
             workspace_roots: None,
             effective_model: None,
             profile_identity: None,
+            effective_provider_guidance: None,
         },
         tool_registry,
     )
@@ -164,6 +172,7 @@ pub fn build_inference_request_with_repo(
             workspace_roots: None,
             effective_model: None,
             profile_identity: None,
+            effective_provider_guidance: None,
         },
         tool_registry,
     )
@@ -215,6 +224,7 @@ pub fn build_inference_request_with_context_and_repo(
             context_pressure: context.context_pressure,
             workspace_roots: context.workspace_roots,
             profile_identity: context.profile_identity,
+            effective_provider_guidance: context.effective_provider_guidance,
         },
     );
     if !composed.is_empty() {
@@ -254,7 +264,7 @@ fn build_composed_instructions(config: &Config, inputs: ComposedInstructionInput
         inputs.python_exec_available,
     );
 
-    let provider_guidance = resolve_provider_guidance(config);
+    let provider_guidance = resolve_provider_guidance(config, inputs.effective_provider_guidance);
 
     crate::prompt::SystemPromptRenderer::render(&crate::prompt::SystemPromptInputs {
         baseline,
@@ -272,10 +282,16 @@ fn build_composed_instructions(config: &Config, inputs: ComposedInstructionInput
     })
 }
 
-/// Resolve provider-specific guidance from `iron-providers` when a provider name
-/// is configured, falling back to the manually set `provider_guidance` in
-/// `PromptCompositionConfig`.
-fn resolve_provider_guidance(config: &Config) -> Option<String> {
+/// Resolve provider-specific guidance.
+///
+/// When `effective_guidance` is provided (from the effective provider
+/// registry), it takes precedence. Otherwise falls back to the built-in
+/// registry lookup by provider name, then to the manually set
+/// `provider_guidance` in `PromptCompositionConfig`.
+fn resolve_provider_guidance(config: &Config, effective_guidance: Option<&str>) -> Option<String> {
+    if let Some(guidance) = effective_guidance {
+        return Some(guidance.to_string());
+    }
     if let Some(ref name) = config.provider_name {
         let registry = ProviderRegistry::default();
         match registry.system_prompt_fragment(name) {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -76,6 +76,9 @@ struct RuntimeInner {
     model_capability_registry: RwLock<crate::context::model_switch::ModelCapabilityRegistry>,
     profile_registry: RwLock<Option<Arc<RwLock<ProfileRegistry>>>>,
     stored_prompt_registry: RwLock<Option<Arc<RwLock<StoredPromptRegistry>>>>,
+    /// Effective provider registry: built-ins plus any persisted custom/override
+    /// provider profiles loaded from the config store.
+    provider_registry: RwLock<iron_providers::ProviderRegistry>,
 }
 
 /// Registry of named agent profiles available for delegation and session creation.
@@ -257,6 +260,7 @@ impl IronRuntime {
             ),
             profile_registry: RwLock::new(None),
             stored_prompt_registry: RwLock::new(None),
+            provider_registry: RwLock::new(iron_providers::ProviderRegistry::default()),
         };
 
         let this = Self {
@@ -374,6 +378,7 @@ impl IronRuntime {
             ),
             profile_registry: RwLock::new(None),
             stored_prompt_registry: RwLock::new(None),
+            provider_registry: RwLock::new(iron_providers::ProviderRegistry::default()),
         };
 
         let this = Self {
@@ -516,6 +521,56 @@ impl IronRuntime {
         self.inner.stored_prompt_registry.read().clone()
     }
 
+    /// Load persisted provider profiles from the config store into the runtime's
+    /// effective provider registry.
+    ///
+    /// Built-in provider profiles are preserved; persisted profiles with the same
+    /// slug override built-ins, and persisted profiles with new slugs are added.
+    /// Credential resolver support maps are updated to reflect any custom/override
+    /// profile credential auth metadata.
+    pub async fn load_provider_profiles(
+        &self,
+        store: &crate::config::ConfigStore,
+    ) -> Result<(), crate::config::ConfigError> {
+        let records = store.list_provider_profiles().await?;
+
+        // Build the effective registry from built-ins plus persisted profiles.
+        let registry = crate::provider_profile::build_effective_registry(store).await?;
+        *self.inner.provider_registry.write() = registry;
+
+        // Update the credential resolver's support map with persisted profiles.
+        if let Some(ref resolver) = self.inner.resolver {
+            let profiles: Vec<iron_providers::ProviderProfile> = records
+                .iter()
+                .filter_map(|r| serde_json::from_str(&r.profile_json).ok())
+                .collect();
+            resolver.merge_support_from_profiles(&profiles);
+        }
+
+        Ok(())
+    }
+
+    /// Resolve provider-specific guidance for the configured provider name
+    /// from the effective provider registry.
+    ///
+    /// Returns `None` if no provider name is configured or the provider is
+    /// unknown to the effective registry.
+    pub(crate) fn resolve_effective_provider_guidance(&self) -> Option<String> {
+        let name = self.inner.config.provider_name.as_ref()?;
+        let registry = self.inner.provider_registry.read();
+        match registry.system_prompt_fragment(name) {
+            Ok(fragment) => Some(fragment.to_string()),
+            Err(_) => None,
+        }
+    }
+
+    /// Borrow the effective provider registry (read guard).
+    pub(crate) fn provider_registry(
+        &self,
+    ) -> parking_lot::RwLockReadGuard<'_, iron_providers::ProviderRegistry> {
+        self.inner.provider_registry.read()
+    }
+
     /// Borrow the validated runtime configuration.
     pub fn config(&self) -> &Config {
         &self.inner.config
@@ -543,7 +598,7 @@ impl IronRuntime {
         let runtime_config =
             iron_providers::RuntimeConfig::from_credential(resolved.provider_credential);
 
-        let registry = iron_providers::ProviderRegistry::default();
+        let registry = self.provider_registry();
         let provider = registry
             .get(context.provider_slug.as_str(), runtime_config)
             .map_err(|_e| ProviderAuthError::UnsupportedCredential {
@@ -665,7 +720,7 @@ impl IronRuntime {
         let runtime_config =
             iron_providers::RuntimeConfig::from_credential(resolved.provider_credential);
 
-        let registry = iron_providers::ProviderRegistry::default();
+        let registry = self.provider_registry();
         let provider = registry
             .get(context.provider_slug.as_str(), runtime_config)
             .map_err(|_e| ProviderAuthError::UnsupportedCredential {

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -2,7 +2,7 @@
 
 use crate::connection::{ClientChannel, IronConnection};
 use agent_client_protocol as acp;
-use agent_client_protocol::schema as acp_schema;
+use agent_client_protocol::schema::v1 as acp_schema;
 use std::future::Future;
 use std::pin::Pin;
 use std::rc::Rc;

--- a/tests/config_store_tests.rs
+++ b/tests/config_store_tests.rs
@@ -1016,7 +1016,7 @@ async fn test_migrations_v1_to_v2() {
         .fetch_one(&mut *conn)
         .await
         .unwrap();
-    assert_eq!(version, 5);
+    assert_eq!(version, 6);
 
     // Verify v2/v3 tables exist by using the new APIs
     store
@@ -1368,7 +1368,7 @@ async fn test_migrations_v2_to_v3_custom_models_columns() {
         .fetch_one(&mut *conn)
         .await
         .unwrap();
-    assert_eq!(version, 5);
+    assert_eq!(version, 6);
 
     // Verify the new columns have correct defaults for existing rows
     let retrieved = store

--- a/tests/interop_tests.rs
+++ b/tests/interop_tests.rs
@@ -10,7 +10,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::rc::Rc;
 
-use agent_client_protocol::schema as acp;
+use agent_client_protocol::schema::{v1 as acp, ProtocolVersion};
 
 #[derive(Clone, Copy)]
 struct TestProvider;
@@ -88,7 +88,7 @@ async fn setup_transport() -> (
 
     let _ = transport
         .client()
-        .initialize(acp::InitializeRequest::new(acp::ProtocolVersion::LATEST))
+        .initialize(acp::InitializeRequest::new(ProtocolVersion::LATEST))
         .await
         .unwrap();
 
@@ -280,12 +280,12 @@ fn inprocess_cross_connection_prompt_rejected() {
 
         let _ = transport1
             .client()
-            .initialize(acp::InitializeRequest::new(acp::ProtocolVersion::LATEST))
+            .initialize(acp::InitializeRequest::new(ProtocolVersion::LATEST))
             .await
             .unwrap();
         let _ = transport2
             .client()
-            .initialize(acp::InitializeRequest::new(acp::ProtocolVersion::LATEST))
+            .initialize(acp::InitializeRequest::new(ProtocolVersion::LATEST))
             .await
             .unwrap();
 
@@ -330,12 +330,12 @@ fn inprocess_cross_connection_close_session_rejected() {
 
         let _ = transport1
             .client()
-            .initialize(acp::InitializeRequest::new(acp::ProtocolVersion::LATEST))
+            .initialize(acp::InitializeRequest::new(ProtocolVersion::LATEST))
             .await
             .unwrap();
         let _ = transport2
             .client()
-            .initialize(acp::InitializeRequest::new(acp::ProtocolVersion::LATEST))
+            .initialize(acp::InitializeRequest::new(ProtocolVersion::LATEST))
             .await
             .unwrap();
 

--- a/tests/provider_profile_tests.rs
+++ b/tests/provider_profile_tests.rs
@@ -1,0 +1,621 @@
+use iron_core::config::{ConfigStore, OpenOptions, ProviderProfileInput};
+use iron_core::provider_profile::{
+    build_effective_registry, export_provider_profile, import_provider_profile,
+    validate_provider_profile,
+};
+use iron_providers::{ApiFamily, AuthStrategy, ProviderProfile};
+use serde_json::json;
+
+/// Helper to create a test cipher for file-based stores.
+fn test_cipher() -> std::sync::Arc<dyn iron_core::config::crypto::CredentialCipher> {
+    let key = iron_core::config::crypto::XChaCha20Poly1305Cipher::generate_key();
+    std::sync::Arc::new(iron_core::config::crypto::XChaCha20Poly1305Cipher::new(
+        &key,
+    ))
+}
+
+/// Helper to open a file-based config store for testing (bypasses OS keyring).
+async fn open_test_store(path: impl AsRef<std::path::Path>) -> ConfigStore {
+    let options = OpenOptions {
+        cipher: Some(test_cipher()),
+        busy_timeout: None,
+    };
+    ConfigStore::open_at_with_options(path, options)
+        .await
+        .unwrap()
+}
+
+// ============================================================================
+// Task 1.5: Config-store provider profile CRUD tests
+// ============================================================================
+
+#[tokio::test]
+async fn provider_profile_roundtrip() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+
+    let profile = ProviderProfile::new(
+        "my-provider",
+        ApiFamily::Completions,
+        "https://api.example.com/v1",
+    );
+    let json = serde_json::to_string(&profile).unwrap();
+
+    store
+        .set_provider_profile(&ProviderProfileInput {
+            slug: "my-provider".to_string(),
+            profile_json: json.clone(),
+            source: Some("test".to_string()),
+        })
+        .await
+        .unwrap();
+
+    let retrieved = store.get_provider_profile("my-provider").await.unwrap();
+    assert!(retrieved.is_some());
+    let retrieved = retrieved.unwrap();
+    assert_eq!(retrieved.slug, "my-provider");
+    assert_eq!(retrieved.profile_json, json);
+    assert_eq!(retrieved.source.as_deref(), Some("test"));
+}
+
+#[tokio::test]
+async fn provider_profile_update_replaces_payload() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+
+    let profile1 = ProviderProfile::new(
+        "test-provider",
+        ApiFamily::Completions,
+        "https://v1.example.com",
+    );
+    let profile2 = ProviderProfile::new(
+        "test-provider",
+        ApiFamily::Messages,
+        "https://v2.example.com",
+    );
+
+    store
+        .set_provider_profile(&ProviderProfileInput {
+            slug: "test-provider".to_string(),
+            profile_json: serde_json::to_string(&profile1).unwrap(),
+            source: None,
+        })
+        .await
+        .unwrap();
+
+    store
+        .set_provider_profile(&ProviderProfileInput {
+            slug: "test-provider".to_string(),
+            profile_json: serde_json::to_string(&profile2).unwrap(),
+            source: None,
+        })
+        .await
+        .unwrap();
+
+    let retrieved = store
+        .get_provider_profile("test-provider")
+        .await
+        .unwrap()
+        .unwrap();
+    let parsed: ProviderProfile = serde_json::from_str(&retrieved.profile_json).unwrap();
+    assert_eq!(parsed.base_url, "https://v2.example.com");
+    assert_eq!(parsed.family, ApiFamily::Messages);
+}
+
+#[tokio::test]
+async fn provider_profile_list_is_deterministic() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+
+    for slug in &["zeta", "alpha", "mid"] {
+        let profile = ProviderProfile::new(*slug, ApiFamily::Completions, "https://example.com");
+        store
+            .set_provider_profile(&ProviderProfileInput {
+                slug: slug.to_string(),
+                profile_json: serde_json::to_string(&profile).unwrap(),
+                source: None,
+            })
+            .await
+            .unwrap();
+    }
+
+    let list = store.list_provider_profiles().await.unwrap();
+    let slugs: Vec<&str> = list.iter().map(|r| r.slug.as_str()).collect();
+    assert_eq!(slugs, vec!["alpha", "mid", "zeta"]);
+}
+
+#[tokio::test]
+async fn provider_profile_delete() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+
+    let profile = ProviderProfile::new("to-delete", ApiFamily::Completions, "https://example.com");
+    store
+        .set_provider_profile(&ProviderProfileInput {
+            slug: "to-delete".to_string(),
+            profile_json: serde_json::to_string(&profile).unwrap(),
+            source: None,
+        })
+        .await
+        .unwrap();
+
+    assert!(store
+        .get_provider_profile("to-delete")
+        .await
+        .unwrap()
+        .is_some());
+
+    store.delete_provider_profile("to-delete").await.unwrap();
+
+    assert!(store
+        .get_provider_profile("to-delete")
+        .await
+        .unwrap()
+        .is_none());
+}
+
+#[tokio::test]
+async fn provider_profile_empty_slug_rejected() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+
+    let result = store
+        .set_provider_profile(&ProviderProfileInput {
+            slug: "".to_string(),
+            profile_json: "{}".to_string(),
+            source: None,
+        })
+        .await;
+
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn provider_profile_migration_preserves_existing_data() {
+    let db_path = std::env::temp_dir().join(format!(
+        "iron-core-provider-profile-migration-{}.db",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    // Write an older schema (v1) directly
+    let pool = sqlx::sqlite::SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect_with(
+            sqlx::sqlite::SqliteConnectOptions::new()
+                .filename(&db_path)
+                .create_if_missing(true),
+        )
+        .await
+        .unwrap();
+
+    sqlx::raw_sql(
+        r#"
+        CREATE TABLE schema_version (id INTEGER PRIMARY KEY CHECK (id = 1), version INTEGER NOT NULL);
+        CREATE TABLE profiles (id TEXT PRIMARY KEY, schema_version INTEGER NOT NULL, payload TEXT NOT NULL, created_at TEXT NOT NULL, updated_at TEXT NOT NULL);
+        INSERT INTO schema_version (id, version) VALUES (1, 1);
+        INSERT INTO profiles (id, schema_version, payload, created_at, updated_at)
+        VALUES ('legacy', 1, '{"name":"Legacy"}', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+        "#,
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+    drop(pool);
+
+    let store = open_test_store(&db_path).await;
+
+    // Legacy profile should be preserved
+    let legacy = store.get_profile("legacy").await.unwrap().unwrap();
+    assert_eq!(legacy.payload, json!({"name": "Legacy"}));
+
+    // New provider_profiles table should be available
+    let profile = ProviderProfile::new(
+        "post-migration",
+        ApiFamily::Completions,
+        "https://example.com",
+    );
+    store
+        .set_provider_profile(&ProviderProfileInput {
+            slug: "post-migration".to_string(),
+            profile_json: serde_json::to_string(&profile).unwrap(),
+            source: None,
+        })
+        .await
+        .unwrap();
+
+    assert!(store
+        .get_provider_profile("post-migration")
+        .await
+        .unwrap()
+        .is_some());
+
+    let _ = std::fs::remove_file(&db_path);
+}
+
+// ============================================================================
+// Task 2.5: Import/export/validation tests
+// ============================================================================
+
+#[tokio::test]
+async fn import_valid_provider_profile() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+
+    let profile = ProviderProfile::new("imported", ApiFamily::Messages, "https://api.imported.com")
+        .with_provider_guidance("Custom guidance for imported provider.");
+    let json = serde_json::to_string(&profile).unwrap();
+
+    let slug = import_provider_profile(&store, &json, Some("test-import"))
+        .await
+        .unwrap();
+    assert_eq!(slug, "imported");
+
+    let record = store
+        .get_provider_profile("imported")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(record.source.as_deref(), Some("test-import"));
+}
+
+#[tokio::test]
+async fn import_invalid_json_rejected() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+
+    let result = import_provider_profile(&store, "{not valid json}", None).await;
+    assert!(result.is_err());
+    assert!(store.list_provider_profiles().await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn import_credential_material_rejected() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+
+    let json = r#"{
+        "slug": "evil",
+        "family": "Completions",
+        "base_url": "https://evil.example.com",
+        "credential_auth": [],
+        "default_headers": {},
+        "purpose": "General",
+        "quirks": {},
+        "api_key": "sk-secret-key"
+    }"#;
+
+    let result = import_provider_profile(&store, json, None).await;
+    assert!(result.is_err());
+    assert!(store.list_provider_profiles().await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn import_override_builtin() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+
+    let profile = ProviderProfile::new(
+        "openai",
+        ApiFamily::Messages,
+        "https://custom.openai.example",
+    )
+    .with_provider_guidance("Custom override guidance.");
+    let json = serde_json::to_string(&profile).unwrap();
+
+    let slug = import_provider_profile(&store, &json, None).await.unwrap();
+    assert_eq!(slug, "openai");
+
+    let registry = build_effective_registry(&store).await.unwrap();
+    let fragment = registry.system_prompt_fragment("openai").unwrap();
+    assert_eq!(fragment, "Custom override guidance.");
+}
+
+#[tokio::test]
+async fn import_custom_profile_resolved_by_effective_registry() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+
+    let profile = ProviderProfile::new(
+        "acme-corp",
+        ApiFamily::Completions,
+        "https://api.acme.corp/v1",
+    )
+    .with_provider_guidance("ACME Corp specific instructions.");
+    let json = serde_json::to_string(&profile).unwrap();
+    import_provider_profile(&store, &json, None).await.unwrap();
+
+    let registry = build_effective_registry(&store).await.unwrap();
+    assert!(registry.slugs().contains(&"acme-corp"));
+}
+
+#[tokio::test]
+async fn export_profile_roundtrip() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+
+    let profile = ProviderProfile::new(
+        "export-test",
+        ApiFamily::Completions,
+        "https://export.example.com",
+    );
+    let json = serde_json::to_string(&profile).unwrap();
+    import_provider_profile(&store, &json, None).await.unwrap();
+
+    let exported = export_provider_profile(&store, "export-test")
+        .await
+        .unwrap();
+    assert!(exported.is_some());
+
+    let exported_json = exported.unwrap();
+    let parsed: ProviderProfile = serde_json::from_str(&exported_json).unwrap();
+    assert_eq!(parsed.slug, "export-test");
+    assert_eq!(parsed.base_url, "https://export.example.com");
+}
+
+#[tokio::test]
+async fn export_nonexistent_returns_none() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+    let result = export_provider_profile(&store, "nonexistent")
+        .await
+        .unwrap();
+    assert!(result.is_none());
+}
+
+#[test]
+fn validate_profile_rejects_empty_slug() {
+    let json = r#"{"slug":"","family":"Completions","base_url":"https://example.com","credential_auth":[],"default_headers":{},"purpose":"General","quirks":{}}"#;
+    assert!(validate_provider_profile(json).is_err());
+}
+
+#[test]
+fn validate_profile_accepts_credential_auth_metadata() {
+    let profile = ProviderProfile::new("test", ApiFamily::Completions, "https://example.com")
+        .with_auth(AuthStrategy::BearerToken);
+    let json = serde_json::to_string(&profile).unwrap();
+    let validated = validate_provider_profile(&json).unwrap();
+    assert!(validated.supports_credential(iron_providers::CredentialKind::ApiKey));
+}
+
+// ============================================================================
+// Task 3.5: Effective registry tests
+// ============================================================================
+
+#[tokio::test]
+async fn effective_registry_empty_store_preserves_builtins() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+    let registry = build_effective_registry(&store).await.unwrap();
+    assert!(registry.slugs().contains(&"openai"));
+    assert!(registry.slugs().contains(&"anthropic"));
+}
+
+#[tokio::test]
+async fn effective_registry_custom_added() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+    let profile = ProviderProfile::new(
+        "custom-slug",
+        ApiFamily::Completions,
+        "https://custom.example.com",
+    );
+    let json = serde_json::to_string(&profile).unwrap();
+    import_provider_profile(&store, &json, None).await.unwrap();
+
+    let registry = build_effective_registry(&store).await.unwrap();
+    assert!(registry.slugs().contains(&"custom-slug"));
+}
+
+#[tokio::test]
+async fn effective_registry_override_replaces_builtin_guidance() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+    let profile = ProviderProfile::new("openai", ApiFamily::Responses, "https://api.openai.com/v1")
+        .with_provider_guidance("Override guidance for OpenAI.");
+    let json = serde_json::to_string(&profile).unwrap();
+    import_provider_profile(&store, &json, None).await.unwrap();
+
+    let registry = build_effective_registry(&store).await.unwrap();
+    let fragment = registry.system_prompt_fragment("openai").unwrap();
+    assert_eq!(fragment, "Override guidance for OpenAI.");
+}
+
+#[tokio::test]
+async fn effective_registry_other_builtins_preserved_after_override() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+    let profile = ProviderProfile::new(
+        "openai",
+        ApiFamily::Responses,
+        "https://custom.openai.example",
+    );
+    let json = serde_json::to_string(&profile).unwrap();
+    import_provider_profile(&store, &json, None).await.unwrap();
+
+    let registry = build_effective_registry(&store).await.unwrap();
+    assert!(registry.slugs().contains(&"openai"));
+    assert!(registry.slugs().contains(&"anthropic"));
+    assert!(registry.slugs().contains(&"kimi"));
+}
+
+#[tokio::test]
+async fn effective_registry_invalid_profile_skipped() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+    store
+        .set_provider_profile(&ProviderProfileInput {
+            slug: "bad".to_string(),
+            profile_json: "{invalid}".to_string(),
+            source: None,
+        })
+        .await
+        .unwrap();
+
+    let registry = build_effective_registry(&store).await.unwrap();
+    assert!(!registry.slugs().contains(&"bad"));
+    assert!(registry.slugs().contains(&"openai"));
+}
+
+// ============================================================================
+// Task 4.5: Known provider slug discovery tests
+// ============================================================================
+
+#[tokio::test]
+async fn known_provider_slugs_includes_persisted_profiles() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+
+    let profile = ProviderProfile::new(
+        "custom-provider",
+        ApiFamily::Completions,
+        "https://custom.example.com",
+    );
+    import_provider_profile(&store, &serde_json::to_string(&profile).unwrap(), None)
+        .await
+        .unwrap();
+
+    let slugs = store.known_provider_slugs().await.unwrap();
+    assert!(slugs.contains("custom-provider"));
+    assert!(slugs.contains("openai"));
+}
+
+// ============================================================================
+// Task 5.4: Credential support from profile metadata tests
+// ============================================================================
+
+#[tokio::test]
+async fn credential_support_derived_from_custom_profile() {
+    use iron_core::provider_credential::store::InMemoryCredentialStore;
+    use iron_core::provider_credential::CredentialResolver;
+
+    let store = InMemoryCredentialStore::new();
+    let resolver = CredentialResolver::new(
+        std::sync::Arc::new(store) as iron_core::provider_credential::DynCredentialStore
+    );
+
+    // Custom profile with only API-key support
+    let profiles = vec![
+        ProviderProfile::new(
+            "api-only",
+            ApiFamily::Completions,
+            "https://api.example.com",
+        )
+        .with_auth(AuthStrategy::BearerToken),
+        ProviderProfile::new(
+            "no-auth-provider",
+            ApiFamily::Completions,
+            "https://local.example.com",
+        )
+        .with_credential_auth(iron_providers::CredentialKind::NoAuth, AuthStrategy::NoAuth),
+    ];
+
+    resolver.merge_support_from_profiles(&profiles);
+
+    // Verify the resolver now has the updated support map
+    // We test this indirectly by checking that the resolver accepts the merge without error
+    // and that resolution behavior changes accordingly.
+    // The support_for method is private, so we verify via the resolver's resolve() path.
+}
+
+#[tokio::test]
+async fn credential_support_api_key_profile() {
+    use iron_core::provider_credential::domain::ProviderSlug;
+    use iron_core::provider_credential::store::InMemoryCredentialStore;
+    use iron_core::provider_credential::CredentialResolver;
+
+    let cred_store = std::sync::Arc::new(InMemoryCredentialStore::new())
+        as iron_core::provider_credential::DynCredentialStore;
+    let resolver = CredentialResolver::new(cred_store.clone());
+
+    let profiles = vec![ProviderProfile::new(
+        "custom-key",
+        ApiFamily::Completions,
+        "https://api.example.com",
+    )
+    .with_auth(AuthStrategy::BearerToken)];
+    resolver.merge_support_from_profiles(&profiles);
+
+    // API key should be accepted for a profile that supports it
+    let result = resolver
+        .resolve(
+            &iron_core::provider_credential::domain::ProviderPromptContext {
+                provider_slug: ProviderSlug::new("custom-key"),
+                model: "test-model".to_string(),
+                api_key: Some("sk-test".to_string()),
+            },
+            Some("sk-test".to_string()),
+        )
+        .await;
+
+    assert!(result.is_ok());
+}
+
+// ============================================================================
+// Task 5.5: Model catalog validation tests
+// ============================================================================
+
+#[tokio::test]
+async fn custom_model_validates_against_custom_provider_profile() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+
+    // First, import a custom provider profile
+    let profile = ProviderProfile::new(
+        "custom-ai",
+        ApiFamily::Completions,
+        "https://api.custom-ai.com",
+    );
+    import_provider_profile(&store, &serde_json::to_string(&profile).unwrap(), None)
+        .await
+        .unwrap();
+
+    // Then, try to add a custom model for that provider
+    let result = store
+        .set_custom_model(&iron_core::config::CustomModelInput {
+            provider_slug: "custom-ai".to_string(),
+            model_id: "custom-model-v1".to_string(),
+            display_name: "Custom Model V1".to_string(),
+            context_window: Some(128000),
+            output_limit: Some(4096),
+            supports_tool_calls: true,
+            supports_reasoning: false,
+            supports_vision: false,
+            supports_streaming: true,
+            reasoning_effort_values: vec![],
+            cost_input_per_million: Some(0.01),
+            cost_output_per_million: Some(0.03),
+        })
+        .await;
+
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn custom_model_rejects_unknown_provider_without_profile() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+
+    let result = store
+        .set_custom_model(&iron_core::config::CustomModelInput {
+            provider_slug: "completely-unknown".to_string(),
+            model_id: "test-model".to_string(),
+            display_name: "Test".to_string(),
+            context_window: None,
+            output_limit: None,
+            supports_tool_calls: true,
+            supports_reasoning: false,
+            supports_vision: false,
+            supports_streaming: true,
+            reasoning_effort_values: vec![],
+            cost_input_per_million: None,
+            cost_output_per_million: None,
+        })
+        .await;
+
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn custom_model_builtin_provider_still_valid() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+
+    let result = store
+        .set_custom_model(&iron_core::config::CustomModelInput {
+            provider_slug: "openai".to_string(),
+            model_id: "custom-gpt".to_string(),
+            display_name: "Custom GPT".to_string(),
+            context_window: None,
+            output_limit: None,
+            supports_tool_calls: true,
+            supports_reasoning: false,
+            supports_vision: false,
+            supports_streaming: true,
+            reasoning_effort_values: vec![],
+            cost_input_per_million: None,
+            cost_output_per_million: None,
+        })
+        .await;
+
+    assert!(result.is_ok());
+}

--- a/tests/provider_profile_tests.rs
+++ b/tests/provider_profile_tests.rs
@@ -426,14 +426,18 @@ async fn effective_registry_other_builtins_preserved_after_override() {
 #[tokio::test]
 async fn effective_registry_invalid_profile_skipped() {
     let store = ConfigStore::open_in_memory().await.unwrap();
-    store
-        .set_provider_profile(&ProviderProfileInput {
-            slug: "bad".to_string(),
-            profile_json: "{invalid}".to_string(),
-            source: None,
-        })
-        .await
-        .unwrap();
+
+    // Insert invalid JSON directly via SQL (bypassing set_provider_profile validation)
+    sqlx::query(
+        "INSERT INTO provider_profiles (slug, profile_json, source, created_at, updated_at) VALUES (?, ?, NULL, ?, ?)",
+    )
+    .bind("bad")
+    .bind("{invalid}")
+    .bind("2026-01-01T00:00:00Z")
+    .bind("2026-01-01T00:00:00Z")
+    .execute(store.pool())
+    .await
+    .unwrap();
 
     let registry = build_effective_registry(&store).await.unwrap();
     assert!(!registry.slugs().contains(&"bad"));
@@ -468,6 +472,7 @@ async fn known_provider_slugs_includes_persisted_profiles() {
 
 #[tokio::test]
 async fn credential_support_derived_from_custom_profile() {
+    use iron_core::provider_credential::domain::{ProviderPromptContext, ProviderSlug};
     use iron_core::provider_credential::store::InMemoryCredentialStore;
     use iron_core::provider_credential::CredentialResolver;
 
@@ -494,10 +499,18 @@ async fn credential_support_derived_from_custom_profile() {
 
     resolver.merge_support_from_profiles(&profiles);
 
-    // Verify the resolver now has the updated support map
-    // We test this indirectly by checking that the resolver accepts the merge without error
-    // and that resolution behavior changes accordingly.
-    // The support_for method is private, so we verify via the resolver's resolve() path.
+    // API-key profile: resolve with API key should succeed
+    let api_only = resolver
+        .resolve(
+            &ProviderPromptContext {
+                provider_slug: ProviderSlug::new("api-only"),
+                model: "test-model".to_string(),
+                api_key: Some("sk-test".to_string()),
+            },
+            Some("sk-test".to_string()),
+        )
+        .await;
+    assert!(api_only.is_ok());
 }
 
 #[tokio::test]

--- a/tests/transport_bench_tests.rs
+++ b/tests/transport_bench_tests.rs
@@ -9,7 +9,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::time::Instant;
 
-use agent_client_protocol::schema as acp;
+use agent_client_protocol::schema::{v1 as acp, ProtocolVersion};
 
 #[derive(Clone, Copy)]
 struct TestProvider;
@@ -69,7 +69,7 @@ async fn setup() -> InProcessTransport {
     tokio::task::spawn_local(agent_fut);
     let _ = transport
         .client()
-        .initialize(acp::InitializeRequest::new(acp::ProtocolVersion::LATEST))
+        .initialize(acp::InitializeRequest::new(ProtocolVersion::LATEST))
         .await
         .unwrap();
     transport
@@ -92,7 +92,7 @@ fn bench_initialize_round_trip() {
             let start = Instant::now();
             let _ = transport
                 .client()
-                .initialize(acp::InitializeRequest::new(acp::ProtocolVersion::LATEST))
+                .initialize(acp::InitializeRequest::new(ProtocolVersion::LATEST))
                 .await
                 .unwrap();
             durations.push(start.elapsed());


### PR DESCRIPTION
## Summary

- upgrade dependencies including iron-providers 0.2.12 with provider_guidance support
- add ConfigStore-backed provider profile storage, import/export, validation, and effective registry loading
- wire the effective provider registry into managed provider construction, provider guidance, credential support, and custom model provider validation
- sync and archive the store-backed-provider-profiles OpenSpec change

## Verification

- cargo fmt --check
- cargo clippy --locked --manifest-path Cargo.toml --all-targets --all-features -- -D warnings
- cargo test --locked --manifest-path Cargo.toml --all-features
- openspec validate store-backed-provider-profiles --strict
- openspec validate affected synced specs individually

Closes #79

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added durable provider-profile support (create/update/get/list/delete) with JSON import/export.
  * Effective provider registry now merges built-in profiles with persisted custom and override profiles.
  * Provider guidance and supported credential modes are now derived from the effective provider profile metadata.
  * Model/provider slug validation now respects provider slugs from persisted profiles.
  * Added APIs to load persisted provider profiles into runtime behavior.

* **Chores**
  * Raised minimum Rust version to 1.96 and updated dependency versions (including `keyring` pin).
  * Added a schema migration for the new `provider_profiles` storage.
  * Expanded automated test coverage for provider profiles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->