### PR TITLE
feat(cli): add headless automation task runner

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,10 @@ num-traits = { version = "0.2", optional = true }
 default = []
 embedded-python = ["monty", "num-bigint", "num-traits"]
 
+[[bin]]
+name = "agent-iron"
+path = "src/bin/agent_iron.rs"
+
 [dev-dependencies]
 tokio-test = "0.4"
 tempfile = "3"

--- a/openspec/changes/archive/2026-07-11-add-agent-iron-headless-cli/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-11-add-agent-iron-headless-cli/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-11

--- a/openspec/changes/archive/2026-07-11-add-agent-iron-headless-cli/design.md
+++ b/openspec/changes/archive/2026-07-11-add-agent-iron-headless-cli/design.md
@@ -1,0 +1,116 @@
+## Context
+
+`iron-core` currently persists typed stored prompts and agent profiles, runtime provider/model settings, provider profiles and credentials, MCP server definitions, and skill settings. Stored prompts may select a profile and are currently invoked through delegated child execution with an interactive parent. There is no durable automation-task record, root-oriented one-shot runner, or binary that reconstructs this state for unattended execution.
+
+Approval behavior is a critical boundary. `AutoApprove` bypasses per-tool permission requests for every tool visible after the profile filter is applied, while `Inherit` can expand as the runtime inventory changes. The no-op client channel is not a safety mechanism because it can answer permission requests. Headless execution must therefore validate policy before any model or tool work.
+
+WASM plugin inventory and auth state are runtime-local and are not represented in `RuntimeSettingsSnapshot` or ConfigStore. MCP servers and skill settings are persisted. The CLI can deterministically reconstruct the latter but cannot reconstruct plugins without broadening this change into plugin installation persistence.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Introduce a small durable automation identity suitable for GUI management and later scheduling.
+- Run an existing automation task non-interactively as a root session.
+- Reconstruct core-owned runtime configuration deterministically and fail closed on missing or interactive dependencies.
+- Make workspace, timeout, output, cancellation, and exit semantics suitable for cron and other automation callers.
+- Share task-resolution and prompt-composition logic between root and delegated execution where practical.
+
+**Non-Goals:**
+
+- CLI CRUD or interactive setup.
+- Scheduling, overlap prevention, persisted run history, retries, or semantic outcome evaluation.
+- Task-level profile/model/tool overrides, arbitrary prompts, or parameter substitution.
+- Adding web search or any other integration.
+- Persisting, discovering, installing, or loading WASM plugins.
+- Changing the security behavior of built-in tools, network policy, credentials, MCP servers, or skills.
+
+## Decisions
+
+### Model automation as a reference, not a configuration aggregate
+
+`AutomationTask` contains `id`, `name`, `stored_prompt_id`, `expected_outcome`, `created_at`, and `updated_at`. The name exists for GUI display. Instructions, skills, and the optional profile remain on `StoredPrompt`; provider/model, tool filters, and approval remain on `AgentProfile`.
+
+This avoids duplicated policy and lets multiple tasks reuse one prompt with distinct expected outcomes. A task-level profile override was rejected because it creates competing ownership for security-sensitive configuration.
+
+### Use a first-class relational task table
+
+ConfigStore will add a dedicated schema-versioned automation-task table and typed `set/get/list/delete_automation_task` APIs. Task writes require the referenced prompt to exist. Prompt deletion is blocked while referenced, returns the referencing task IDs, and never cascades.
+
+Encoding tasks as prompt or opaque schedule payloads was rejected because tasks have their own lifecycle and will become the target of future schedules. Allowing dangling references was rejected because it postpones a predictable configuration error until unattended execution.
+
+### Resolve live dependencies once per run
+
+At run start, a resolver loads the current task, prompt, profile, requested skills, effective tools, provider, model, and workspace into an immutable execution input. The expected outcome is appended to the model-visible user goal; profile identity remains in system prompt layers. Concurrent configuration edits affect only later runs.
+
+The resolver should be reusable by root CLI execution and delegated prompt invocation, while the execution mechanism remains distinct: CLI runs are root sessions and delegated calls remain child sessions.
+
+### Make the CLI run-only
+
+The command surface is:
+
+```text
+agent-iron run <task-id> \
+  [--config <path>] \
+  [--workspace <path>] \
+  --timeout <duration> \
+  [--format text|json] \
+  [--quiet]
+```
+
+Supported options may use corresponding `AGENTIRON_*` environment variables. Command line wins over environment. The task remains positional so cron definitions state exactly what they run. Configuration editing belongs in the GUI and typed core APIs, not the initial CLI.
+
+Workspace resolves from CLI, environment, then process current directory and must canonicalize to an existing directory. Timeout must resolve from CLI or environment and applies to the complete execution. There is deliberately no unbounded default.
+
+### Bootstrap only core-owned persisted configuration
+
+Startup opens and migrates ConfigStore, loads runtime settings and effective provider profiles, resolves credentials, registers built-ins, registers enabled MCP definitions, discovers skills under persisted trust settings and the resolved workspace, then loads profiles, prompts, and the task. Existing built-in network and filesystem protections remain in force.
+
+WASM plugins are excluded because no core-owned persisted inventory currently exists. The CLI does not scan directories or opportunistically install artifacts. A profile that explicitly allow-lists an absent plugin tool fails unavailable-tool preflight. Plugin support can be added after a separate change defines durable installation records and deterministic bootstrap.
+
+### Give RuntimeDefault a persisted headless meaning
+
+For the CLI, `RuntimeDefault` resolves the saved ConfigStore default provider/model through the effective provider profile and credential store. Missing, disabled, invalid, or unauthenticated defaults fail without selecting another provider or model.
+
+Injecting a dummy provider and treating it as the default was rejected because it makes unattended behavior dependent on construction details rather than saved configuration.
+
+### Treat profile approval and tools as the security boundary
+
+Headless preflight requires the resolved profile to be explicitly `AutoApprove`; `PerTool` fails and is never upgraded. `Allow`, `Deny`, and `Inherit` retain their existing meanings. `Inherit` explicitly trusts every tool in the current reconstructed inventory, while `Allow` provides a constrained option. Explicitly allow-listed but unavailable tools fail preflight.
+
+An omitted prompt profile follows existing default-profile resolution. Because the built-in default is interactive, it ordinarily fails headless preflight. This makes unattended privilege an intentional profile decision rather than an implicit CLI convenience.
+
+Interactive provider or integration authentication also fails. Existing credentials and supported automatic refresh are allowed, but the CLI never waits for browser, device-code, permission, or other client-mediated input.
+
+### Execute a root session with explicit terminal outcomes
+
+After resolution and preflight, the CLI creates a root session using the resolved execution input. It does not manufacture a parent session to reuse delegated machinery. A generated run ID and terminal status (`completed`, `failed`, `cancelled`, or `timed_out`) form an ephemeral `AutomationRun` result; run persistence is deferred.
+
+Timeout and signal handlers request cancellation. Timeout wins if it has already determined the terminal condition. Runtime completion means technical completion only; expected-outcome text is not independently evaluated.
+
+### Keep stdout automation-safe
+
+Text mode writes only final assistant text to stdout. JSON mode writes exactly one versioned terminal object containing run/task identity, status, output, expected outcome, resolved profile/provider/model/workspace, effective tools, timing, and structured error. Progress and warnings use stderr; quiet suppresses progress but not final or fatal output.
+
+Stable exit codes separate usage (`2`), config/reference (`3`), unsafe policy (`4`), provider/credential initialization (`5`), execution (`6`), cancellation (`7`), and timeout (`8`) from completion (`0`). Recoverable tool errors do not override a technically completed run.
+
+## Risks / Trade-offs
+
+- [An `AutoApprove + Inherit` profile gains newly registered tools] -> Document this as explicit trust in the current inventory, report effective tools in JSON, and support `Allow` for constrained profiles.
+- [Startup may partially initialize MCP servers before another dependency fails] -> Complete static reference and policy checks as early as possible, cancel initialized resources on failure, and emit a single terminal result.
+- [Timeout cancellation may not stop an external operation immediately] -> Mark the terminal result `timed_out`, request cooperative cancellation, bound cleanup where possible, and avoid reporting completion afterward.
+- [Local skill contents or MCP executables can change between runs] -> Snapshot the resolved run inventory at start and report identities; artifact pinning is outside this change.
+- [Blocking prompt deletion changes an existing API's behavior] -> Return a typed conflict with task IDs so GUI callers can reassign or delete references deliberately.
+- [Plugin-backed profiles cannot run through the initial CLI] -> Fail explicit missing-tool requirements and add plugin bootstrap only after plugin persistence has its own contract.
+
+## Migration Plan
+
+1. Add the automation-task migration and typed ConfigStore APIs without creating any task records automatically.
+2. Add reference checks to prompt deletion and map database conflicts to typed domain errors.
+3. Add shared execution resolution, root execution, and CLI bootstrap behind the new binary target.
+4. Add CLI contract and integration tests using temporary ConfigStores and controlled providers/tools.
+5. Existing profiles, prompts, schedules, and interactive execution continue unchanged; rollback removes the binary and code paths while leaving the additive task table harmless to older builds.
+
+## Open Questions
+
+None required for implementation. Scheduling, run persistence, plugin installation persistence, and semantic expected-outcome evaluation require separate proposals.

--- a/openspec/changes/archive/2026-07-11-add-agent-iron-headless-cli/proposal.md
+++ b/openspec/changes/archive/2026-07-11-add-agent-iron-headless-cli/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+AgentIron needs a deterministic, non-interactive execution path for durable automation such as cron-driven reports. The current runtime can execute stored prompts interactively or as delegated child work, but it has no first-class automation-task identity or CLI that can safely reconstruct persisted runtime configuration and run one as a root session.
+
+## What Changes
+
+- Add a durable `AutomationTask` that names a stored prompt and records the expected outcome for a reusable, eventually schedulable automation.
+- Add typed core CRUD for automation tasks, including validation and referential integrity with stored prompts.
+- Block deletion of a stored prompt while automation tasks reference it; do not cascade-delete tasks.
+- Add an `agent-iron run <task-id>` binary for non-interactive root-session execution.
+- Require a workspace and timeout for every headless run, with command-line, environment, and process-working-directory resolution where applicable.
+- Resolve profile, approval policy, tools, skills, MCP servers, provider, model, and credentials from persisted core configuration and snapshot the resolved execution inputs at run start.
+- Require an explicitly `AutoApprove` profile for headless execution and fail closed for interactive approval policies, unresolved references, unavailable allow-listed tools, missing credentials, or interactive authentication requirements.
+- Define stable text and versioned JSON output, run statuses, cancellation behavior, and process exit codes for automation consumers.
+- Exclude task mutation commands, scheduling, persisted run history, arbitrary prompt/context overrides, web-search functionality, and WASM plugin discovery or bootstrap from this change.
+
+## Capabilities
+
+### New Capabilities
+
+- `automation-tasks`: Durable automation-task identity, typed persistence, validation, referential integrity, and execution-input resolution.
+- `headless-task-cli`: Non-interactive CLI startup, safety preflight, root execution, timeout and cancellation, output contracts, and exit behavior.
+
+### Modified Capabilities
+
+- `stored-prompts`: Prevent deletion of a stored prompt that is referenced by one or more automation tasks.
+
+## Impact
+
+- Adds an `agent-iron` binary target and CLI parsing/runtime bootstrap dependencies.
+- Extends `ConfigStore` with an automation-task migration, typed records, CRUD, and reference-conflict errors.
+- Refactors prompt execution so root CLI runs and delegated stored-prompt runs can share resolved execution inputs without manufacturing a parent session.
+- Uses persisted provider/model settings, provider profiles, credential storage, MCP server settings, skill settings, agent profiles, and stored prompts during CLI bootstrap.
+- Establishes automation-facing output and exit-code APIs that future schedulers and run-history persistence can consume.
+- Does not persist or load WASM plugin inventory because plugin installation state is currently runtime-local rather than core-owned configuration.

--- a/openspec/changes/archive/2026-07-11-add-agent-iron-headless-cli/specs/automation-tasks/spec.md
+++ b/openspec/changes/archive/2026-07-11-add-agent-iron-headless-cli/specs/automation-tasks/spec.md
@@ -1,0 +1,92 @@
+## ADDED Requirements
+
+### Requirement: Core SHALL define durable automation tasks
+The system SHALL define a typed `AutomationTask` with a stable ID, user-facing name, stored-prompt ID, expected-outcome text, creation timestamp, and update timestamp. The task SHALL reference its profile, instructions, skills, provider, model, tools, and approval policy indirectly through its stored prompt and that prompt's optional profile.
+
+#### Scenario: Automation task captures durable automation identity
+- **WHEN** a caller creates an automation task
+- **THEN** it includes a stable task ID
+- **AND** includes a user-facing name suitable for GUI display
+- **AND** references a stored prompt by ID
+- **AND** includes required expected-outcome text
+
+#### Scenario: Multiple tasks reuse one stored prompt
+- **WHEN** multiple automation tasks reference the same stored prompt
+- **THEN** each task retains its own identity, name, and expected outcome
+- **AND** the stored prompt's instructions, skills, and optional profile are not duplicated into either task
+
+### Requirement: Core SHALL validate automation-task identity and content
+The system SHALL trim the task ID, name, stored-prompt ID, and expected outcome, and SHALL reject a task when any resulting value is empty or when a textual identifier contains control characters. Task IDs SHALL be case-sensitive and SHALL remain stable across updates.
+
+#### Scenario: Valid automation task is accepted
+- **WHEN** a caller supplies non-empty valid fields and an existing stored-prompt ID
+- **THEN** the system accepts the automation task
+- **AND** preserves the normalized task ID exactly after validation
+
+#### Scenario: Invalid automation task is rejected
+- **WHEN** a required task field is empty after trimming or a textual identifier contains control characters
+- **THEN** the system returns a typed validation error
+- **AND** does not persist a partial task
+
+### Requirement: ConfigStore SHALL provide typed automation-task CRUD
+ConfigStore SHALL provide typed set, get, list, and delete operations for schema-versioned automation tasks in a first-class task table. Set SHALL create or replace a task atomically, preserve its original creation timestamp on replacement, and update its modification timestamp. List SHALL return tasks in deterministic order.
+
+#### Scenario: Task is created and retrieved
+- **WHEN** a caller stores a valid automation task
+- **THEN** the caller can retrieve the typed task by ID
+- **AND** its persisted fields and timestamps are available
+
+#### Scenario: Existing task is replaced
+- **WHEN** a caller stores a valid task using an existing task ID
+- **THEN** the new task fields replace the previous fields atomically
+- **AND** the original creation timestamp is preserved
+- **AND** the update timestamp advances
+
+#### Scenario: Tasks are listed deterministically
+- **WHEN** a caller lists automation tasks repeatedly without intervening writes
+- **THEN** each result uses the same ordering
+
+#### Scenario: Task is deleted without deleting its prompt
+- **WHEN** a caller deletes an automation task
+- **THEN** later retrieval reports that the task does not exist
+- **AND** its referenced stored prompt remains unchanged
+
+### Requirement: Automation tasks SHALL preserve stored-prompt referential integrity
+ConfigStore SHALL require an automation task's stored-prompt ID to identify an existing stored prompt at write time. It SHALL prevent dangling task references without cascading deletion in either direction.
+
+#### Scenario: Missing stored prompt rejects task write
+- **WHEN** a caller attempts to store a task whose stored-prompt ID does not exist
+- **THEN** ConfigStore returns a typed reference error
+- **AND** does not persist the task
+
+#### Scenario: Task deletion preserves stored prompt
+- **WHEN** a caller deletes the last task referencing a stored prompt
+- **THEN** ConfigStore does not delete or modify the stored prompt
+
+### Requirement: Core SHALL resolve an immutable execution input for a task run
+At run start, the system SHALL resolve the automation task, stored prompt, selected agent profile, expected outcome, requested skills, effective tools, provider, model, and workspace into an execution input used for that run. Resolution SHALL use current persisted values, and later configuration edits SHALL not alter the in-progress run.
+
+#### Scenario: Run resolves current dependencies
+- **WHEN** execution of an automation task begins
+- **THEN** the system resolves the task's current stored prompt and profile references
+- **AND** combines stored instructions with the task's expected outcome as the model-visible user goal
+- **AND** keeps profile identity instructions in the system prompt layers
+
+#### Scenario: Concurrent edit does not mutate active run
+- **WHEN** a referenced task, prompt, or profile changes after run resolution completes
+- **THEN** the active run continues with its resolved execution input
+- **AND** a later run observes the updated configuration
+
+#### Scenario: Missing named dependency fails resolution
+- **WHEN** a task references a missing or malformed stored prompt or named profile
+- **THEN** resolution fails with an actionable typed error
+- **AND** no model request or tool execution begins
+
+### Requirement: Automation run outcomes SHALL distinguish technical completion from expected-outcome verification
+An automation run SHALL treat the task's expected outcome as model-visible goal text and SHALL NOT claim to independently verify semantic success. A `completed` run status SHALL mean runtime execution completed successfully, not that an external evaluator proved the expected outcome.
+
+#### Scenario: Technically completed run
+- **WHEN** the runtime finishes the root session without an unhandled execution error
+- **THEN** the run status is `completed`
+- **AND** the result retains the expected-outcome text
+- **AND** the result does not assert independent semantic verification

--- a/openspec/changes/archive/2026-07-11-add-agent-iron-headless-cli/specs/headless-task-cli/spec.md
+++ b/openspec/changes/archive/2026-07-11-add-agent-iron-headless-cli/specs/headless-task-cli/spec.md
@@ -1,0 +1,193 @@
+## ADDED Requirements
+
+### Requirement: The agent-iron CLI SHALL expose run-only task execution
+The `agent-iron` binary SHALL provide `agent-iron run <task-id>` for non-interactive execution of an existing automation task. It SHALL NOT provide task, prompt, profile, credential, integration, or schedule mutation commands in this change, and SHALL NOT accept an arbitrary prompt, task-level profile override, or arbitrary context variables.
+
+#### Scenario: Existing task is selected by ID
+- **WHEN** a caller invokes `agent-iron run <task-id>` with valid required options
+- **THEN** the CLI loads and executes that existing automation task
+
+#### Scenario: Task ID is omitted
+- **WHEN** a caller invokes the run command without a task ID
+- **THEN** the CLI reports a usage error
+- **AND** does not start runtime bootstrap
+
+#### Scenario: Mutation is attempted
+- **WHEN** a caller requests an unsupported creation, editing, or deletion command
+- **THEN** the CLI reports a usage error
+- **AND** does not mutate persisted configuration
+
+### Requirement: Headless configuration SHALL use explicit deterministic precedence
+The CLI SHALL resolve supported startup settings with command-line values taking precedence over corresponding `AGENTIRON_*` environment variables, which take precedence over documented defaults. The config location SHALL be selectable by `--config` or its environment equivalent. The task ID SHALL remain a required positional argument and SHALL NOT be sourced from an environment variable.
+
+#### Scenario: Command-line setting overrides environment
+- **WHEN** both a supported command-line option and its environment equivalent are present
+- **THEN** the command-line value is used
+
+#### Scenario: Environment supplies an omitted optional setting
+- **WHEN** a supported command-line option is absent and its environment equivalent is valid
+- **THEN** the environment value is used
+
+#### Scenario: Environment does not select task
+- **WHEN** an environment variable names a task but the positional task ID is absent
+- **THEN** the CLI reports a usage error
+
+### Requirement: Every headless run SHALL have a validated workspace
+The CLI SHALL support `--workspace` and `AGENTIRON_WORKSPACE`, resolving workspace in the order command line, environment, then process working directory. Before runtime execution, it SHALL canonicalize the selected path, require it to be an existing directory, and use it as both the session workspace root and the allowed root for workspace-scoped built-in tools.
+
+#### Scenario: Explicit workspace is used
+- **WHEN** a caller supplies an existing directory through `--workspace`
+- **THEN** the CLI canonicalizes that directory
+- **AND** uses it as the run's session workspace and built-in-tool allowed root
+
+#### Scenario: Process directory supplies workspace
+- **WHEN** neither `--workspace` nor `AGENTIRON_WORKSPACE` is supplied
+- **THEN** the CLI resolves the process working directory as the workspace
+
+#### Scenario: Workspace is invalid
+- **WHEN** the resolved workspace does not exist, is not a directory, or cannot be canonicalized
+- **THEN** the CLI returns a configuration error
+- **AND** no model request or tool execution begins
+
+### Requirement: Every headless run SHALL have an execution timeout
+The CLI SHALL support `--timeout` and `AGENTIRON_TIMEOUT` using documented duration values such as `30s`, `5m`, and `1h`. A run SHALL NOT start unless a valid positive timeout resolves from the command line or environment. Timeout expiration SHALL request cancellation and produce the `timed_out` status even if cleanup continues afterward.
+
+#### Scenario: Timeout is supplied on command line
+- **WHEN** a caller supplies a valid positive `--timeout`
+- **THEN** the CLI applies it to the complete task execution
+
+#### Scenario: Timeout is absent
+- **WHEN** neither `--timeout` nor `AGENTIRON_TIMEOUT` is supplied
+- **THEN** the CLI reports a usage or configuration error
+- **AND** does not begin task execution
+
+#### Scenario: Timeout expires
+- **WHEN** execution exceeds the resolved timeout
+- **THEN** the CLI requests cancellation of the run
+- **AND** reports status `timed_out`
+- **AND** exits with the timeout exit code
+
+### Requirement: Headless bootstrap SHALL reconstruct core-owned runtime configuration
+The CLI SHALL open and migrate ConfigStore, load persisted runtime settings, provider profiles, credentials, MCP server definitions, skill settings, agent profiles, stored prompts, and the selected automation task, then construct the runtime and root session from those values. It SHALL preserve existing built-in-tool and network protections. It SHALL NOT discover, install, register, or load WASM plugins because plugin inventory is not core-persisted in this change.
+
+#### Scenario: Persisted integrations are reconstructed
+- **WHEN** the selected task resolves successfully
+- **THEN** enabled persisted MCP servers and configured skill sources are made available according to their saved settings and workspace trust policy
+- **AND** core built-in tools are configured with the resolved workspace and existing safety settings
+
+#### Scenario: WASM plugins are not bootstrapped
+- **WHEN** runtime-local plugin artifacts or plugin directories are present
+- **THEN** the CLI does not scan, register, install, or load them
+- **AND** plugin tools are absent from the effective headless tool inventory
+
+#### Scenario: Required plugin tool is unavailable
+- **WHEN** the selected profile explicitly allow-lists a plugin tool that is not available in the reconstructed runtime
+- **THEN** headless preflight fails with an actionable unavailable-tool error
+
+### Requirement: RuntimeDefault SHALL resolve the saved default provider and model
+For headless execution, a profile using `RuntimeDefault` SHALL resolve through ConfigStore's saved default provider/model selection, effective provider profile, and stored credential configuration. The CLI SHALL fail closed if that chain is missing, disabled, invalid, or unavailable and SHALL NOT substitute a different provider or model.
+
+#### Scenario: Saved default resolves
+- **WHEN** a task's effective profile uses `RuntimeDefault`
+- **AND** ConfigStore contains a valid enabled default provider/model with usable credentials
+- **THEN** the CLI uses that exact provider and model
+
+#### Scenario: Saved default is unavailable
+- **WHEN** the saved default provider/model or required credential cannot be resolved
+- **THEN** bootstrap fails with an actionable provider or credential error
+- **AND** no fallback provider or model is selected
+
+### Requirement: Headless execution SHALL fail closed on interactive policy
+Before starting a model request, the CLI SHALL require the effective agent profile to use `AutoApprove`. It SHALL accept `Inherit`, `Allow`, or `Deny` tool filters without changing them, SHALL reject `PerTool`, and SHALL never upgrade an approval policy automatically. An omitted stored-prompt profile SHALL resolve through the existing default-profile behavior and SHALL fail preflight if the resulting profile is not explicitly headless-safe.
+
+#### Scenario: AutoApprove profile passes policy preflight
+- **WHEN** the effective profile uses `AutoApprove`
+- **AND** all explicitly allow-listed tools are available
+- **THEN** policy preflight permits execution with the profile's effective tool inventory
+
+#### Scenario: Inherit trusts current inventory
+- **WHEN** an `AutoApprove` profile uses the `Inherit` tool filter
+- **THEN** every tool in the reconstructed session-effective runtime inventory is eligible to execute without interactive approval
+
+#### Scenario: Interactive approval is rejected
+- **WHEN** the effective profile uses `PerTool` or otherwise requires client interaction
+- **THEN** policy preflight fails with an unsafe-policy error
+- **AND** no policy is silently changed
+
+#### Scenario: Default profile is not headless-safe
+- **WHEN** a stored prompt omits its profile
+- **AND** the resolved default profile requires interactive approval
+- **THEN** policy preflight fails before model or tool execution
+
+### Requirement: Headless authentication SHALL not wait for user interaction
+The CLI SHALL use already configured credentials and MAY perform supported automatic token refresh. If provider, MCP, or other capability initialization requires interactive login, browser authorization, a device code response, or another client-mediated auth interaction, the CLI SHALL fail actionably rather than wait for input.
+
+#### Scenario: Existing credential is usable
+- **WHEN** a required provider or integration credential is already usable or can refresh automatically
+- **THEN** headless bootstrap proceeds without prompting
+
+#### Scenario: Interactive authentication is required
+- **WHEN** a required capability requests interactive authentication
+- **THEN** the CLI reports a credential or initialization failure
+- **AND** does not wait for terminal input or an absent client
+
+### Requirement: Headless tasks SHALL execute as root sessions
+The CLI SHALL create and execute a root session directly from the resolved automation execution input. It SHALL NOT manufacture an interactive parent session or route root execution through delegated child-session APIs. Root and delegated stored-prompt execution SHALL share resolution and prompt-composition machinery where their semantics overlap.
+
+#### Scenario: CLI task starts root execution
+- **WHEN** bootstrap and preflight succeed
+- **THEN** the CLI creates a root session using the resolved profile, provider, model, tools, skills, workspace, instructions, and expected outcome
+- **AND** execution does not require a parent client or parent session
+
+### Requirement: Headless execution SHALL support signal cancellation
+The CLI SHALL handle supported interrupt and termination signals by requesting runtime cancellation and reporting `cancelled` unless timeout had already determined the terminal status.
+
+#### Scenario: Interrupt requests cancellation
+- **WHEN** the process receives a supported interrupt or termination signal during execution
+- **THEN** it requests cancellation of the active run
+- **AND** reports status `cancelled`
+- **AND** exits with the cancellation exit code
+
+### Requirement: Headless output SHALL separate machine data from diagnostics
+The CLI SHALL support `text` and `json` formats and a quiet mode. Standard output SHALL contain only the selected final result contract. Progress, warnings, and human-readable diagnostics SHALL use standard error. Quiet mode SHALL suppress progress but SHALL NOT suppress the final result or fatal errors.
+
+#### Scenario: Text run completes
+- **WHEN** a run completes in text format
+- **THEN** standard output contains only the final assistant text
+- **AND** progress or warnings, if emitted, use standard error
+
+#### Scenario: Quiet mode completes
+- **WHEN** quiet mode is enabled
+- **THEN** progress output is suppressed
+- **AND** final output and fatal errors remain observable
+
+### Requirement: JSON output SHALL be one versioned terminal object
+For JSON format, the CLI SHALL emit exactly one JSON object on standard output after argument parsing establishes JSON mode. The object SHALL include a schema version, run ID, task ID and name, status, output, expected outcome, resolved profile/provider/model/workspace, effective tool names, start/end timing, duration, and a structured nullable error. Terminal statuses SHALL be `completed`, `failed`, `cancelled`, or `timed_out`.
+
+#### Scenario: JSON run completes
+- **WHEN** execution completes in JSON format
+- **THEN** standard output contains exactly one valid terminal JSON object
+- **AND** its status is `completed`
+- **AND** its error is null
+
+#### Scenario: Post-parse JSON run fails
+- **WHEN** configuration, policy, initialization, execution, cancellation, or timeout fails after JSON mode is established
+- **THEN** standard output still contains exactly one valid terminal JSON object
+- **AND** its non-completed status and structured error describe the failure
+- **AND** the process exits nonzero
+
+### Requirement: Headless exit codes SHALL be stable
+The CLI SHALL use exit code `0` for `completed`, `2` for usage errors, `3` for configuration or reference errors, `4` for unsafe policy, `5` for provider or credential initialization, `6` for execution failure, `7` for cancellation, and `8` for timeout. A tool error that the model handles successfully SHALL NOT by itself force a nonzero exit.
+
+#### Scenario: Completed run exits successfully
+- **WHEN** the terminal run status is `completed`
+- **THEN** the process exits with code `0`
+
+#### Scenario: Failure category maps to stable code
+- **WHEN** the run terminates in a defined non-completed category
+- **THEN** the process exits with that category's documented nonzero code
+
+#### Scenario: Model recovers from tool error
+- **WHEN** a tool invocation fails but the model handles the error and runtime execution completes
+- **THEN** the run may report `completed`
+- **AND** the tool error alone does not force exit code `6`

--- a/openspec/changes/archive/2026-07-11-add-agent-iron-headless-cli/specs/stored-prompts/spec.md
+++ b/openspec/changes/archive/2026-07-11-add-agent-iron-headless-cli/specs/stored-prompts/spec.md
@@ -1,0 +1,25 @@
+## MODIFIED Requirements
+
+### Requirement: Core SHALL register and list stored prompts
+
+The system SHALL provide APIs to register, unregister, retrieve, and list stored prompts by stable prompt name or ID for the lifetime of the runtime or agent instance. Unregistering or deleting a stored prompt SHALL fail with a typed conflict while one or more automation tasks reference it and SHALL NOT cascade-delete those tasks.
+
+#### Scenario: Stored prompt is registered
+- **WHEN** a caller registers a stored prompt with a valid name or ID
+- **THEN** the prompt can be retrieved by that name or ID
+- **AND** list operations include it with deterministic ordering
+
+#### Scenario: Stored prompt is replaced
+- **WHEN** a caller registers a stored prompt using an existing name or ID
+- **THEN** the new prompt replaces the previous prompt if validation succeeds
+
+#### Scenario: Unreferenced stored prompt is unregistered
+- **WHEN** a caller unregisters a stored prompt by name or ID
+- **AND** no automation task references that prompt
+- **THEN** later retrieval by that name or ID reports that no prompt is registered
+
+#### Scenario: Referenced stored prompt deletion is blocked
+- **WHEN** a caller unregisters or deletes a stored prompt referenced by one or more automation tasks
+- **THEN** the operation returns a typed conflict identifying the referencing task IDs
+- **AND** the stored prompt remains registered
+- **AND** the referencing tasks remain unchanged

--- a/openspec/changes/archive/2026-07-11-add-agent-iron-headless-cli/tasks.md
+++ b/openspec/changes/archive/2026-07-11-add-agent-iron-headless-cli/tasks.md
@@ -1,0 +1,48 @@
+## 1. Automation Task Domain
+
+- [x] 1.1 Add typed `AutomationTask`, input, ID, validation, schema-version, and error types with unit tests for normalization and invalid fields
+- [x] 1.2 Add the ConfigStore migration for the first-class automation-task table, timestamps, deterministic indexing, and stored-prompt foreign-key relationship
+- [x] 1.3 Implement typed set, get, list, and delete automation-task APIs with atomic replacement and timestamp semantics
+- [x] 1.4 Add ConfigStore tests for CRUD, deterministic ordering, replacement, unsupported or malformed records, and missing-prompt references
+- [x] 1.5 Change stored-prompt deletion to return a typed conflict with referencing task IDs and add tests proving neither prompts nor tasks cascade-delete
+
+## 2. Shared Execution Resolution
+
+- [x] 2.1 Define the immutable resolved execution input and ephemeral automation-run result types, including terminal statuses, timing, resolved identities, effective tools, and structured errors
+- [x] 2.2 Implement task, stored-prompt, profile, skill, tool, workspace, provider, and model resolution with actionable typed failures
+- [x] 2.3 Compose stored instructions and expected outcome as the user goal while preserving profile identity in system prompt layers
+- [x] 2.4 Refactor delegated stored-prompt execution to share applicable resolution and prompt-composition code without changing its child-session behavior
+- [x] 2.5 Add tests proving dependency snapshots are stable during a run and subsequent runs observe updated records
+
+## 3. Headless Safety And Runtime Bootstrap
+
+- [x] 3.1 Implement headless policy preflight requiring `AutoApprove`, preserving `Inherit`/`Allow`/`Deny`, rejecting interactive approval, and checking explicitly allow-listed tool availability
+- [x] 3.2 Implement saved `RuntimeDefault` resolution through the persisted default provider/model, effective provider profile, and credential configuration without fallback
+- [x] 3.3 Implement non-interactive credential behavior that permits existing credentials and automatic refresh but fails client-mediated authentication requests
+- [x] 3.4 Build runtime bootstrap from ConfigStore settings, built-in protections, persisted MCP definitions, skill settings, profiles, prompts, and automation tasks
+- [x] 3.5 Ensure CLI bootstrap neither scans for nor registers or installs WASM plugins and reports explicitly required plugin tools as unavailable
+- [x] 3.6 Add bootstrap and preflight tests for valid configuration, missing references, unsafe profiles, unavailable tools, missing defaults, credential failures, MCP/skill loading, and plugin exclusion
+
+## 4. Root Automation Execution
+
+- [x] 4.1 Add a root-session execution entry point that consumes the resolved execution input without creating a synthetic parent session
+- [x] 4.2 Apply the canonical workspace to the session and workspace-scoped built-in tool roots while preserving existing network and filesystem restrictions
+- [x] 4.3 Implement whole-run timeout and cooperative cancellation with distinct timeout and signal-cancellation terminal outcomes
+- [x] 4.4 Add tests for root execution, technical completion semantics, model-recovered tool errors, execution failures, cancellation, and timeout
+
+## 5. agent-iron Binary And Contracts
+
+- [x] 5.1 Add the `agent-iron` binary target and minimal CLI parsing dependency or module consistent with repository conventions
+- [x] 5.2 Implement `run <task-id>` parsing for config, workspace, required timeout, text/JSON format, and quiet options with CLI-over-environment precedence
+- [x] 5.3 Validate and canonicalize workspace selection from CLI, environment, or process current directory and validate positive duration syntax
+- [x] 5.4 Implement text stdout, diagnostic stderr, and quiet-mode behavior
+- [x] 5.5 Implement the single versioned terminal JSON object and stable exit-code mapping for all post-parse outcomes
+- [x] 5.6 Handle supported interrupt and termination signals by cancelling the active root run and preserving timeout precedence
+
+## 6. End-To-End Verification
+
+- [x] 6.1 Add binary integration fixtures that create temporary ConfigStores with controlled profiles, prompts, tasks, providers, credentials, MCP definitions, and skills
+- [x] 6.2 Add command-level tests for usage failures, precedence, invalid workspace and timeout, successful text output, quiet mode, and each stable exit category
+- [x] 6.3 Add JSON contract tests asserting exactly one stdout object, required versioned fields, clean stdout, and structured failure results
+- [x] 6.4 Add end-to-end tests proving task runs use saved default provider/model, execute as root sessions, enforce AutoApprove preflight, and exclude runtime-local plugins
+- [x] 6.5 Run `cargo fmt --check`, `cargo test`, and `cargo clippy --all-targets --all-features -- -D warnings`, resolving any regressions introduced by the change

--- a/openspec/specs/automation-tasks/spec.md
+++ b/openspec/specs/automation-tasks/spec.md
@@ -1,0 +1,96 @@
+# automation-tasks Specification
+
+## Purpose
+Define durable automation-task identities, storage, reference integrity, execution resolution, and run outcome semantics.
+
+## Requirements
+### Requirement: Core SHALL define durable automation tasks
+The system SHALL define a typed `AutomationTask` with a stable ID, user-facing name, stored-prompt ID, expected-outcome text, creation timestamp, and update timestamp. The task SHALL reference its profile, instructions, skills, provider, model, tools, and approval policy indirectly through its stored prompt and that prompt's optional profile.
+
+#### Scenario: Automation task captures durable automation identity
+- **WHEN** a caller creates an automation task
+- **THEN** it includes a stable task ID
+- **AND** includes a user-facing name suitable for GUI display
+- **AND** references a stored prompt by ID
+- **AND** includes required expected-outcome text
+
+#### Scenario: Multiple tasks reuse one stored prompt
+- **WHEN** multiple automation tasks reference the same stored prompt
+- **THEN** each task retains its own identity, name, and expected outcome
+- **AND** the stored prompt's instructions, skills, and optional profile are not duplicated into either task
+
+### Requirement: Core SHALL validate automation-task identity and content
+The system SHALL trim the task ID, name, stored-prompt ID, and expected outcome, and SHALL reject a task when any resulting value is empty or when a textual identifier contains control characters. Task IDs SHALL be case-sensitive and SHALL remain stable across updates.
+
+#### Scenario: Valid automation task is accepted
+- **WHEN** a caller supplies non-empty valid fields and an existing stored-prompt ID
+- **THEN** the system accepts the automation task
+- **AND** preserves the normalized task ID exactly after validation
+
+#### Scenario: Invalid automation task is rejected
+- **WHEN** a required task field is empty after trimming or a textual identifier contains control characters
+- **THEN** the system returns a typed validation error
+- **AND** does not persist a partial task
+
+### Requirement: ConfigStore SHALL provide typed automation-task CRUD
+ConfigStore SHALL provide typed set, get, list, and delete operations for schema-versioned automation tasks in a first-class task table. Set SHALL create or replace a task atomically, preserve its original creation timestamp on replacement, and update its modification timestamp. List SHALL return tasks in deterministic order.
+
+#### Scenario: Task is created and retrieved
+- **WHEN** a caller stores a valid automation task
+- **THEN** the caller can retrieve the typed task by ID
+- **AND** its persisted fields and timestamps are available
+
+#### Scenario: Existing task is replaced
+- **WHEN** a caller stores a valid task using an existing task ID
+- **THEN** the new task fields replace the previous fields atomically
+- **AND** the original creation timestamp is preserved
+- **AND** the update timestamp advances
+
+#### Scenario: Tasks are listed deterministically
+- **WHEN** a caller lists automation tasks repeatedly without intervening writes
+- **THEN** each result uses the same ordering
+
+#### Scenario: Task is deleted without deleting its prompt
+- **WHEN** a caller deletes an automation task
+- **THEN** later retrieval reports that the task does not exist
+- **AND** its referenced stored prompt remains unchanged
+
+### Requirement: Automation tasks SHALL preserve stored-prompt referential integrity
+ConfigStore SHALL require an automation task's stored-prompt ID to identify an existing stored prompt at write time. It SHALL prevent dangling task references without cascading deletion in either direction.
+
+#### Scenario: Missing stored prompt rejects task write
+- **WHEN** a caller attempts to store a task whose stored-prompt ID does not exist
+- **THEN** ConfigStore returns a typed reference error
+- **AND** does not persist the task
+
+#### Scenario: Task deletion preserves stored prompt
+- **WHEN** a caller deletes the last task referencing a stored prompt
+- **THEN** ConfigStore does not delete or modify the stored prompt
+
+### Requirement: Core SHALL resolve an immutable execution input for a task run
+At run start, the system SHALL resolve the automation task, stored prompt, selected agent profile, expected outcome, requested skills, effective tools, provider, model, and workspace into an execution input used for that run. Resolution SHALL use current persisted values, and later configuration edits SHALL not alter the in-progress run.
+
+#### Scenario: Run resolves current dependencies
+- **WHEN** execution of an automation task begins
+- **THEN** the system resolves the task's current stored prompt and profile references
+- **AND** combines stored instructions with the task's expected outcome as the model-visible user goal
+- **AND** keeps profile identity instructions in the system prompt layers
+
+#### Scenario: Concurrent edit does not mutate active run
+- **WHEN** a referenced task, prompt, or profile changes after run resolution completes
+- **THEN** the active run continues with its resolved execution input
+- **AND** a later run observes the updated configuration
+
+#### Scenario: Missing named dependency fails resolution
+- **WHEN** a task references a missing or malformed stored prompt or named profile
+- **THEN** resolution fails with an actionable typed error
+- **AND** no model request or tool execution begins
+
+### Requirement: Automation run outcomes SHALL distinguish technical completion from expected-outcome verification
+An automation run SHALL treat the task's expected outcome as model-visible goal text and SHALL NOT claim to independently verify semantic success. A `completed` run status SHALL mean runtime execution completed successfully, not that an external evaluator proved the expected outcome.
+
+#### Scenario: Technically completed run
+- **WHEN** the runtime finishes the root session without an unhandled execution error
+- **THEN** the run status is `completed`
+- **AND** the result retains the expected-outcome text
+- **AND** the result does not assert independent semantic verification

--- a/openspec/specs/headless-task-cli/spec.md
+++ b/openspec/specs/headless-task-cli/spec.md
@@ -166,7 +166,7 @@ The CLI SHALL support `text` and `json` formats and a quiet mode. Standard outpu
 - **AND** final output and fatal errors remain observable
 
 ### Requirement: JSON output SHALL be one versioned terminal object
-For JSON format, the CLI SHALL emit exactly one JSON object on standard output after argument parsing establishes JSON mode. The object SHALL include a schema version, run ID, task ID and name, status, output, expected outcome, resolved profile/provider/model/workspace, effective tool names, start/end timing, duration, and a structured nullable error. Terminal statuses SHALL be `completed`, `failed`, `cancelled`, or `timed_out`.
+For JSON format, the CLI SHALL emit exactly one JSON object on standard output whenever JSON mode is requested through arguments or environment, including usage errors detected before argument parsing completes. The object SHALL include a schema version, run ID, task ID and name, status, output, expected outcome, resolved profile/provider/model/workspace, effective tool names, start/end timing, duration, and a structured nullable error. Terminal statuses SHALL be `completed`, `failed`, `cancelled`, or `timed_out`.
 
 #### Scenario: JSON run completes
 - **WHEN** execution completes in JSON format
@@ -179,6 +179,11 @@ For JSON format, the CLI SHALL emit exactly one JSON object on standard output a
 - **THEN** standard output still contains exactly one valid terminal JSON object
 - **AND** its non-completed status and structured error describe the failure
 - **AND** the process exits nonzero
+
+#### Scenario: Pre-parse usage error honors JSON
+- **WHEN** a caller requests JSON format through arguments or environment but supplies arguments that fail parsing (missing task ID, unknown option, missing value, or missing subcommand)
+- **THEN** standard output still contains exactly one valid terminal JSON object describing the usage error
+- **AND** the process exits with the usage exit code
 
 ### Requirement: Headless exit codes SHALL be stable
 The CLI SHALL use exit code `0` for `completed`, `2` for usage errors, `3` for configuration or reference errors, `4` for unsafe policy, `5` for provider or credential initialization, `6` for execution failure, `7` for cancellation, and `8` for timeout. A tool error that the model handles successfully SHALL NOT by itself force a nonzero exit.

--- a/openspec/specs/headless-task-cli/spec.md
+++ b/openspec/specs/headless-task-cli/spec.md
@@ -1,0 +1,197 @@
+# headless-task-cli Specification
+
+## Purpose
+Define deterministic, non-interactive execution of durable automation tasks through the `agent-iron` CLI.
+
+## Requirements
+### Requirement: The agent-iron CLI SHALL expose run-only task execution
+The `agent-iron` binary SHALL provide `agent-iron run <task-id>` for non-interactive execution of an existing automation task. It SHALL NOT provide task, prompt, profile, credential, integration, or schedule mutation commands in this change, and SHALL NOT accept an arbitrary prompt, task-level profile override, or arbitrary context variables.
+
+#### Scenario: Existing task is selected by ID
+- **WHEN** a caller invokes `agent-iron run <task-id>` with valid required options
+- **THEN** the CLI loads and executes that existing automation task
+
+#### Scenario: Task ID is omitted
+- **WHEN** a caller invokes the run command without a task ID
+- **THEN** the CLI reports a usage error
+- **AND** does not start runtime bootstrap
+
+#### Scenario: Mutation is attempted
+- **WHEN** a caller requests an unsupported creation, editing, or deletion command
+- **THEN** the CLI reports a usage error
+- **AND** does not mutate persisted configuration
+
+### Requirement: Headless configuration SHALL use explicit deterministic precedence
+The CLI SHALL resolve supported startup settings with command-line values taking precedence over corresponding `AGENTIRON_*` environment variables, which take precedence over documented defaults. The config location SHALL be selectable by `--config` or its environment equivalent. The task ID SHALL remain a required positional argument and SHALL NOT be sourced from an environment variable.
+
+#### Scenario: Command-line setting overrides environment
+- **WHEN** both a supported command-line option and its environment equivalent are present
+- **THEN** the command-line value is used
+
+#### Scenario: Environment supplies an omitted optional setting
+- **WHEN** a supported command-line option is absent and its environment equivalent is valid
+- **THEN** the environment value is used
+
+#### Scenario: Environment does not select task
+- **WHEN** an environment variable names a task but the positional task ID is absent
+- **THEN** the CLI reports a usage error
+
+### Requirement: Every headless run SHALL have a validated workspace
+The CLI SHALL support `--workspace` and `AGENTIRON_WORKSPACE`, resolving workspace in the order command line, environment, then process working directory. Before runtime execution, it SHALL canonicalize the selected path, require it to be an existing directory, and use it as both the session workspace root and the allowed root for workspace-scoped built-in tools.
+
+#### Scenario: Explicit workspace is used
+- **WHEN** a caller supplies an existing directory through `--workspace`
+- **THEN** the CLI canonicalizes that directory
+- **AND** uses it as the run's session workspace and built-in-tool allowed root
+
+#### Scenario: Process directory supplies workspace
+- **WHEN** neither `--workspace` nor `AGENTIRON_WORKSPACE` is supplied
+- **THEN** the CLI resolves the process working directory as the workspace
+
+#### Scenario: Workspace is invalid
+- **WHEN** the resolved workspace does not exist, is not a directory, or cannot be canonicalized
+- **THEN** the CLI returns a configuration error
+- **AND** no model request or tool execution begins
+
+### Requirement: Every headless run SHALL have an execution timeout
+The CLI SHALL support `--timeout` and `AGENTIRON_TIMEOUT` using documented duration values such as `30s`, `5m`, and `1h`. A run SHALL NOT start unless a valid positive timeout resolves from the command line or environment. Timeout expiration SHALL request cancellation and produce the `timed_out` status even if cleanup continues afterward.
+
+#### Scenario: Timeout is supplied on command line
+- **WHEN** a caller supplies a valid positive `--timeout`
+- **THEN** the CLI applies it to the complete task execution
+
+#### Scenario: Timeout is absent
+- **WHEN** neither `--timeout` nor `AGENTIRON_TIMEOUT` is supplied
+- **THEN** the CLI reports a usage or configuration error
+- **AND** does not begin task execution
+
+#### Scenario: Timeout expires
+- **WHEN** execution exceeds the resolved timeout
+- **THEN** the CLI requests cancellation of the run
+- **AND** reports status `timed_out`
+- **AND** exits with the timeout exit code
+
+### Requirement: Headless bootstrap SHALL reconstruct core-owned runtime configuration
+The CLI SHALL open and migrate ConfigStore, load persisted runtime settings, provider profiles, credentials, MCP server definitions, skill settings, agent profiles, stored prompts, and the selected automation task, then construct the runtime and root session from those values. It SHALL preserve existing built-in-tool and network protections. It SHALL NOT discover, install, register, or load WASM plugins because plugin inventory is not core-persisted in this change.
+
+#### Scenario: Persisted integrations are reconstructed
+- **WHEN** the selected task resolves successfully
+- **THEN** enabled persisted MCP servers and configured skill sources are made available according to their saved settings and workspace trust policy
+- **AND** core built-in tools are configured with the resolved workspace and existing safety settings
+
+#### Scenario: WASM plugins are not bootstrapped
+- **WHEN** runtime-local plugin artifacts or plugin directories are present
+- **THEN** the CLI does not scan, register, install, or load them
+- **AND** plugin tools are absent from the effective headless tool inventory
+
+#### Scenario: Required plugin tool is unavailable
+- **WHEN** the selected profile explicitly allow-lists a plugin tool that is not available in the reconstructed runtime
+- **THEN** headless preflight fails with an actionable unavailable-tool error
+
+### Requirement: RuntimeDefault SHALL resolve the saved default provider and model
+For headless execution, a profile using `RuntimeDefault` SHALL resolve through ConfigStore's saved default provider/model selection, effective provider profile, and stored credential configuration. The CLI SHALL fail closed if that chain is missing, disabled, invalid, or unavailable and SHALL NOT substitute a different provider or model.
+
+#### Scenario: Saved default resolves
+- **WHEN** a task's effective profile uses `RuntimeDefault`
+- **AND** ConfigStore contains a valid enabled default provider/model with usable credentials
+- **THEN** the CLI uses that exact provider and model
+
+#### Scenario: Saved default is unavailable
+- **WHEN** the saved default provider/model or required credential cannot be resolved
+- **THEN** bootstrap fails with an actionable provider or credential error
+- **AND** no fallback provider or model is selected
+
+### Requirement: Headless execution SHALL fail closed on interactive policy
+Before starting a model request, the CLI SHALL require the effective agent profile to use `AutoApprove`. It SHALL accept `Inherit`, `Allow`, or `Deny` tool filters without changing them, SHALL reject `PerTool`, and SHALL never upgrade an approval policy automatically. An omitted stored-prompt profile SHALL resolve through the existing default-profile behavior and SHALL fail preflight if the resulting profile is not explicitly headless-safe.
+
+#### Scenario: AutoApprove profile passes policy preflight
+- **WHEN** the effective profile uses `AutoApprove`
+- **AND** all explicitly allow-listed tools are available
+- **THEN** policy preflight permits execution with the profile's effective tool inventory
+
+#### Scenario: Inherit trusts current inventory
+- **WHEN** an `AutoApprove` profile uses the `Inherit` tool filter
+- **THEN** every tool in the reconstructed session-effective runtime inventory is eligible to execute without interactive approval
+
+#### Scenario: Interactive approval is rejected
+- **WHEN** the effective profile uses `PerTool` or otherwise requires client interaction
+- **THEN** policy preflight fails with an unsafe-policy error
+- **AND** no policy is silently changed
+
+#### Scenario: Default profile is not headless-safe
+- **WHEN** a stored prompt omits its profile
+- **AND** the resolved default profile requires interactive approval
+- **THEN** policy preflight fails before model or tool execution
+
+### Requirement: Headless authentication SHALL not wait for user interaction
+The CLI SHALL use already configured credentials and MAY perform supported automatic token refresh. If provider, MCP, or other capability initialization requires interactive login, browser authorization, a device code response, or another client-mediated auth interaction, the CLI SHALL fail actionably rather than wait for input.
+
+#### Scenario: Existing credential is usable
+- **WHEN** a required provider or integration credential is already usable or can refresh automatically
+- **THEN** headless bootstrap proceeds without prompting
+
+#### Scenario: Interactive authentication is required
+- **WHEN** a required capability requests interactive authentication
+- **THEN** the CLI reports a credential or initialization failure
+- **AND** does not wait for terminal input or an absent client
+
+### Requirement: Headless tasks SHALL execute as root sessions
+The CLI SHALL create and execute a root session directly from the resolved automation execution input. It SHALL NOT manufacture an interactive parent session or route root execution through delegated child-session APIs. Root and delegated stored-prompt execution SHALL share resolution and prompt-composition machinery where their semantics overlap.
+
+#### Scenario: CLI task starts root execution
+- **WHEN** bootstrap and preflight succeed
+- **THEN** the CLI creates a root session using the resolved profile, provider, model, tools, skills, workspace, instructions, and expected outcome
+- **AND** execution does not require a parent client or parent session
+
+### Requirement: Headless execution SHALL support signal cancellation
+The CLI SHALL handle supported interrupt and termination signals by requesting runtime cancellation and reporting `cancelled` unless timeout had already determined the terminal status.
+
+#### Scenario: Interrupt requests cancellation
+- **WHEN** the process receives a supported interrupt or termination signal during execution
+- **THEN** it requests cancellation of the active run
+- **AND** reports status `cancelled`
+- **AND** exits with the cancellation exit code
+
+### Requirement: Headless output SHALL separate machine data from diagnostics
+The CLI SHALL support `text` and `json` formats and a quiet mode. Standard output SHALL contain only the selected final result contract. Progress, warnings, and human-readable diagnostics SHALL use standard error. Quiet mode SHALL suppress progress but SHALL NOT suppress the final result or fatal errors.
+
+#### Scenario: Text run completes
+- **WHEN** a run completes in text format
+- **THEN** standard output contains only the final assistant text
+- **AND** progress or warnings, if emitted, use standard error
+
+#### Scenario: Quiet mode completes
+- **WHEN** quiet mode is enabled
+- **THEN** progress output is suppressed
+- **AND** final output and fatal errors remain observable
+
+### Requirement: JSON output SHALL be one versioned terminal object
+For JSON format, the CLI SHALL emit exactly one JSON object on standard output after argument parsing establishes JSON mode. The object SHALL include a schema version, run ID, task ID and name, status, output, expected outcome, resolved profile/provider/model/workspace, effective tool names, start/end timing, duration, and a structured nullable error. Terminal statuses SHALL be `completed`, `failed`, `cancelled`, or `timed_out`.
+
+#### Scenario: JSON run completes
+- **WHEN** execution completes in JSON format
+- **THEN** standard output contains exactly one valid terminal JSON object
+- **AND** its status is `completed`
+- **AND** its error is null
+
+#### Scenario: Post-parse JSON run fails
+- **WHEN** configuration, policy, initialization, execution, cancellation, or timeout fails after JSON mode is established
+- **THEN** standard output still contains exactly one valid terminal JSON object
+- **AND** its non-completed status and structured error describe the failure
+- **AND** the process exits nonzero
+
+### Requirement: Headless exit codes SHALL be stable
+The CLI SHALL use exit code `0` for `completed`, `2` for usage errors, `3` for configuration or reference errors, `4` for unsafe policy, `5` for provider or credential initialization, `6` for execution failure, `7` for cancellation, and `8` for timeout. A tool error that the model handles successfully SHALL NOT by itself force a nonzero exit.
+
+#### Scenario: Completed run exits successfully
+- **WHEN** the terminal run status is `completed`
+- **THEN** the process exits with code `0`
+
+#### Scenario: Failure category maps to stable code
+- **WHEN** the run terminates in a defined non-completed category
+- **THEN** the process exits with that category's documented nonzero code
+
+#### Scenario: Model recovers from tool error
+- **WHEN** a tool invocation fails but the model handles the error and runtime execution completes
+- **THEN** the run may report `completed`
+- **AND** the tool error alone does not force exit code `6`

--- a/openspec/specs/stored-prompts/spec.md
+++ b/openspec/specs/stored-prompts/spec.md
@@ -21,7 +21,7 @@ The system SHALL define a typed `StoredPrompt` payload for reusable prompt tasks
 
 ### Requirement: Core SHALL register and list stored prompts
 
-The system SHALL provide APIs to register, unregister, retrieve, and list stored prompts by stable prompt name or ID for the lifetime of the runtime or agent instance.
+The system SHALL provide APIs to register, unregister, retrieve, and list stored prompts by stable prompt name or ID for the lifetime of the runtime or agent instance. Unregistering or deleting a stored prompt SHALL fail with a typed conflict while one or more automation tasks reference it and SHALL NOT cascade-delete those tasks.
 
 #### Scenario: Stored prompt is registered
 - **WHEN** a caller registers a stored prompt with a valid name or ID
@@ -32,9 +32,16 @@ The system SHALL provide APIs to register, unregister, retrieve, and list stored
 - **WHEN** a caller registers a stored prompt using an existing name or ID
 - **THEN** the new prompt replaces the previous prompt if validation succeeds
 
-#### Scenario: Stored prompt is unregistered
+#### Scenario: Unreferenced stored prompt is unregistered
 - **WHEN** a caller unregisters a stored prompt by name or ID
+- **AND** no automation task references that prompt
 - **THEN** later retrieval by that name or ID reports that no prompt is registered
+
+#### Scenario: Referenced stored prompt deletion is blocked
+- **WHEN** a caller unregisters or deletes a stored prompt referenced by one or more automation tasks
+- **THEN** the operation returns a typed conflict identifying the referencing task IDs
+- **AND** the stored prompt remains registered
+- **AND** the referencing tasks remain unchanged
 
 ### Requirement: Core SHALL load typed stored prompts from ConfigStore
 

--- a/src/automation_task/mod.rs
+++ b/src/automation_task/mod.rs
@@ -1,0 +1,211 @@
+//! Durable automation-task identity and validation.
+//!
+//! An `AutomationTask` is a reference to a `StoredPrompt` with its own
+//! expected-outcome text. It is designed for GUI management and eventual
+//! scheduling. The task does not duplicate instructions, skills, profile,
+//! provider, model, tools, or approval policy — those live on the stored
+//! prompt and its optional profile.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Schema version for automation-task records.
+pub const AUTOMATION_TASK_SCHEMA_VERSION: i64 = 1;
+
+/// A durable automation-task identity.
+///
+/// Contains a stable ID, a user-facing name, a reference to a stored prompt,
+/// required expected-outcome text, and timestamps. Provider, model, tool,
+/// approval, skills, and profile configuration are resolved indirectly
+/// through the referenced stored prompt and its optional profile.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AutomationTask {
+    /// Stable, case-sensitive task identifier.
+    pub id: String,
+    /// User-facing display name.
+    pub name: String,
+    /// ID of the referenced stored prompt.
+    pub stored_prompt_id: String,
+    /// Required prose describing the desired outcome (not independently verified).
+    pub expected_outcome: String,
+    /// When the task was first created.
+    pub created_at: DateTime<Utc>,
+    /// When the task was last updated.
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Input for creating or replacing an automation task.
+///
+/// On replacement, the original creation timestamp is preserved and the
+/// update timestamp advances.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AutomationTaskInput {
+    /// Stable, case-sensitive task identifier.
+    pub id: String,
+    /// User-facing display name.
+    pub name: String,
+    /// ID of the referenced stored prompt (must exist at write time).
+    pub stored_prompt_id: String,
+    /// Required prose describing the desired outcome.
+    pub expected_outcome: String,
+}
+
+/// Validate and normalize an automation-task input.
+///
+/// Trims all fields. Returns `Ok` with normalized values, or `Err` with a
+/// human-readable message when a field is empty after trimming or when a
+/// textual identifier contains control characters.
+pub fn validate_task_input(input: &AutomationTaskInput) -> Result<AutomationTaskInput, String> {
+    let id = validate_text_id(&input.id, "Task ID")?;
+    let name = validate_text_content(&input.name, "Task name")?;
+    let stored_prompt_id = validate_text_id(&input.stored_prompt_id, "Stored prompt ID")?;
+    let expected_outcome = validate_text_content(&input.expected_outcome, "Expected outcome")?;
+    Ok(AutomationTaskInput {
+        id,
+        name,
+        stored_prompt_id,
+        expected_outcome,
+    })
+}
+
+/// Validate a textual identifier: trim, non-empty, no control characters.
+fn validate_text_id(raw: &str, label: &str) -> Result<String, String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err(format!("{} must not be empty", label));
+    }
+    if trimmed.as_bytes().iter().any(|b| b.is_ascii_control()) {
+        return Err(format!("{} must not contain control characters", label));
+    }
+    Ok(trimmed.to_string())
+}
+
+/// Validate a general text field: trim, non-empty. Control characters are
+/// permitted because these fields carry prose (names, descriptions).
+fn validate_text_content(raw: &str, label: &str) -> Result<String, String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err(format!("{} must not be empty", label));
+    }
+    Ok(trimmed.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn valid_input() -> AutomationTaskInput {
+        AutomationTaskInput {
+            id: "daily-report".to_string(),
+            name: "Daily Report".to_string(),
+            stored_prompt_id: "report-prompt".to_string(),
+            expected_outcome: "A summary of today's activity".to_string(),
+        }
+    }
+
+    #[test]
+    fn valid_input_passes_validation() {
+        let input = valid_input();
+        let result = validate_task_input(&input).unwrap();
+        assert_eq!(result.id, "daily-report");
+        assert_eq!(result.name, "Daily Report");
+        assert_eq!(result.stored_prompt_id, "report-prompt");
+        assert_eq!(result.expected_outcome, "A summary of today's activity");
+    }
+
+    #[test]
+    fn input_is_trimmed() {
+        let input = AutomationTaskInput {
+            id: "  daily-report  ".to_string(),
+            name: "  Daily Report  ".to_string(),
+            stored_prompt_id: "  report-prompt  ".to_string(),
+            expected_outcome: "  Summary  ".to_string(),
+        };
+        let result = validate_task_input(&input).unwrap();
+        assert_eq!(result.id, "daily-report");
+        assert_eq!(result.name, "Daily Report");
+        assert_eq!(result.stored_prompt_id, "report-prompt");
+        assert_eq!(result.expected_outcome, "Summary");
+    }
+
+    #[test]
+    fn empty_id_rejected() {
+        let mut input = valid_input();
+        input.id = "   ".to_string();
+        assert!(validate_task_input(&input).is_err());
+    }
+
+    #[test]
+    fn empty_name_rejected() {
+        let mut input = valid_input();
+        input.name = "".to_string();
+        assert!(validate_task_input(&input).is_err());
+    }
+
+    #[test]
+    fn empty_stored_prompt_id_rejected() {
+        let mut input = valid_input();
+        input.stored_prompt_id = "  ".to_string();
+        assert!(validate_task_input(&input).is_err());
+    }
+
+    #[test]
+    fn empty_expected_outcome_rejected() {
+        let mut input = valid_input();
+        input.expected_outcome = "".to_string();
+        assert!(validate_task_input(&input).is_err());
+    }
+
+    #[test]
+    fn control_chars_in_id_rejected() {
+        let mut input = valid_input();
+        input.id = "task\0id".to_string();
+        assert!(validate_task_input(&input).is_err());
+    }
+
+    #[test]
+    fn control_chars_in_stored_prompt_id_rejected() {
+        let mut input = valid_input();
+        input.stored_prompt_id = "prompt\rid".to_string();
+        assert!(validate_task_input(&input).is_err());
+    }
+
+    #[test]
+    fn ids_are_case_sensitive() {
+        let input_a = AutomationTaskInput {
+            id: "TaskA".to_string(),
+            ..valid_input()
+        };
+        let input_b = AutomationTaskInput {
+            id: "taska".to_string(),
+            ..valid_input()
+        };
+        let a = validate_task_input(&input_a).unwrap();
+        let b = validate_task_input(&input_b).unwrap();
+        assert_ne!(a.id, b.id);
+    }
+
+    #[test]
+    fn multiline_expected_outcome_accepted() {
+        let mut input = valid_input();
+        input.expected_outcome = "Line one\nLine two".to_string();
+        let result = validate_task_input(&input).unwrap();
+        assert_eq!(result.expected_outcome, "Line one\nLine two");
+    }
+
+    #[test]
+    fn automation_task_serializes() {
+        let now = Utc::now();
+        let task = AutomationTask {
+            id: "t1".to_string(),
+            name: "Test".to_string(),
+            stored_prompt_id: "p1".to_string(),
+            expected_outcome: "Done".to_string(),
+            created_at: now,
+            updated_at: now,
+        };
+        let json = serde_json::to_string(&task).unwrap();
+        let restored: AutomationTask = serde_json::from_str(&json).unwrap();
+        assert_eq!(task, restored);
+    }
+}

--- a/src/bin/agent_iron.rs
+++ b/src/bin/agent_iron.rs
@@ -1,0 +1,18 @@
+//! `agent-iron` headless CLI binary.
+//!
+//! Run-only task execution: `agent-iron run <task-id> [OPTIONS]`.
+//! See `agent-iron run --help` for usage.
+
+fn main() -> std::process::ExitCode {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("failed to create Tokio runtime");
+
+    let local = tokio::task::LocalSet::new();
+    let code = local.block_on(&runtime, async { iron_core::cli::execute_run(&args).await });
+
+    std::process::ExitCode::from(code as u8)
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,0 +1,623 @@
+//! Command-line interface for the `agent-iron` headless binary.
+//!
+//! The CLI is run-only: `agent-iron run <task-id>` executes an existing
+//! automation task non-interactively. All task/prompt/profile management is
+//! handled by the GUI and typed core APIs.
+//!
+//! ## Precedence
+//!
+//! Command-line values take precedence over `AGENTIRON_*` environment
+//! variables, which take precedence over documented defaults. The task ID is
+//! always a positional argument and is never sourced from an environment
+//! variable.
+//!
+//! ## Exit codes
+//!
+//! | Code | Meaning                       |
+//! |------|-------------------------------|
+//! | 0    | completed                     |
+//! | 2    | usage error                   |
+//! | 3    | configuration or reference    |
+//! | 4    | unsafe policy                 |
+//! | 5    | provider/credential init      |
+//! | 6    | execution failure             |
+//! | 7    | cancelled                     |
+//! | 8    | timed out                     |
+
+use crate::config::{default_config_path, ConfigStore};
+use crate::execution::{AutomationRunErrorCategory, AutomationRunResult, AutomationRunStatus};
+use crate::headless::{bootstrap_headless, run_automation, HeadlessBootstrapError};
+use std::io::Write;
+use std::path::PathBuf;
+use std::time::Duration;
+use tokio_util::sync::CancellationToken;
+
+// ============================================================================
+// Exit codes
+// ============================================================================
+
+pub const EXIT_COMPLETED: i32 = 0;
+pub const EXIT_USAGE: i32 = 2;
+pub const EXIT_CONFIG: i32 = 3;
+pub const EXIT_UNSAFE_POLICY: i32 = 4;
+pub const EXIT_PROVIDER_INIT: i32 = 5;
+pub const EXIT_EXECUTION: i32 = 6;
+pub const EXIT_CANCELLED: i32 = 7;
+pub const EXIT_TIMED_OUT: i32 = 8;
+
+// ============================================================================
+// Output format
+// ============================================================================
+
+/// Output format selection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutputFormat {
+    Text,
+    Json,
+}
+
+// ============================================================================
+// Parsed arguments
+// ============================================================================
+
+/// Parsed CLI arguments.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CliArgs {
+    pub task_id: String,
+    pub config: Option<String>,
+    pub workspace: Option<String>,
+    pub timeout: Option<String>,
+    pub format: Option<String>,
+    pub quiet: bool,
+}
+
+/// Usage error from argument parsing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UsageError {
+    pub message: String,
+}
+
+impl std::fmt::Display for UsageError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for UsageError {}
+
+const USAGE: &str = "\
+Usage: agent-iron run <task-id> [OPTIONS]
+
+Options:
+  --config <path>        Path to ConfigStore database
+  --workspace <dir>      Workspace directory (default: process cwd)
+  --timeout <duration>   Execution timeout (e.g. 30s, 5m, 1h) [required]
+  --format <text|json>   Output format (default: text)
+  --quiet                Suppress progress output on stderr
+  -h, --help             Show this help message";
+
+/// Parse command-line arguments (everything after the program name).
+pub fn parse_args(args: &[String]) -> Result<CliArgs, UsageError> {
+    if args.is_empty() {
+        return Err(UsageError {
+            message: format!("missing 'run' subcommand\n\n{}", USAGE),
+        });
+    }
+
+    let subcommand = args[0].as_str();
+    if subcommand == "-h" || subcommand == "--help" {
+        return Err(UsageError {
+            message: USAGE.to_string(),
+        });
+    }
+    if subcommand != "run" {
+        return Err(UsageError {
+            message: format!(
+                "unknown subcommand '{}': only 'run' is supported\n\n{}",
+                subcommand, USAGE
+            ),
+        });
+    }
+
+    let mut task_id: Option<String> = None;
+    let mut config: Option<String> = None;
+    let mut workspace: Option<String> = None;
+    let mut timeout: Option<String> = None;
+    let mut format: Option<String> = None;
+    let mut quiet = false;
+
+    let rest = &args[1..];
+    let mut i = 0;
+    while i < rest.len() {
+        let arg = &rest[i];
+        match arg.as_str() {
+            "--config" => {
+                i += 1;
+                config = Some(expect_value(rest, i, "--config")?);
+            }
+            "--workspace" => {
+                i += 1;
+                workspace = Some(expect_value(rest, i, "--workspace")?);
+            }
+            "--timeout" => {
+                i += 1;
+                timeout = Some(expect_value(rest, i, "--timeout")?);
+            }
+            "--format" => {
+                i += 1;
+                format = Some(expect_value(rest, i, "--format")?);
+            }
+            "--quiet" => {
+                quiet = true;
+            }
+            "-h" | "--help" => {
+                return Err(UsageError {
+                    message: USAGE.to_string(),
+                });
+            }
+            s if s.starts_with('-') => {
+                return Err(UsageError {
+                    message: format!("unknown option '{}'\n\n{}", s, USAGE),
+                });
+            }
+            s => {
+                if task_id.is_none() {
+                    task_id = Some(s.to_string());
+                } else {
+                    return Err(UsageError {
+                        message: format!("unexpected positional argument '{}'\n\n{}", s, USAGE),
+                    });
+                }
+            }
+        }
+        i += 1;
+    }
+
+    let task_id = task_id.ok_or_else(|| UsageError {
+        message: format!(
+            "missing required <task-id> positional argument\n\n{}",
+            USAGE
+        ),
+    })?;
+
+    Ok(CliArgs {
+        task_id,
+        config,
+        workspace,
+        timeout,
+        format,
+        quiet,
+    })
+}
+
+fn expect_value(args: &[String], idx: usize, flag: &str) -> Result<String, UsageError> {
+    args.get(idx).cloned().ok_or_else(|| UsageError {
+        message: format!("{} requires a value\n\n{}", flag, USAGE),
+    })
+}
+
+// ============================================================================
+// Duration parsing
+// ============================================================================
+
+/// Parse a positive duration string like `30s`, `5m`, `1h`.
+///
+/// Returns an error for zero, negative, or malformed values.
+pub fn parse_duration(s: &str) -> Result<Duration, String> {
+    let trimmed = s.trim();
+    if trimmed.is_empty() {
+        return Err("timeout must not be empty".to_string());
+    }
+
+    let last = trimmed.chars().last().unwrap();
+    let (num_str, multiplier) = match last {
+        's' => (&trimmed[..trimmed.len() - 1], 1u64),
+        'm' => (&trimmed[..trimmed.len() - 1], 60),
+        'h' => (&trimmed[..trimmed.len() - 1], 3600),
+        c if c.is_ascii_digit() => (trimmed, 1u64),
+        _ => {
+            return Err(format!(
+                "invalid timeout unit '{}': use 30s, 5m, or 1h",
+                last
+            ))
+        }
+    };
+
+    let seconds: u64 = num_str.parse().map_err(|_| {
+        format!(
+            "invalid timeout value '{}': expected a positive number",
+            num_str
+        )
+    })?;
+
+    if seconds == 0 {
+        return Err("timeout must be greater than zero".to_string());
+    }
+
+    let total = seconds
+        .checked_mul(multiplier)
+        .ok_or_else(|| "timeout value is too large".to_string())?;
+
+    Ok(Duration::from_secs(total))
+}
+
+// ============================================================================
+// Resolution functions (CLI > env > defaults)
+// ============================================================================
+
+/// Resolve workspace from CLI, environment, or process cwd.
+///
+/// Canonicalizes the path and requires it to be an existing directory.
+pub fn resolve_workspace(cli: Option<&str>, env: Option<&str>) -> Result<PathBuf, String> {
+    let raw = cli.or(env).unwrap_or(".");
+
+    let path = PathBuf::from(raw);
+    if !path.exists() {
+        return Err(format!("workspace does not exist: {}", raw));
+    }
+    if !path.is_dir() {
+        return Err(format!("workspace is not a directory: {}", raw));
+    }
+
+    path.canonicalize()
+        .map_err(|e| format!("failed to canonicalize workspace '{}': {}", raw, e))
+}
+
+/// Resolve the ConfigStore database path from CLI, environment, or default.
+pub fn resolve_config_path(cli: Option<&str>, env: Option<&str>) -> Result<PathBuf, String> {
+    if let Some(p) = cli {
+        return Ok(PathBuf::from(p));
+    }
+    if let Some(p) = env {
+        return Ok(PathBuf::from(p));
+    }
+    default_config_path().map_err(|e| format!("failed to determine default config path: {}", e))
+}
+
+/// Resolve timeout duration from CLI or environment (required).
+pub fn resolve_timeout(cli: Option<&str>, env: Option<&str>) -> Result<Duration, String> {
+    let raw = cli.or(env).ok_or_else(|| {
+        "timeout is required: use --timeout or AGENTIRON_TIMEOUT (e.g. 30s, 5m, 1h)".to_string()
+    })?;
+    parse_duration(raw)
+}
+
+/// Resolve output format from CLI or environment (default: text).
+pub fn resolve_format(cli: Option<&str>, env: Option<&str>) -> Result<OutputFormat, String> {
+    let raw = cli.or(env).unwrap_or("text");
+    match raw.trim().to_lowercase().as_str() {
+        "text" => Ok(OutputFormat::Text),
+        "json" => Ok(OutputFormat::Json),
+        other => Err(format!(
+            "invalid format '{}': expected 'text' or 'json'",
+            other
+        )),
+    }
+}
+
+/// Resolve quiet flag from CLI flag or environment.
+pub fn resolve_quiet(quiet_flag: bool, env: Option<&str>) -> bool {
+    if quiet_flag {
+        return true;
+    }
+    matches!(
+        env.map(|s| s.trim().to_lowercase()),
+        Some(ref s) if s == "1" || s == "true" || s == "yes"
+    )
+}
+
+// ============================================================================
+// Exit-code mapping
+// ============================================================================
+
+/// Map a terminal run status to the stable exit code.
+pub fn exit_code_for_status(status: AutomationRunStatus) -> i32 {
+    match status {
+        AutomationRunStatus::Completed => EXIT_COMPLETED,
+        AutomationRunStatus::Failed => EXIT_EXECUTION,
+        AutomationRunStatus::Cancelled => EXIT_CANCELLED,
+        AutomationRunStatus::TimedOut => EXIT_TIMED_OUT,
+    }
+}
+
+/// Map a run result to the stable exit code, considering the error category
+/// for failed runs.
+pub fn exit_code_for_result(result: &AutomationRunResult) -> i32 {
+    match result.status {
+        AutomationRunStatus::Completed => EXIT_COMPLETED,
+        AutomationRunStatus::Cancelled => EXIT_CANCELLED,
+        AutomationRunStatus::TimedOut => EXIT_TIMED_OUT,
+        AutomationRunStatus::Failed => match result.error.as_ref().map(|e| &e.category) {
+            Some(AutomationRunErrorCategory::Config)
+            | Some(AutomationRunErrorCategory::Reference) => EXIT_CONFIG,
+            Some(AutomationRunErrorCategory::UnsafePolicy) => EXIT_UNSAFE_POLICY,
+            Some(AutomationRunErrorCategory::ProviderInit) => EXIT_PROVIDER_INIT,
+            _ => EXIT_EXECUTION,
+        },
+    }
+}
+
+/// Map a bootstrap error to the stable exit code.
+pub fn exit_code_for_bootstrap_error(err: &HeadlessBootstrapError) -> i32 {
+    match err {
+        HeadlessBootstrapError::MissingDefaultProvider
+        | HeadlessBootstrapError::ProviderInit { .. }
+        | HeadlessBootstrapError::CredentialFailure { .. }
+        | HeadlessBootstrapError::InteractiveAuthRequired { .. } => EXIT_PROVIDER_INIT,
+        HeadlessBootstrapError::UnsafePolicy(_) | HeadlessBootstrapError::UnavailableTool(_) => {
+            EXIT_UNSAFE_POLICY
+        }
+        HeadlessBootstrapError::Config(_) | HeadlessBootstrapError::Resolution(_) => EXIT_CONFIG,
+    }
+}
+
+// ============================================================================
+// Bootstrap-error to result mapping (for JSON failure output)
+// =============================================================================
+
+/// Convert a bootstrap error into an `AutomationRunErrorCategory`.
+fn bootstrap_error_category(err: &HeadlessBootstrapError) -> AutomationRunErrorCategory {
+    match err {
+        HeadlessBootstrapError::MissingDefaultProvider
+        | HeadlessBootstrapError::ProviderInit { .. }
+        | HeadlessBootstrapError::CredentialFailure { .. }
+        | HeadlessBootstrapError::InteractiveAuthRequired { .. } => {
+            AutomationRunErrorCategory::ProviderInit
+        }
+        HeadlessBootstrapError::UnsafePolicy(_) | HeadlessBootstrapError::UnavailableTool(_) => {
+            AutomationRunErrorCategory::UnsafePolicy
+        }
+        HeadlessBootstrapError::Config(_) | HeadlessBootstrapError::Resolution(_) => {
+            AutomationRunErrorCategory::Config
+        }
+    }
+}
+
+// ============================================================================
+// Output formatting
+// ============================================================================
+
+/// Format a run result for text-mode stdout (final assistant text only).
+pub fn format_text_output(result: &AutomationRunResult) -> String {
+    result.output.clone()
+}
+
+/// Format a run result as a single versioned JSON object.
+pub fn format_json_output(result: &AutomationRunResult) -> String {
+    serde_json::to_string_pretty(result).unwrap_or_else(|e| {
+        format!(
+            "{{\"schema_version\":1,\"status\":\"failed\",\"error\":{{\"category\":\"execution\",\"message\":\"failed to serialize result: {}\"}}}}",
+            e
+        )
+    })
+}
+
+// ============================================================================
+// Signal handling
+// ============================================================================
+
+/// Wait for an interrupt (SIGINT) or termination (SIGTERM) signal.
+async fn wait_for_signal() {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{signal, SignalKind};
+        let sigterm = signal(SignalKind::terminate());
+        let mut sigterm = match sigterm {
+            Ok(s) => s,
+            Err(_) => {
+                let _ = tokio::signal::ctrl_c().await;
+                return;
+            }
+        };
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {}
+            _ = sigterm.recv() => {}
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = tokio::signal::ctrl_c().await;
+    }
+}
+
+// ============================================================================
+// Main execution entry point
+// ============================================================================
+
+/// Execute a headless automation run end-to-end.
+///
+/// Returns the process exit code. This function is intended to be called
+/// from the binary's `main` on a `current_thread` Tokio runtime inside a
+/// `LocalSet`.
+pub async fn execute_run(args: &[String]) -> i32 {
+    let env: Vec<(String, String)> = std::env::vars().collect();
+    execute_run_with_streams(
+        args,
+        &mut env.clone(),
+        &mut std::io::stdout(),
+        &mut std::io::stderr(),
+    )
+    .await
+}
+
+/// Execute a headless run using the provided environment variables.
+///
+/// Separated from [`execute_run`] for testability.
+pub async fn execute_run_with_env(args: &[String], env: &mut [(String, String)]) -> i32 {
+    execute_run_with_streams(args, env, &mut std::io::stdout(), &mut std::io::stderr()).await
+}
+
+/// Execute a headless run writing output to the provided writers.
+///
+/// This is the core implementation. Tests pass `Vec<u8>` buffers to capture
+/// stdout and stderr.
+pub async fn execute_run_with_streams(
+    args: &[String],
+    env: &mut [(String, String)],
+    stdout: &mut impl Write,
+    stderr: &mut impl Write,
+) -> i32 {
+    // 1. Parse arguments.
+    let parsed = match parse_args(args) {
+        Ok(p) => p,
+        Err(e) => {
+            let _ = writeln!(stderr, "{}", e.message);
+            return EXIT_USAGE;
+        }
+    };
+
+    // 2. Resolve output format early to know if JSON mode is active.
+    let format = match resolve_format(parsed.format.as_deref(), env_get(env, "AGENTIRON_FORMAT")) {
+        Ok(f) => f,
+        Err(e) => {
+            let _ = writeln!(stderr, "{}", e);
+            return EXIT_USAGE;
+        }
+    };
+
+    let quiet = resolve_quiet(parsed.quiet, env_get(env, "AGENTIRON_QUIET"));
+
+    // Helper: emit a failure and return an exit code.
+    // In JSON mode, constructs a terminal JSON object on stdout.
+    // In text mode, writes the error to stderr.
+    macro_rules! emit_failure {
+        ($category:expr, $message:expr, $exit_code:expr, $workspace:expr) => {{
+            match format {
+                OutputFormat::Json => {
+                    let result = AutomationRunResult::cli_failure(
+                        &parsed.task_id,
+                        $workspace,
+                        $category,
+                        $message,
+                    );
+                    let _ = writeln!(stdout, "{}", format_json_output(&result));
+                }
+                OutputFormat::Text => {
+                    let _ = writeln!(stderr, "{}", &$message);
+                }
+            }
+            return $exit_code;
+        }};
+    }
+
+    // 3. Resolve workspace.
+    let workspace = match resolve_workspace(
+        parsed.workspace.as_deref(),
+        env_get(env, "AGENTIRON_WORKSPACE"),
+    ) {
+        Ok(w) => w,
+        Err(e) => {
+            emit_failure!(
+                AutomationRunErrorCategory::Config,
+                e,
+                EXIT_CONFIG,
+                PathBuf::from(parsed.workspace.as_deref().unwrap_or("."))
+            );
+        }
+    };
+
+    if !quiet {
+        let _ = writeln!(stderr, "workspace: {}", workspace.display());
+    }
+
+    // 4. Resolve timeout (required).
+    let timeout =
+        match resolve_timeout(parsed.timeout.as_deref(), env_get(env, "AGENTIRON_TIMEOUT")) {
+            Ok(t) => t,
+            Err(e) => {
+                emit_failure!(AutomationRunErrorCategory::Config, e, EXIT_USAGE, workspace);
+            }
+        };
+
+    if !quiet {
+        let _ = writeln!(stderr, "timeout: {:?}", timeout);
+    }
+
+    // 5. Resolve config path and open ConfigStore.
+    let config_path =
+        match resolve_config_path(parsed.config.as_deref(), env_get(env, "AGENTIRON_CONFIG")) {
+            Ok(p) => p,
+            Err(e) => {
+                emit_failure!(
+                    AutomationRunErrorCategory::Config,
+                    e,
+                    EXIT_CONFIG,
+                    workspace
+                );
+            }
+        };
+
+    if !quiet {
+        let _ = writeln!(stderr, "config: {}", config_path.display());
+    }
+
+    let store = match ConfigStore::open_at(&config_path).await {
+        Ok(s) => s,
+        Err(e) => {
+            emit_failure!(
+                AutomationRunErrorCategory::Config,
+                format!("failed to open config store: {}", e),
+                EXIT_CONFIG,
+                workspace
+            );
+        }
+    };
+
+    // 6. Bootstrap headless runtime.
+    if !quiet {
+        let _ = writeln!(stderr, "bootstrapping headless runtime...");
+    }
+
+    let headless = match bootstrap_headless(store, &parsed.task_id, workspace.clone()).await {
+        Ok(h) => h,
+        Err(e) => {
+            let code = exit_code_for_bootstrap_error(&e);
+            emit_failure!(bootstrap_error_category(&e), e.to_string(), code, workspace);
+        }
+    };
+
+    if !quiet {
+        let _ = writeln!(
+            stderr,
+            "running task '{}' with provider '{}' model '{}'",
+            parsed.task_id, headless.provider_slug, headless.model
+        );
+    }
+
+    // 7. Set up signal handler.
+    let cancel = CancellationToken::new();
+    let signal_cancel = cancel.clone();
+    tokio::spawn(async move {
+        wait_for_signal().await;
+        signal_cancel.cancel();
+    });
+
+    // 8. Execute the automation run.
+    let result = run_automation(headless, timeout, cancel).await;
+
+    // 9. Format and emit output.
+    match format {
+        OutputFormat::Text => {
+            let text = format_text_output(&result);
+            let _ = writeln!(stdout, "{}", text);
+        }
+        OutputFormat::Json => {
+            let json = format_json_output(&result);
+            let _ = writeln!(stdout, "{}", json);
+        }
+    }
+
+    exit_code_for_result(&result)
+}
+
+/// Look up an environment variable from a collected vector.
+fn env_get<'a>(env: &'a [(String, String)], key: &str) -> Option<&'a str> {
+    env.iter().find(|(k, _)| k == key).map(|(_, v)| v.as_str())
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -89,12 +89,12 @@ const USAGE: &str = "\
 Usage: agent-iron run <task-id> [OPTIONS]
 
 Options:
-  --config <path>        Path to ConfigStore database
-  --workspace <dir>      Workspace directory (default: process cwd)
-  --timeout <duration>   Execution timeout (e.g. 30s, 5m, 1h) [required]
-  --format <text|json>   Output format (default: text)
-  --quiet                Suppress progress output on stderr
-  -h, --help             Show this help message";
+  -c, --config <path>     Path to ConfigStore database
+  --workspace <dir>       Workspace directory (default: process cwd)
+  --timeout <duration>    Execution timeout (e.g. 30s, 5m, 1h) [required]
+  -o, --format <text|json> Output format (default: text)
+  -q, --quiet             Suppress progress output on stderr
+  -h, --help              Show this help message";
 
 /// Parse command-line arguments (everything after the program name).
 pub fn parse_args(args: &[String]) -> Result<CliArgs, UsageError> {
@@ -131,7 +131,7 @@ pub fn parse_args(args: &[String]) -> Result<CliArgs, UsageError> {
     while i < rest.len() {
         let arg = &rest[i];
         match arg.as_str() {
-            "--config" => {
+            "--config" | "-c" => {
                 i += 1;
                 config = Some(expect_value(rest, i, "--config")?);
             }
@@ -143,11 +143,11 @@ pub fn parse_args(args: &[String]) -> Result<CliArgs, UsageError> {
                 i += 1;
                 timeout = Some(expect_value(rest, i, "--timeout")?);
             }
-            "--format" => {
+            "--format" | "-o" => {
                 i += 1;
                 format = Some(expect_value(rest, i, "--format")?);
             }
-            "--quiet" => {
+            "--quiet" | "-q" => {
                 quiet = true;
             }
             "-h" | "--help" => {
@@ -194,6 +194,34 @@ fn expect_value(args: &[String], idx: usize, flag: &str) -> Result<String, Usage
     args.get(idx).cloned().ok_or_else(|| UsageError {
         message: format!("{} requires a value\n\n{}", flag, USAGE),
     })
+}
+
+/// Lightweight raw scan of args to detect a JSON output request
+/// (`--format json`, `-o json`, or `--format=json`) without a full parse.
+///
+/// Used to honor the JSON output contract for usage errors that occur before
+/// argument parsing completes.
+fn raw_args_request_json(args: &[String]) -> bool {
+    let mut i = 0;
+    while i < args.len() {
+        let a = args[i].as_str();
+        if a == "--format" || a == "-o" {
+            if let Some(v) = args.get(i + 1) {
+                if v.trim().eq_ignore_ascii_case("json") {
+                    return true;
+                }
+            }
+            i += 2;
+            continue;
+        }
+        if let Some(v) = a.strip_prefix("--format=") {
+            if v.trim().eq_ignore_ascii_case("json") {
+                return true;
+            }
+        }
+        i += 1;
+    }
+    false
 }
 
 // ============================================================================
@@ -457,11 +485,28 @@ pub async fn execute_run_with_streams(
     stdout: &mut impl Write,
     stderr: &mut impl Write,
 ) -> i32 {
+    // Detect JSON output mode from raw args/env so that usage errors emitted
+    // before or during argument parsing still honor the JSON output contract.
+    let json_mode = raw_args_request_json(args)
+        || env_get(env, "AGENTIRON_FORMAT")
+            .map(|v| v.trim().eq_ignore_ascii_case("json"))
+            .unwrap_or(false);
+
     // 1. Parse arguments.
     let parsed = match parse_args(args) {
         Ok(p) => p,
         Err(e) => {
-            let _ = writeln!(stderr, "{}", e.message);
+            if json_mode {
+                let result = AutomationRunResult::cli_failure(
+                    "unknown",
+                    PathBuf::from("."),
+                    AutomationRunErrorCategory::Config,
+                    e.message.clone(),
+                );
+                let _ = writeln!(stdout, "{}", format_json_output(&result));
+            } else {
+                let _ = writeln!(stderr, "{}", e.message);
+            }
             return EXIT_USAGE;
         }
     };

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -115,6 +115,79 @@ fn parse_help_shorthand() {
     assert!(err.message.contains("Usage:"));
 }
 
+#[test]
+fn parse_short_flag_aliases() {
+    let args = vec![
+        "run".to_string(),
+        "daily-report".to_string(),
+        "-c".to_string(),
+        "/etc/iron.db".to_string(),
+        "-o".to_string(),
+        "json".to_string(),
+        "-q".to_string(),
+    ];
+    let parsed = parse_args(&args).unwrap();
+    assert_eq!(parsed.task_id, "daily-report");
+    assert_eq!(parsed.config.as_deref(), Some("/etc/iron.db"));
+    assert_eq!(parsed.format.as_deref(), Some("json"));
+    assert!(parsed.quiet);
+}
+
+#[test]
+fn parse_short_config_without_value_errors() {
+    let args = vec!["run".to_string(), "task".to_string(), "-c".to_string()];
+    let err = parse_args(&args).unwrap_err();
+    assert!(err.message.contains("--config requires a value"));
+}
+
+// ============================================================================
+// Raw JSON detection (pre-parse usage-error contract)
+// ============================================================================
+
+#[test]
+fn raw_json_detects_long_flag() {
+    let args = vec![
+        "run".to_string(),
+        "--format".to_string(),
+        "json".to_string(),
+    ];
+    assert!(raw_args_request_json(&args));
+}
+
+#[test]
+fn raw_json_detects_short_flag() {
+    let args = vec!["run".to_string(), "-o".to_string(), "json".to_string()];
+    assert!(raw_args_request_json(&args));
+}
+
+#[test]
+fn raw_json_detects_equals_form() {
+    let args = vec!["--format=json".to_string()];
+    assert!(raw_args_request_json(&args));
+}
+
+#[test]
+fn raw_json_case_insensitive() {
+    let args = vec!["--format".to_string(), "JSON".to_string()];
+    assert!(raw_args_request_json(&args));
+}
+
+#[test]
+fn raw_json_false_for_text_format() {
+    let args = vec![
+        "run".to_string(),
+        "--format".to_string(),
+        "text".to_string(),
+    ];
+    assert!(!raw_args_request_json(&args));
+}
+
+#[test]
+fn raw_json_false_when_absent() {
+    let args = vec!["run".to_string(), "task".to_string()];
+    assert!(!raw_args_request_json(&args));
+}
+
 // ============================================================================
 // Duration parsing
 // ============================================================================

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -1,0 +1,557 @@
+use super::*;
+use crate::execution::{AutomationRunErrorCategory, AutomationRunStatus};
+use std::time::Duration;
+
+// ============================================================================
+// Argument parsing
+// ============================================================================
+
+#[test]
+fn parse_minimal_valid() {
+    let args = vec!["run".to_string(), "my-task".to_string()];
+    let parsed = parse_args(&args).unwrap();
+    assert_eq!(parsed.task_id, "my-task");
+    assert_eq!(parsed.config, None);
+    assert_eq!(parsed.workspace, None);
+    assert_eq!(parsed.timeout, None);
+    assert_eq!(parsed.format, None);
+    assert!(!parsed.quiet);
+}
+
+#[test]
+fn parse_all_options() {
+    let args = vec![
+        "run".to_string(),
+        "daily-report".to_string(),
+        "--config".to_string(),
+        "/etc/iron.db".to_string(),
+        "--workspace".to_string(),
+        "/tmp/work".to_string(),
+        "--timeout".to_string(),
+        "30s".to_string(),
+        "--format".to_string(),
+        "json".to_string(),
+        "--quiet".to_string(),
+    ];
+    let parsed = parse_args(&args).unwrap();
+    assert_eq!(parsed.task_id, "daily-report");
+    assert_eq!(parsed.config.as_deref(), Some("/etc/iron.db"));
+    assert_eq!(parsed.workspace.as_deref(), Some("/tmp/work"));
+    assert_eq!(parsed.timeout.as_deref(), Some("30s"));
+    assert_eq!(parsed.format.as_deref(), Some("json"));
+    assert!(parsed.quiet);
+}
+
+#[test]
+fn parse_options_before_task_id() {
+    let args = vec![
+        "run".to_string(),
+        "--timeout".to_string(),
+        "5m".to_string(),
+        "report".to_string(),
+    ];
+    let parsed = parse_args(&args).unwrap();
+    assert_eq!(parsed.task_id, "report");
+    assert_eq!(parsed.timeout.as_deref(), Some("5m"));
+}
+
+#[test]
+fn parse_missing_subcommand() {
+    let args: Vec<String> = vec![];
+    let err = parse_args(&args).unwrap_err();
+    assert!(err.message.contains("missing 'run'"));
+}
+
+#[test]
+fn parse_unknown_subcommand() {
+    let args = vec!["create".to_string(), "task".to_string()];
+    let err = parse_args(&args).unwrap_err();
+    assert!(err.message.contains("unknown subcommand"));
+}
+
+#[test]
+fn parse_missing_task_id() {
+    let args = vec!["run".to_string()];
+    let err = parse_args(&args).unwrap_err();
+    assert!(err.message.contains("missing required <task-id>"));
+}
+
+#[test]
+fn parse_unknown_option() {
+    let args = vec!["run".to_string(), "task".to_string(), "--bogus".to_string()];
+    let err = parse_args(&args).unwrap_err();
+    assert!(err.message.contains("unknown option"));
+}
+
+#[test]
+fn parse_option_without_value() {
+    let args = vec![
+        "run".to_string(),
+        "task".to_string(),
+        "--timeout".to_string(),
+    ];
+    let err = parse_args(&args).unwrap_err();
+    assert!(err.message.contains("--timeout requires a value"));
+}
+
+#[test]
+fn parse_extra_positional() {
+    let args = vec!["run".to_string(), "task1".to_string(), "task2".to_string()];
+    let err = parse_args(&args).unwrap_err();
+    assert!(err.message.contains("unexpected positional"));
+}
+
+#[test]
+fn parse_help_flag() {
+    let args = vec!["--help".to_string()];
+    let err = parse_args(&args).unwrap_err();
+    assert!(err.message.contains("Usage:"));
+}
+
+#[test]
+fn parse_help_shorthand() {
+    let args = vec!["run".to_string(), "task".to_string(), "-h".to_string()];
+    let err = parse_args(&args).unwrap_err();
+    assert!(err.message.contains("Usage:"));
+}
+
+// ============================================================================
+// Duration parsing
+// ============================================================================
+
+#[test]
+fn duration_seconds() {
+    assert_eq!(parse_duration("30s").unwrap(), Duration::from_secs(30));
+    assert_eq!(parse_duration("1s").unwrap(), Duration::from_secs(1));
+    assert_eq!(parse_duration("600s").unwrap(), Duration::from_secs(600));
+}
+
+#[test]
+fn duration_minutes() {
+    assert_eq!(parse_duration("5m").unwrap(), Duration::from_secs(300));
+    assert_eq!(parse_duration("1m").unwrap(), Duration::from_secs(60));
+}
+
+#[test]
+fn duration_hours() {
+    assert_eq!(parse_duration("1h").unwrap(), Duration::from_secs(3600));
+    assert_eq!(parse_duration("2h").unwrap(), Duration::from_secs(7200));
+}
+
+#[test]
+fn duration_bare_seconds() {
+    assert_eq!(parse_duration("45").unwrap(), Duration::from_secs(45));
+}
+
+#[test]
+fn duration_rejects_zero() {
+    assert!(parse_duration("0s").is_err());
+    assert!(parse_duration("0").is_err());
+    assert!(parse_duration("0m").is_err());
+}
+
+#[test]
+fn duration_rejects_empty() {
+    assert!(parse_duration("").is_err());
+    assert!(parse_duration("   ").is_err());
+}
+
+#[test]
+fn duration_rejects_invalid_unit() {
+    assert!(parse_duration("30x").is_err());
+    assert!(parse_duration("30d").is_err());
+}
+
+#[test]
+fn duration_rejects_non_numeric() {
+    assert!(parse_duration("abcs").is_err());
+    assert!(parse_duration("--5s").is_err());
+}
+
+#[test]
+fn duration_trims_whitespace() {
+    assert_eq!(parse_duration("  30s  ").unwrap(), Duration::from_secs(30));
+}
+
+// ============================================================================
+// Workspace resolution
+// ============================================================================
+
+#[test]
+fn resolve_workspace_uses_cli() {
+    let env = vec![(
+        "AGENTIRON_WORKSPACE".to_string(),
+        "/nonexistent-env".to_string(),
+    )];
+    let env_ref: Vec<(String, String)> = env;
+    let w = resolve_workspace(Some("."), env_get(&env_ref, "AGENTIRON_WORKSPACE"));
+    assert!(w.is_ok());
+    // Should resolve to cwd, not the env value
+    assert!(w.unwrap().is_absolute());
+}
+
+#[test]
+fn resolve_workspace_uses_env() {
+    let env_val = std::env::current_dir()
+        .unwrap()
+        .to_string_lossy()
+        .to_string();
+    let env = vec![("AGENTIRON_WORKSPACE".to_string(), env_val.clone())];
+    let w = resolve_workspace(None, env_get(&env, "AGENTIRON_WORKSPACE"));
+    assert!(w.is_ok());
+    assert_eq!(w.unwrap(), PathBuf::from(env_val).canonicalize().unwrap());
+}
+
+#[test]
+fn resolve_workspace_defaults_to_cwd() {
+    let w = resolve_workspace(None, None).unwrap();
+    let cwd = std::env::current_dir().unwrap().canonicalize().unwrap();
+    assert_eq!(w, cwd);
+}
+
+#[test]
+fn resolve_workspace_rejects_nonexistent() {
+    let err = resolve_workspace(Some("/nonexistent/path/xyz"), None).unwrap_err();
+    assert!(err.contains("does not exist"));
+}
+
+#[test]
+fn resolve_workspace_rejects_file() {
+    let err = resolve_workspace(Some("/etc/hostname"), None);
+    match err {
+        Ok(path) => {
+            // On some systems /etc/hostname might not exist; if it does,
+            // it should be rejected.
+            if path.exists() && !path.is_dir() {
+                panic!("expected error for file as workspace");
+            }
+        }
+        Err(e) => {
+            assert!(e.contains("not a directory") || e.contains("does not exist"));
+        }
+    }
+}
+
+// ============================================================================
+// Timeout resolution
+// ============================================================================
+
+#[test]
+fn resolve_timeout_from_cli() {
+    let t = resolve_timeout(Some("5m"), Some("1h")).unwrap();
+    assert_eq!(t, Duration::from_secs(300));
+}
+
+#[test]
+fn resolve_timeout_from_env() {
+    let t = resolve_timeout(None, Some("1h")).unwrap();
+    assert_eq!(t, Duration::from_secs(3600));
+}
+
+#[test]
+fn resolve_timeout_missing() {
+    let err = resolve_timeout(None, None).unwrap_err();
+    assert!(err.contains("required"));
+}
+
+#[test]
+fn resolve_timeout_invalid_value() {
+    let err = resolve_timeout(Some("0s"), None).unwrap_err();
+    assert!(err.contains("greater than zero"));
+}
+
+// ============================================================================
+// Format resolution
+// ============================================================================
+
+#[test]
+fn resolve_format_default_text() {
+    assert_eq!(resolve_format(None, None).unwrap(), OutputFormat::Text);
+}
+
+#[test]
+fn resolve_format_from_cli() {
+    assert_eq!(
+        resolve_format(Some("json"), Some("text")).unwrap(),
+        OutputFormat::Json
+    );
+}
+
+#[test]
+fn resolve_format_from_env() {
+    assert_eq!(
+        resolve_format(None, Some("json")).unwrap(),
+        OutputFormat::Json
+    );
+}
+
+#[test]
+fn resolve_format_case_insensitive() {
+    assert_eq!(
+        resolve_format(Some("JSON"), None).unwrap(),
+        OutputFormat::Json
+    );
+    assert_eq!(
+        resolve_format(Some("Text"), None).unwrap(),
+        OutputFormat::Text
+    );
+}
+
+#[test]
+fn resolve_format_invalid() {
+    assert!(resolve_format(Some("xml"), None).is_err());
+}
+
+// ============================================================================
+// Quiet resolution
+// ============================================================================
+
+#[test]
+fn resolve_quiet_from_flag() {
+    assert!(resolve_quiet(true, Some("false")));
+}
+
+#[test]
+fn resolve_quiet_from_env() {
+    assert!(resolve_quiet(false, Some("true")));
+    assert!(resolve_quiet(false, Some("1")));
+    assert!(resolve_quiet(false, Some("yes")));
+}
+
+#[test]
+fn resolve_quiet_default_false() {
+    assert!(!resolve_quiet(false, None));
+    assert!(!resolve_quiet(false, Some("no")));
+    assert!(!resolve_quiet(false, Some("0")));
+}
+
+// ============================================================================
+// Exit-code mapping
+// ============================================================================
+
+#[test]
+fn exit_code_completed() {
+    assert_eq!(exit_code_for_status(AutomationRunStatus::Completed), 0);
+}
+
+#[test]
+fn exit_code_failed() {
+    assert_eq!(exit_code_for_status(AutomationRunStatus::Failed), 6);
+}
+
+#[test]
+fn exit_code_cancelled() {
+    assert_eq!(exit_code_for_status(AutomationRunStatus::Cancelled), 7);
+}
+
+#[test]
+fn exit_code_timed_out() {
+    assert_eq!(exit_code_for_status(AutomationRunStatus::TimedOut), 8);
+}
+
+#[test]
+fn exit_code_for_result_failed_unsafe_policy() {
+    let now = chrono::Utc::now();
+    let mut result = AutomationRunResult::started(
+        &crate::automation_task::AutomationTask {
+            id: "t".to_string(),
+            name: "T".to_string(),
+            stored_prompt_id: "p".to_string(),
+            expected_outcome: "o".to_string(),
+            created_at: now,
+            updated_at: now,
+        },
+        std::path::PathBuf::from("/w"),
+    );
+    result.fail(
+        AutomationRunErrorCategory::UnsafePolicy,
+        "tool not available".to_string(),
+    );
+    assert_eq!(exit_code_for_result(&result), EXIT_UNSAFE_POLICY);
+}
+
+#[test]
+fn exit_code_for_result_failed_execution() {
+    let now = chrono::Utc::now();
+    let mut result = AutomationRunResult::started(
+        &crate::automation_task::AutomationTask {
+            id: "t".to_string(),
+            name: "T".to_string(),
+            stored_prompt_id: "p".to_string(),
+            expected_outcome: "o".to_string(),
+            created_at: now,
+            updated_at: now,
+        },
+        std::path::PathBuf::from("/w"),
+    );
+    result.fail(
+        AutomationRunErrorCategory::Execution,
+        "provider error".to_string(),
+    );
+    assert_eq!(exit_code_for_result(&result), EXIT_EXECUTION);
+}
+
+#[test]
+fn exit_code_for_result_completed() {
+    let now = chrono::Utc::now();
+    let mut result = AutomationRunResult::started(
+        &crate::automation_task::AutomationTask {
+            id: "t".to_string(),
+            name: "T".to_string(),
+            stored_prompt_id: "p".to_string(),
+            expected_outcome: "o".to_string(),
+            created_at: now,
+            updated_at: now,
+        },
+        std::path::PathBuf::from("/w"),
+    );
+    result.complete("done".to_string());
+    assert_eq!(exit_code_for_result(&result), EXIT_COMPLETED);
+}
+
+#[test]
+fn exit_code_for_result_failed_config() {
+    let now = chrono::Utc::now();
+    let mut result = AutomationRunResult::started(
+        &crate::automation_task::AutomationTask {
+            id: "t".to_string(),
+            name: "T".to_string(),
+            stored_prompt_id: "p".to_string(),
+            expected_outcome: "o".to_string(),
+            created_at: now,
+            updated_at: now,
+        },
+        std::path::PathBuf::from("/w"),
+    );
+    result.fail(
+        AutomationRunErrorCategory::Config,
+        "config error".to_string(),
+    );
+    assert_eq!(exit_code_for_result(&result), EXIT_CONFIG);
+}
+
+#[test]
+fn exit_code_for_missing_default() {
+    assert_eq!(
+        exit_code_for_bootstrap_error(&HeadlessBootstrapError::MissingDefaultProvider),
+        EXIT_PROVIDER_INIT
+    );
+}
+
+#[test]
+fn exit_code_for_provider_init() {
+    assert_eq!(
+        exit_code_for_bootstrap_error(&HeadlessBootstrapError::ProviderInit {
+            provider: "openai".to_string(),
+            reason: "timeout".to_string()
+        }),
+        EXIT_PROVIDER_INIT
+    );
+}
+
+#[test]
+fn exit_code_for_unsafe_policy() {
+    assert_eq!(
+        exit_code_for_bootstrap_error(&HeadlessBootstrapError::UnsafePolicy("PerTool".to_string())),
+        EXIT_UNSAFE_POLICY
+    );
+}
+
+#[test]
+fn exit_code_for_unavailable_tool() {
+    assert_eq!(
+        exit_code_for_bootstrap_error(&HeadlessBootstrapError::UnavailableTool(
+            "plugin_x".to_string()
+        )),
+        EXIT_UNSAFE_POLICY
+    );
+}
+
+#[test]
+fn exit_code_for_config_error() {
+    assert_eq!(
+        exit_code_for_bootstrap_error(&HeadlessBootstrapError::Config(
+            crate::config::ConfigError::Path("bad".to_string())
+        )),
+        EXIT_CONFIG
+    );
+}
+
+#[test]
+fn exit_code_for_resolution_error() {
+    assert_eq!(
+        exit_code_for_bootstrap_error(&HeadlessBootstrapError::Resolution(
+            crate::execution::ResolutionError::TaskNotFound("x".to_string())
+        )),
+        EXIT_CONFIG
+    );
+}
+
+// ============================================================================
+// Output formatting
+// ============================================================================
+
+#[test]
+fn text_output_returns_final_text() {
+    let result = AutomationRunResult::cli_failure(
+        "task1",
+        PathBuf::from("/tmp"),
+        AutomationRunErrorCategory::Execution,
+        "test error".to_string(),
+    );
+    // cli_failure has empty output
+    assert_eq!(format_text_output(&result), "");
+}
+
+#[test]
+fn json_output_is_valid_json_with_schema_version() {
+    let result = AutomationRunResult::cli_failure(
+        "task1",
+        PathBuf::from("/tmp"),
+        AutomationRunErrorCategory::Config,
+        "config error".to_string(),
+    );
+    let json = format_json_output(&result);
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(parsed["schema_version"], 1);
+    assert_eq!(parsed["status"], "failed");
+    assert_eq!(parsed["task_id"], "task1");
+    assert_eq!(parsed["error"]["category"], "config");
+    assert_eq!(parsed["error"]["message"], "config error");
+}
+
+// ============================================================================
+// Config path resolution
+// ============================================================================
+
+#[test]
+fn resolve_config_from_cli() {
+    let p = resolve_config_path(Some("/custom/path.db"), Some("/env/path.db")).unwrap();
+    assert_eq!(p, PathBuf::from("/custom/path.db"));
+}
+
+#[test]
+fn resolve_config_from_env() {
+    let p = resolve_config_path(None, Some("/env/path.db")).unwrap();
+    assert_eq!(p, PathBuf::from("/env/path.db"));
+}
+
+// ============================================================================
+// Env helper
+// ============================================================================
+
+#[test]
+fn env_get_finds_key() {
+    let env = vec![
+        ("FOO".to_string(), "bar".to_string()),
+        ("BAZ".to_string(), "qux".to_string()),
+    ];
+    assert_eq!(env_get(&env, "FOO"), Some("bar"));
+    assert_eq!(env_get(&env, "BAZ"), Some("qux"));
+}
+
+#[test]
+fn env_get_returns_none_for_missing() {
+    let env = vec![("FOO".to_string(), "bar".to_string())];
+    assert_eq!(env_get(&env, "MISSING"), None);
+}

--- a/src/config/automation_task_tests.rs
+++ b/src/config/automation_task_tests.rs
@@ -1,0 +1,288 @@
+use crate::automation_task::{AutomationTaskInput, AUTOMATION_TASK_SCHEMA_VERSION};
+use crate::config::records::PromptInput;
+use crate::config::{ConfigError, ConfigStore};
+use serde_json::json;
+use sqlx::Row;
+
+async fn setup_store() -> ConfigStore {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+    // Seed a prompt so tasks can reference it.
+    store
+        .set_prompt(&PromptInput {
+            id: "prompt-1".to_string(),
+            schema_version: crate::stored_prompt::STORED_PROMPT_SCHEMA_VERSION,
+            payload: json!({
+                "instructions": "Do the thing",
+                "skills": [],
+            }),
+        })
+        .await
+        .unwrap();
+    store
+}
+
+fn task_input(id: &str, prompt_id: &str) -> AutomationTaskInput {
+    AutomationTaskInput {
+        id: id.to_string(),
+        name: format!("Task {}", id),
+        stored_prompt_id: prompt_id.to_string(),
+        expected_outcome: "Done".to_string(),
+    }
+}
+
+#[tokio::test]
+async fn task_crud_create_get_list_delete() {
+    let store = setup_store().await;
+
+    // Create
+    let task = store
+        .set_automation_task(&task_input("daily-report", "prompt-1"))
+        .await
+        .unwrap();
+    assert_eq!(task.id, "daily-report");
+    assert_eq!(task.name, "Task daily-report");
+    assert_eq!(task.stored_prompt_id, "prompt-1");
+    assert_eq!(task.expected_outcome, "Done");
+    assert_eq!(task.created_at, task.updated_at);
+
+    // Get
+    let fetched = store
+        .get_automation_task("daily-report")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(fetched, task);
+
+    // Delete
+    store.delete_automation_task("daily-report").await.unwrap();
+    assert!(store
+        .get_automation_task("daily-report")
+        .await
+        .unwrap()
+        .is_none());
+
+    // Prompt remains
+    assert!(store.get_prompt("prompt-1").await.unwrap().is_some());
+}
+
+#[tokio::test]
+async fn task_list_is_deterministic_by_id() {
+    let store = setup_store().await;
+    store
+        .set_automation_task(&task_input("charlie", "prompt-1"))
+        .await
+        .unwrap();
+    store
+        .set_automation_task(&task_input("alpha", "prompt-1"))
+        .await
+        .unwrap();
+    store
+        .set_automation_task(&task_input("bravo", "prompt-1"))
+        .await
+        .unwrap();
+
+    let list = store.list_automation_tasks().await.unwrap();
+    let ids: Vec<&str> = list.iter().map(|t| t.id.as_str()).collect();
+    assert_eq!(ids, vec!["alpha", "bravo", "charlie"]);
+
+    // Repeat — same order.
+    let list2 = store.list_automation_tasks().await.unwrap();
+    let ids2: Vec<&str> = list2.iter().map(|t| t.id.as_str()).collect();
+    assert_eq!(ids, ids2);
+}
+
+#[tokio::test]
+async fn task_replacement_preserves_created_at_and_advances_updated_at() {
+    let store = setup_store().await;
+    let original = store
+        .set_automation_task(&task_input("t1", "prompt-1"))
+        .await
+        .unwrap();
+
+    // Small delay so timestamps differ.
+    tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
+
+    let updated_input = AutomationTaskInput {
+        id: "t1".to_string(),
+        name: "Updated Name".to_string(),
+        stored_prompt_id: "prompt-1".to_string(),
+        expected_outcome: "New outcome".to_string(),
+    };
+    let updated = store.set_automation_task(&updated_input).await.unwrap();
+
+    assert_eq!(updated.created_at, original.created_at);
+    assert_ne!(updated.updated_at, original.updated_at);
+    assert!(updated.updated_at > original.updated_at);
+    assert_eq!(updated.name, "Updated Name");
+    assert_eq!(updated.expected_outcome, "New outcome");
+}
+
+#[tokio::test]
+async fn task_missing_prompt_rejected() {
+    let store = setup_store().await;
+    let result = store
+        .set_automation_task(&task_input("t1", "nonexistent-prompt"))
+        .await;
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        ConfigError::UnknownStoredPrompt(prompt_id) => {
+            assert_eq!(prompt_id, "nonexistent-prompt");
+        }
+        other => panic!("expected UnknownStoredPrompt, got {:?}", other),
+    }
+
+    // Task was not persisted.
+    assert!(store.get_automation_task("t1").await.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn task_validation_rejects_empty_fields() {
+    let store = setup_store().await;
+
+    let bad_input = AutomationTaskInput {
+        id: "  ".to_string(),
+        name: "Name".to_string(),
+        stored_prompt_id: "prompt-1".to_string(),
+        expected_outcome: "Done".to_string(),
+    };
+    let result = store.set_automation_task(&bad_input).await;
+    assert!(matches!(result, Err(ConfigError::Validation(_))));
+}
+
+#[tokio::test]
+async fn task_delete_preserves_prompt() {
+    let store = setup_store().await;
+    store
+        .set_automation_task(&task_input("t1", "prompt-1"))
+        .await
+        .unwrap();
+    store.delete_automation_task("t1").await.unwrap();
+    assert!(store.get_prompt("prompt-1").await.unwrap().is_some());
+}
+
+#[tokio::test]
+async fn prompt_deletion_blocked_when_task_references_it() {
+    let store = setup_store().await;
+    store
+        .set_automation_task(&task_input("t1", "prompt-1"))
+        .await
+        .unwrap();
+    store
+        .set_automation_task(&task_input("t2", "prompt-1"))
+        .await
+        .unwrap();
+
+    let result = store.delete_prompt("prompt-1").await;
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        ConfigError::PromptReferencedByTasks {
+            prompt_id,
+            task_ids,
+        } => {
+            assert_eq!(prompt_id, "prompt-1");
+            assert_eq!(task_ids, vec!["t1", "t2"]);
+        }
+        other => panic!("expected PromptReferencedByTasks, got {:?}", other),
+    }
+
+    // Prompt and tasks remain.
+    assert!(store.get_prompt("prompt-1").await.unwrap().is_some());
+    assert!(store.get_automation_task("t1").await.unwrap().is_some());
+    assert!(store.get_automation_task("t2").await.unwrap().is_some());
+}
+
+#[tokio::test]
+async fn prompt_deletion_allowed_when_no_task_references_it() {
+    let store = setup_store().await;
+    store.delete_prompt("prompt-1").await.unwrap();
+    assert!(store.get_prompt("prompt-1").await.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn tasks_referencing_prompt_helper() {
+    let store = setup_store().await;
+    store
+        .set_automation_task(&task_input("t1", "prompt-1"))
+        .await
+        .unwrap();
+
+    let refs = store.tasks_referencing_prompt("prompt-1").await.unwrap();
+    assert_eq!(refs, vec!["t1"]);
+
+    let no_refs = store.tasks_referencing_prompt("other").await.unwrap();
+    assert!(no_refs.is_empty());
+}
+
+#[tokio::test]
+async fn task_input_is_trimmed_on_store() {
+    let store = setup_store().await;
+    let input = AutomationTaskInput {
+        id: "  spaced-id  ".to_string(),
+        name: "  Spaced  ".to_string(),
+        stored_prompt_id: "  prompt-1  ".to_string(),
+        expected_outcome: "  Outcome  ".to_string(),
+    };
+    let task = store.set_automation_task(&input).await.unwrap();
+    assert_eq!(task.id, "spaced-id");
+    assert_eq!(task.name, "Spaced");
+    assert_eq!(task.stored_prompt_id, "prompt-1");
+    assert_eq!(task.expected_outcome, "Outcome");
+}
+
+#[tokio::test]
+async fn schema_version_is_stored() {
+    let store = setup_store().await;
+    store
+        .set_automation_task(&task_input("t1", "prompt-1"))
+        .await
+        .unwrap();
+
+    // Verify the schema_version column directly.
+    let row = sqlx::query("SELECT schema_version FROM automation_tasks WHERE id = ?")
+        .bind("t1")
+        .fetch_one(store.pool())
+        .await
+        .unwrap();
+    let sv: i64 = row.get("schema_version");
+    assert_eq!(sv, AUTOMATION_TASK_SCHEMA_VERSION);
+}
+
+#[tokio::test]
+async fn get_rejects_unsupported_schema_version() {
+    let store = setup_store().await;
+    store
+        .set_automation_task(&task_input("t1", "prompt-1"))
+        .await
+        .unwrap();
+
+    // Tamper: set an unsupported schema version.
+    sqlx::query("UPDATE automation_tasks SET schema_version = ? WHERE id = ?")
+        .bind(999)
+        .bind("t1")
+        .execute(store.pool())
+        .await
+        .unwrap();
+
+    let result = store.get_automation_task("t1").await;
+    assert!(matches!(result, Err(ConfigError::Deserialization(_))));
+}
+
+#[tokio::test]
+async fn list_rejects_unsupported_schema_version() {
+    let store = setup_store().await;
+    store
+        .set_automation_task(&task_input("t1", "prompt-1"))
+        .await
+        .unwrap();
+
+    // Tamper: set an unsupported schema version.
+    sqlx::query("UPDATE automation_tasks SET schema_version = ? WHERE id = ?")
+        .bind(999)
+        .bind("t1")
+        .execute(store.pool())
+        .await
+        .unwrap();
+
+    let result = store.list_automation_tasks().await;
+    assert!(matches!(result, Err(ConfigError::Deserialization(_))));
+}

--- a/src/config/db.rs
+++ b/src/config/db.rs
@@ -9,6 +9,11 @@ pub async fn create_pool(path: &Path) -> Result<SqlitePool, super::error::Config
 }
 
 /// Create a SQLite connection pool with WAL mode and a custom busy timeout.
+///
+/// Foreign-key enforcement is enabled explicitly on every connection (sqlx
+/// also enables it by default) so schema-level `FOREIGN KEY` constraints are
+/// always active. See [`migrations`](super::migrations) for declared
+/// constraints.
 pub async fn create_pool_with_timeout(
     path: &Path,
     busy_timeout: Duration,
@@ -17,7 +22,8 @@ pub async fn create_pool_with_timeout(
         .filename(path)
         .create_if_missing(true)
         .journal_mode(sqlx::sqlite::SqliteJournalMode::Wal)
-        .busy_timeout(busy_timeout);
+        .busy_timeout(busy_timeout)
+        .foreign_keys(true);
 
     let pool = SqlitePoolOptions::new()
         .max_connections(5)
@@ -29,10 +35,17 @@ pub async fn create_pool_with_timeout(
 }
 
 /// Create an in-memory SQLite pool for testing.
+///
+/// Foreign-key enforcement is enabled to keep test behavior consistent with
+/// the file-backed pool.
 pub async fn create_memory_pool() -> Result<SqlitePool, super::error::ConfigError> {
+    let options = SqliteConnectOptions::new()
+        .filename(":memory:")
+        .foreign_keys(true);
+
     let pool = SqlitePoolOptions::new()
         .max_connections(1)
-        .connect(":memory:")
+        .connect_with(options)
         .await
         .map_err(|e| super::error::ConfigError::DatabaseOpen(e.to_string()))?;
 

--- a/src/config/error.rs
+++ b/src/config/error.rs
@@ -62,6 +62,19 @@ pub enum ConfigError {
     /// Effective model catalog error.
     #[error("Model catalog error: {0}")]
     Catalog(String),
+
+    /// Automation task references a stored prompt that does not exist.
+    #[error("Automation task references unknown stored prompt: {0}")]
+    UnknownStoredPrompt(String),
+
+    /// Stored prompt deletion blocked because automation tasks reference it.
+    #[error("Stored prompt '{prompt_id}' is referenced by automation tasks: {task_ids:?}")]
+    PromptReferencedByTasks {
+        /// The prompt that was being deleted.
+        prompt_id: String,
+        /// IDs of tasks that reference the prompt.
+        task_ids: Vec<String>,
+    },
 }
 
 impl From<sqlx::Error> for ConfigError {

--- a/src/config/migrations.rs
+++ b/src/config/migrations.rs
@@ -175,7 +175,8 @@ pub const MIGRATIONS: &[(i64, &str)] = &[
                 expected_outcome TEXT NOT NULL,
                 schema_version INTEGER NOT NULL,
                 created_at TEXT NOT NULL,
-                updated_at TEXT NOT NULL
+                updated_at TEXT NOT NULL,
+                FOREIGN KEY (stored_prompt_id) REFERENCES prompts(id) ON DELETE RESTRICT
             );
 
             CREATE INDEX IF NOT EXISTS idx_automation_tasks_stored_prompt_id

--- a/src/config/migrations.rs
+++ b/src/config/migrations.rs
@@ -165,11 +165,30 @@ pub const MIGRATIONS: &[(i64, &str)] = &[
             INSERT OR IGNORE INTO schema_version (id, version) VALUES (1, 6);
             "#,
     ),
+    (
+        7,
+        r#"
+            CREATE TABLE IF NOT EXISTS automation_tasks (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                stored_prompt_id TEXT NOT NULL,
+                expected_outcome TEXT NOT NULL,
+                schema_version INTEGER NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_automation_tasks_stored_prompt_id
+                ON automation_tasks (stored_prompt_id);
+
+            INSERT OR IGNORE INTO schema_version (id, version) VALUES (1, 7);
+            "#,
+    ),
 ];
 
 /// The current schema version.
 #[allow(dead_code)]
-pub const CURRENT_SCHEMA_VERSION: i64 = 6;
+pub const CURRENT_SCHEMA_VERSION: i64 = 7;
 
 /// Apply all pending migrations to the database.
 pub async fn apply_migrations(pool: &sqlx::SqlitePool) -> Result<(), super::error::ConfigError> {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -585,6 +585,9 @@ mod db;
 mod key_source;
 mod migrations;
 
+#[cfg(test)]
+mod automation_task_tests;
+
 pub use builtin_models::{builtin_model_catalog, BuiltinModelEntry};
 pub use effective_catalog::{
     build_effective_catalog, CatalogError, EffectiveModelCatalog, EffectiveModelEntry,

--- a/src/config/store.rs
+++ b/src/config/store.rs
@@ -331,16 +331,7 @@ impl ConfigStore {
         let mut tx = self.pool.begin().await.map_err(ConfigError::from)?;
 
         // Check whether automation tasks reference this prompt.
-        let referencing_tasks: Vec<String> = sqlx::query(
-            "SELECT id FROM automation_tasks WHERE stored_prompt_id = ? ORDER BY id ASC",
-        )
-        .bind(id)
-        .fetch_all(&mut *tx)
-        .await
-        .map_err(ConfigError::from)?
-        .into_iter()
-        .map(|row| row.get::<String, _>("id"))
-        .collect();
+        let referencing_tasks = fetch_referencing_task_ids(&mut *tx, id).await?;
 
         if !referencing_tasks.is_empty() {
             return Err(ConfigError::PromptReferencedByTasks {
@@ -2130,18 +2121,30 @@ impl ConfigStore {
         &self,
         prompt_id: &str,
     ) -> Result<Vec<String>, ConfigError> {
-        let rows = sqlx::query(
-            "SELECT id FROM automation_tasks WHERE stored_prompt_id = ? ORDER BY id ASC",
-        )
-        .bind(prompt_id)
-        .fetch_all(&self.pool)
-        .await
-        .map_err(ConfigError::from)?;
-        Ok(rows
-            .into_iter()
-            .map(|row| row.get::<String, _>("id"))
-            .collect())
+        fetch_referencing_task_ids(&self.pool, prompt_id).await
     }
+}
+
+/// Fetch the IDs of automation tasks referencing a stored prompt, ordered by
+/// ID ascending. Generic over the executor so it works with both the
+/// connection pool and an in-flight transaction.
+async fn fetch_referencing_task_ids<'e, E>(
+    executor: E,
+    prompt_id: &str,
+) -> Result<Vec<String>, ConfigError>
+where
+    E: sqlx::Executor<'e, Database = sqlx::Sqlite>,
+{
+    let rows =
+        sqlx::query("SELECT id FROM automation_tasks WHERE stored_prompt_id = ? ORDER BY id ASC")
+            .bind(prompt_id)
+            .fetch_all(executor)
+            .await
+            .map_err(ConfigError::from)?;
+    Ok(rows
+        .into_iter()
+        .map(|row| row.get::<String, _>("id"))
+        .collect())
 }
 
 /// Resolve the platform-default config path.

--- a/src/config/store.rs
+++ b/src/config/store.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 /// Durable configuration store for AgentIron.
+#[derive(Clone)]
 pub struct ConfigStore {
     pool: SqlitePool,
     cipher: Option<DynCredentialCipher>,
@@ -320,12 +321,41 @@ impl ConfigStore {
     }
 
     /// Delete a prompt by ID.
+    ///
+    /// Returns `ConfigError::PromptReferencedByTasks` if one or more
+    /// automation tasks reference this prompt.
+    ///
+    /// The reference check and deletion are performed atomically in a
+    /// transaction to prevent race conditions.
     pub async fn delete_prompt(&self, id: &str) -> Result<(), ConfigError> {
+        let mut tx = self.pool.begin().await.map_err(ConfigError::from)?;
+
+        // Check whether automation tasks reference this prompt.
+        let referencing_tasks: Vec<String> = sqlx::query(
+            "SELECT id FROM automation_tasks WHERE stored_prompt_id = ? ORDER BY id ASC",
+        )
+        .bind(id)
+        .fetch_all(&mut *tx)
+        .await
+        .map_err(ConfigError::from)?
+        .into_iter()
+        .map(|row| row.get::<String, _>("id"))
+        .collect();
+
+        if !referencing_tasks.is_empty() {
+            return Err(ConfigError::PromptReferencedByTasks {
+                prompt_id: id.to_string(),
+                task_ids: referencing_tasks,
+            });
+        }
+
         sqlx::query("DELETE FROM prompts WHERE id = ?")
             .bind(id)
-            .execute(&self.pool)
+            .execute(&mut *tx)
             .await
             .map_err(ConfigError::from)?;
+
+        tx.commit().await.map_err(ConfigError::from)?;
 
         Ok(())
     }
@@ -1918,6 +1948,199 @@ impl ConfigStore {
                 })
             })
             .collect()
+    }
+
+    // ============================================================================
+    // Automation Task APIs
+    // ============================================================================
+
+    /// Store or replace an automation task.
+    ///
+    /// Validates the input, requires the referenced stored prompt to exist,
+    /// and creates or replaces the task atomically. On replacement, the
+    /// original creation timestamp is preserved and the update timestamp
+    /// advances.
+    pub async fn set_automation_task(
+        &self,
+        input: &crate::automation_task::AutomationTaskInput,
+    ) -> Result<crate::automation_task::AutomationTask, ConfigError> {
+        use crate::automation_task::{validate_task_input, AUTOMATION_TASK_SCHEMA_VERSION};
+
+        let normalized = validate_task_input(input).map_err(ConfigError::Validation)?;
+
+        let mut tx = self.pool.begin().await.map_err(ConfigError::from)?;
+
+        // Require the referenced prompt to exist.
+        let prompt_exists: Option<(i64,)> = sqlx::query_as("SELECT 1 FROM prompts WHERE id = ?")
+            .bind(&normalized.stored_prompt_id)
+            .fetch_optional(&mut *tx)
+            .await
+            .map_err(ConfigError::from)?;
+
+        if prompt_exists.is_none() {
+            return Err(ConfigError::UnknownStoredPrompt(
+                normalized.stored_prompt_id.clone(),
+            ));
+        }
+
+        let now = Utc::now().to_rfc3339();
+
+        // Try to fetch the existing created_at so we can preserve it.
+        let existing_created_at: Option<(String,)> =
+            sqlx::query_as("SELECT created_at FROM automation_tasks WHERE id = ?")
+                .bind(&normalized.id)
+                .fetch_optional(&mut *tx)
+                .await
+                .map_err(ConfigError::from)?;
+
+        let created_at = existing_created_at
+            .map(|(ca,)| ca)
+            .unwrap_or_else(|| now.clone());
+
+        sqlx::query(
+            r#"
+            INSERT INTO automation_tasks (id, name, stored_prompt_id, expected_outcome, schema_version, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(id) DO UPDATE SET
+                name = excluded.name,
+                stored_prompt_id = excluded.stored_prompt_id,
+                expected_outcome = excluded.expected_outcome,
+                schema_version = excluded.schema_version,
+                created_at = excluded.created_at,
+                updated_at = excluded.updated_at
+            "#,
+        )
+        .bind(&normalized.id)
+        .bind(&normalized.name)
+        .bind(&normalized.stored_prompt_id)
+        .bind(&normalized.expected_outcome)
+        .bind(AUTOMATION_TASK_SCHEMA_VERSION)
+        .bind(&created_at)
+        .bind(&now)
+        .execute(&mut *tx)
+        .await
+        .map_err(ConfigError::from)?;
+
+        tx.commit().await.map_err(ConfigError::from)?;
+
+        let created_at_dt = parse_datetime(created_at)?;
+        let updated_at_dt = parse_datetime(now)?;
+
+        Ok(crate::automation_task::AutomationTask {
+            id: normalized.id,
+            name: normalized.name,
+            stored_prompt_id: normalized.stored_prompt_id,
+            expected_outcome: normalized.expected_outcome,
+            created_at: created_at_dt,
+            updated_at: updated_at_dt,
+        })
+    }
+
+    /// Get an automation task by ID.
+    ///
+    /// Returns `ConfigError::Deserialization` if the stored record has an
+    /// unsupported schema version.
+    pub async fn get_automation_task(
+        &self,
+        id: &str,
+    ) -> Result<Option<crate::automation_task::AutomationTask>, ConfigError> {
+        use crate::automation_task::AUTOMATION_TASK_SCHEMA_VERSION;
+
+        let row = sqlx::query(
+            "SELECT id, name, stored_prompt_id, expected_outcome, schema_version, created_at, updated_at FROM automation_tasks WHERE id = ?",
+        )
+        .bind(id)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(ConfigError::from)?;
+
+        match row {
+            Some(row) => {
+                let schema_version: i64 = row.get("schema_version");
+                if schema_version != AUTOMATION_TASK_SCHEMA_VERSION {
+                    return Err(ConfigError::Deserialization(format!(
+                        "automation task '{}' has unsupported schema version {} (expected {})",
+                        id, schema_version, AUTOMATION_TASK_SCHEMA_VERSION
+                    )));
+                }
+                Ok(Some(crate::automation_task::AutomationTask {
+                    id: row.get("id"),
+                    name: row.get("name"),
+                    stored_prompt_id: row.get("stored_prompt_id"),
+                    expected_outcome: row.get("expected_outcome"),
+                    created_at: parse_datetime(row.get::<String, _>("created_at"))?,
+                    updated_at: parse_datetime(row.get::<String, _>("updated_at"))?,
+                }))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// List all automation tasks in deterministic order (by ID ascending).
+    ///
+    /// Returns `ConfigError::Deserialization` if any stored record has an
+    /// unsupported schema version.
+    pub async fn list_automation_tasks(
+        &self,
+    ) -> Result<Vec<crate::automation_task::AutomationTask>, ConfigError> {
+        use crate::automation_task::AUTOMATION_TASK_SCHEMA_VERSION;
+
+        let rows = sqlx::query(
+            "SELECT id, name, stored_prompt_id, expected_outcome, schema_version, created_at, updated_at FROM automation_tasks ORDER BY id ASC",
+        )
+        .fetch_all(&self.pool)
+        .await
+        .map_err(ConfigError::from)?;
+
+        rows.into_iter()
+            .map(|row| {
+                let schema_version: i64 = row.get("schema_version");
+                if schema_version != AUTOMATION_TASK_SCHEMA_VERSION {
+                    return Err(ConfigError::Deserialization(format!(
+                        "automation task '{}' has unsupported schema version {} (expected {})",
+                        row.get::<String, _>("id"),
+                        schema_version,
+                        AUTOMATION_TASK_SCHEMA_VERSION
+                    )));
+                }
+                Ok(crate::automation_task::AutomationTask {
+                    id: row.get("id"),
+                    name: row.get("name"),
+                    stored_prompt_id: row.get("stored_prompt_id"),
+                    expected_outcome: row.get("expected_outcome"),
+                    created_at: parse_datetime(row.get::<String, _>("created_at"))?,
+                    updated_at: parse_datetime(row.get::<String, _>("updated_at"))?,
+                })
+            })
+            .collect()
+    }
+
+    /// Delete an automation task by ID. Does not affect the referenced prompt.
+    pub async fn delete_automation_task(&self, id: &str) -> Result<(), ConfigError> {
+        sqlx::query("DELETE FROM automation_tasks WHERE id = ?")
+            .bind(id)
+            .execute(&self.pool)
+            .await
+            .map_err(ConfigError::from)?;
+        Ok(())
+    }
+
+    /// List task IDs that reference a given stored prompt.
+    pub async fn tasks_referencing_prompt(
+        &self,
+        prompt_id: &str,
+    ) -> Result<Vec<String>, ConfigError> {
+        let rows = sqlx::query(
+            "SELECT id FROM automation_tasks WHERE stored_prompt_id = ? ORDER BY id ASC",
+        )
+        .bind(prompt_id)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(ConfigError::from)?;
+        Ok(rows
+            .into_iter()
+            .map(|row| row.get::<String, _>("id"))
+            .collect())
     }
 }
 

--- a/src/delegation/runtime.rs
+++ b/src/delegation/runtime.rs
@@ -303,7 +303,10 @@ impl IronRuntime {
 
         // Build initial user message.
         let user_text = if let Some(context) = &request.context {
-            format!("{}\n\nContext:\n{}", request.goal, context)
+            crate::execution::compose_user_goal(
+                &request.goal,
+                Some(&format!("Context:\n{}", context)),
+            )
         } else {
             request.goal.clone()
         };

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -1,0 +1,971 @@
+//! Shared execution resolution and ephemeral automation-run types.
+//!
+//! At run start a resolver loads the current automation task, its referenced
+//! stored prompt, the resolved agent profile, and the composed user-visible
+//! goal into an immutable [`ResolvedExecutionInput`]. This snapshot is stable
+//! for the duration of the run; subsequent configuration edits are visible
+//! only to later runs.
+//!
+//! The resolver is shared between root CLI execution and delegated stored
+//! prompt invocation. The execution mechanism itself remains distinct: CLI
+//! runs are root sessions and delegated calls remain child sessions.
+
+use crate::automation_task::AutomationTask;
+use crate::config::{ConfigError, ConfigStore};
+use crate::profile::{AgentApproval, AgentProfile, AgentProfileId, SkillFilter, ToolFilter};
+use crate::stored_prompt::{StoredPrompt, STORED_PROMPT_SCHEMA_VERSION};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+/// Schema version for automation-run result payloads.
+pub const AUTOMATION_RUN_SCHEMA_VERSION: i64 = 1;
+
+// ============================================================================
+// Immutable resolved execution input
+// ============================================================================
+
+/// Immutable snapshot of everything resolved from persistent state at run
+/// start.
+///
+/// All fields are owned clones taken at resolution time. Concurrent edits to
+/// ConfigStore or the profile registry after resolution do not affect the
+/// values in this struct.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ResolvedExecutionInput {
+    /// The automation task being executed.
+    pub task: AutomationTask,
+    /// The stored prompt referenced by the task (snapshot at resolution time).
+    pub prompt: StoredPrompt,
+    /// Resolved profile identifier (explicit prompt profile or built-in
+    /// `"default"`).
+    pub profile_id: AgentProfileId,
+    /// Resolved agent profile (snapshot at resolution time).
+    pub profile: AgentProfile,
+    /// Composed model-visible user goal: stored instructions plus the task's
+    /// expected outcome.
+    pub user_goal: String,
+    /// Effective skill names after combining the stored prompt's requested
+    /// skills with the profile's skill filter policy.
+    pub effective_skills: Vec<String>,
+    /// Canonical workspace directory for the run.
+    pub workspace: PathBuf,
+    /// When this snapshot was resolved.
+    pub resolved_at: DateTime<Utc>,
+}
+
+// ============================================================================
+// Ephemeral automation-run result types
+// ============================================================================
+
+/// Terminal status of an automation run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AutomationRunStatus {
+    /// The runtime completed the prompt turn without unhandled error.
+    ///
+    /// This means technical completion only; the expected outcome is not
+    /// independently verified.
+    Completed,
+    /// An unhandled runtime, provider, or configuration error terminated the
+    /// run.
+    Failed,
+    /// A cancellation signal (SIGINT / SIGTERM) terminated the run.
+    Cancelled,
+    /// The run exceeded its configured timeout.
+    TimedOut,
+}
+
+impl AutomationRunStatus {
+    /// Stable lowercase string representation for JSON and text output.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Completed => "completed",
+            Self::Failed => "failed",
+            Self::Cancelled => "cancelled",
+            Self::TimedOut => "timed_out",
+        }
+    }
+}
+
+/// Category of a structured run error.
+///
+/// Categories align with the stable CLI exit-code mapping so that callers can
+/// distinguish failure reasons programmatically.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AutomationRunErrorCategory {
+    /// Configuration or reference resolution failure.
+    Config,
+    /// Referenced entity (task, prompt, or profile) was not found.
+    Reference,
+    /// Profile approval or tool policy is unsafe for headless execution.
+    UnsafePolicy,
+    /// Provider or credential initialization failure.
+    ProviderInit,
+    /// Unhandled error during prompt execution.
+    Execution,
+    /// Run was cancelled by a signal.
+    Cancelled,
+    /// Run exceeded its timeout.
+    TimedOut,
+}
+
+/// Structured error carried in a failed, cancelled, or timed-out run result.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AutomationRunError {
+    pub category: AutomationRunErrorCategory,
+    pub message: String,
+}
+
+/// Ephemeral result of a single automation-run attempt.
+///
+/// This struct is produced after execution completes (or fails). It is not
+/// persisted in IC-7A; the shape is designed to allow run-history persistence
+/// in a future change.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AutomationRunResult {
+    /// Schema version of this result payload.
+    pub schema_version: i64,
+    /// Generated unique identifier for this run attempt.
+    pub run_id: String,
+    /// ID of the executed automation task.
+    pub task_id: String,
+    /// Display name of the executed automation task.
+    pub task_name: String,
+    /// Terminal status.
+    pub status: AutomationRunStatus,
+    /// Final assistant text (empty when no assistant text was produced).
+    #[serde(default)]
+    pub output: String,
+    /// Expected-outcome text copied from the task for reporting.
+    #[serde(default)]
+    pub expected_outcome: String,
+    /// Resolved profile identifier used for the run.
+    #[serde(default)]
+    pub profile_id: String,
+    /// Provider slug or `"runtime_default"` when resolved from the persisted
+    /// default. `null` when not resolved.
+    #[serde(default)]
+    pub provider: Option<String>,
+    /// Model identifier used for the run. `null` when not resolved.
+    #[serde(default)]
+    pub model: Option<String>,
+    /// Canonical workspace path used for the run.
+    pub workspace: PathBuf,
+    /// Sorted effective tool names available to the run.
+    #[serde(default)]
+    pub effective_tools: Vec<String>,
+    /// When the run started.
+    pub started_at: DateTime<Utc>,
+    /// When the run ended.
+    pub ended_at: DateTime<Utc>,
+    /// Wall-clock duration in milliseconds.
+    pub duration_ms: u64,
+    /// Structured error when the run did not complete successfully. `null`
+    /// for successful runs.
+    #[serde(default)]
+    pub error: Option<AutomationRunError>,
+}
+
+impl AutomationRunResult {
+    /// Create a builder pre-populated with task identity and timing defaults.
+    pub fn started(task: &AutomationTask, workspace: PathBuf) -> Self {
+        Self {
+            schema_version: AUTOMATION_RUN_SCHEMA_VERSION,
+            run_id: uuid::Uuid::new_v4().to_string(),
+            task_id: task.id.clone(),
+            task_name: task.name.clone(),
+            status: AutomationRunStatus::Failed,
+            output: String::new(),
+            expected_outcome: task.expected_outcome.clone(),
+            profile_id: String::new(),
+            provider: None,
+            model: None,
+            workspace,
+            effective_tools: Vec::new(),
+            started_at: Utc::now(),
+            ended_at: Utc::now(),
+            duration_ms: 0,
+            error: None,
+        }
+    }
+
+    /// Mark the run as completed with the given final assistant text.
+    pub fn complete(&mut self, output: String) {
+        self.status = AutomationRunStatus::Completed;
+        self.output = output;
+        self.error = None;
+        self.finalize_timing();
+    }
+
+    /// Mark the run as failed with a structured error.
+    pub fn fail(&mut self, category: AutomationRunErrorCategory, message: String) {
+        self.status = AutomationRunStatus::Failed;
+        self.error = Some(AutomationRunError { category, message });
+        self.finalize_timing();
+    }
+
+    /// Mark the run as cancelled.
+    pub fn cancel(&mut self, message: String) {
+        self.status = AutomationRunStatus::Cancelled;
+        self.error = Some(AutomationRunError {
+            category: AutomationRunErrorCategory::Cancelled,
+            message,
+        });
+        self.finalize_timing();
+    }
+
+    /// Mark the run as timed out.
+    pub fn timeout(&mut self, message: String) {
+        self.status = AutomationRunStatus::TimedOut;
+        self.error = Some(AutomationRunError {
+            category: AutomationRunErrorCategory::TimedOut,
+            message,
+        });
+        self.finalize_timing();
+    }
+
+    /// Set resolved provider/model/tool metadata.
+    pub fn set_resolved_metadata(
+        &mut self,
+        profile_id: &str,
+        provider: Option<String>,
+        model: Option<String>,
+        effective_tools: Vec<String>,
+    ) {
+        self.profile_id = profile_id.to_string();
+        self.provider = provider;
+        self.model = model;
+        self.effective_tools = effective_tools;
+    }
+
+    /// Create a terminal failure result for CLI-level errors that occur
+    /// before or during bootstrap, when the task record may not be loaded.
+    pub fn cli_failure(
+        task_id: &str,
+        workspace: PathBuf,
+        category: AutomationRunErrorCategory,
+        message: String,
+    ) -> Self {
+        let now = Utc::now();
+        Self {
+            schema_version: AUTOMATION_RUN_SCHEMA_VERSION,
+            run_id: uuid::Uuid::new_v4().to_string(),
+            task_id: task_id.to_string(),
+            task_name: String::new(),
+            status: AutomationRunStatus::Failed,
+            output: String::new(),
+            expected_outcome: String::new(),
+            profile_id: String::new(),
+            provider: None,
+            model: None,
+            workspace,
+            effective_tools: Vec::new(),
+            started_at: now,
+            ended_at: now,
+            duration_ms: 0,
+            error: Some(AutomationRunError { category, message }),
+        }
+    }
+
+    fn finalize_timing(&mut self) {
+        self.ended_at = Utc::now();
+        self.duration_ms = self
+            .ended_at
+            .signed_duration_since(self.started_at)
+            .num_milliseconds()
+            .max(0) as u64;
+    }
+}
+
+// ============================================================================
+// Resolution errors
+// ============================================================================
+
+/// Typed failure during execution-input resolution.
+#[derive(Debug, thiserror::Error)]
+pub enum ResolutionError {
+    #[error("automation task '{0}' not found")]
+    TaskNotFound(String),
+    #[error("stored prompt '{0}' not found")]
+    PromptNotFound(String),
+    #[error("stored prompt '{0}' has an unsupported schema version or invalid payload")]
+    InvalidPrompt(String),
+    #[error("profile '{}' not found", _0.as_str())]
+    ProfileNotFound(AgentProfileId),
+    #[error(transparent)]
+    Store(#[from] ConfigError),
+}
+
+// ============================================================================
+// Shared resolution helpers
+// ============================================================================
+
+/// Compose a model-visible user goal by appending optional additional text.
+///
+/// When `addition` is `Some` the two parts are joined with a blank-line
+/// separator. When `addition` is `None` the primary text is returned as-is.
+pub fn compose_user_goal(primary: &str, addition: Option<&str>) -> String {
+    match addition {
+        Some(add) => format!("{}\n\n{}", primary, add),
+        None => primary.to_string(),
+    }
+}
+
+/// Resolve the profile for a stored prompt.
+///
+/// If the prompt specifies a profile, that profile ID is used. Otherwise the
+/// built-in `"default"` profile is resolved. The returned profile is cloned
+/// from the registry, producing an immutable snapshot.
+pub fn resolve_profile_for_prompt(
+    prompt_profile_id: Option<&AgentProfileId>,
+    registry: &HashMap<AgentProfileId, AgentProfile>,
+) -> Result<(AgentProfileId, AgentProfile), ResolutionError> {
+    let profile_id = prompt_profile_id
+        .cloned()
+        .unwrap_or_else(|| AgentProfileId::from("default"));
+
+    let profile = registry
+        .get(&profile_id)
+        .cloned()
+        .ok_or_else(|| ResolutionError::ProfileNotFound(profile_id.clone()))?;
+
+    Ok((profile_id, profile))
+}
+
+/// Resolve a complete execution input from ConfigStore and profile registry.
+///
+/// This loads the task, validates and loads the referenced prompt, resolves
+/// the profile, composes the user goal, and returns an immutable snapshot.
+/// All values are cloned at resolution time so concurrent edits do not affect
+/// the returned input.
+pub async fn resolve_task_execution(
+    store: &ConfigStore,
+    profiles: &HashMap<AgentProfileId, AgentProfile>,
+    task_id: &str,
+    workspace: PathBuf,
+) -> Result<ResolvedExecutionInput, ResolutionError> {
+    let task = store
+        .get_automation_task(task_id)
+        .await?
+        .ok_or_else(|| ResolutionError::TaskNotFound(task_id.to_string()))?;
+
+    let prompt = load_single_prompt(store, &task.stored_prompt_id).await?;
+
+    let (profile_id, profile) = resolve_profile_for_prompt(prompt.profile.as_ref(), profiles)?;
+
+    let user_goal = compose_user_goal(&prompt.instructions, Some(&task.expected_outcome));
+
+    let skills = match &profile.skills {
+        SkillFilter::None => Vec::new(),
+        SkillFilter::Inherit => prompt.skills.clone(),
+        SkillFilter::Allow(allowed) => prompt
+            .skills
+            .iter()
+            .filter(|s| allowed.iter().any(|a| a == *s))
+            .cloned()
+            .collect(),
+    };
+
+    Ok(ResolvedExecutionInput {
+        task,
+        prompt,
+        profile_id,
+        profile,
+        user_goal,
+        effective_skills: skills,
+        workspace,
+        resolved_at: Utc::now(),
+    })
+}
+
+/// Load, validate, and deserialize a single stored prompt from ConfigStore.
+async fn load_single_prompt(
+    store: &ConfigStore,
+    prompt_id: &str,
+) -> Result<StoredPrompt, ResolutionError> {
+    let record = store
+        .get_prompt(prompt_id)
+        .await?
+        .ok_or_else(|| ResolutionError::PromptNotFound(prompt_id.to_string()))?;
+
+    if record.schema_version != STORED_PROMPT_SCHEMA_VERSION {
+        return Err(ResolutionError::InvalidPrompt(prompt_id.to_string()));
+    }
+
+    let prompt: StoredPrompt = serde_json::from_value(record.payload)
+        .map_err(|_| ResolutionError::InvalidPrompt(prompt_id.to_string()))?;
+
+    prompt
+        .validate()
+        .map_err(|_| ResolutionError::InvalidPrompt(prompt_id.to_string()))?;
+
+    Ok(prompt)
+}
+
+/// Effective skill names for a resolved execution input.
+///
+/// This returns the pre-computed snapshot from [`ResolvedExecutionInput`],
+/// which was derived at resolution time by combining the stored prompt's
+/// requested skills with the profile's skill filter policy.
+pub fn effective_skills(input: &ResolvedExecutionInput) -> Vec<String> {
+    input.effective_skills.clone()
+}
+
+/// Whether the resolved profile is safe for headless execution.
+///
+/// Headless preflight requires `AutoApprove`. `PerTool` is rejected because
+/// there is no interactive client to approve tool calls. This is a pure check
+/// on the already-resolved profile snapshot.
+pub fn is_headless_safe(approval: AgentApproval) -> bool {
+    matches!(approval, AgentApproval::AutoApprove)
+}
+
+/// Compute the effective tool filter for the resolved profile.
+pub fn effective_tool_filter(input: &ResolvedExecutionInput) -> ToolFilter {
+    input.profile.tools.clone()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::automation_task::AutomationTaskInput;
+    use crate::config::ConfigStore;
+    use crate::profile::{AgentApproval, AgentProfile, SkillFilter};
+    use crate::stored_prompt::StoredPrompt;
+
+    // ---- compose_user_goal ----
+
+    #[test]
+    fn compose_user_goal_no_addition() {
+        let result = compose_user_goal("do thing", None);
+        assert_eq!(result, "do thing");
+    }
+
+    #[test]
+    fn compose_user_goal_with_addition() {
+        let result = compose_user_goal("do thing", Some("expected: done"));
+        assert_eq!(result, "do thing\n\nexpected: done");
+    }
+
+    #[test]
+    fn compose_user_goal_preserves_multiline() {
+        let result = compose_user_goal("line1\nline2", Some("outcome"));
+        assert_eq!(result, "line1\nline2\n\noutcome");
+    }
+
+    // ---- resolve_profile_for_prompt ----
+
+    fn make_registry() -> HashMap<AgentProfileId, AgentProfile> {
+        let mut reg = HashMap::new();
+        reg.insert(
+            AgentProfileId::from("default"),
+            AgentProfile::with_name("default"),
+        );
+        reg.insert(
+            AgentProfileId::from("auto"),
+            AgentProfile {
+                name: "auto".to_string(),
+                approval: AgentApproval::AutoApprove,
+                ..AgentProfile::with_name("auto")
+            },
+        );
+        reg
+    }
+
+    #[test]
+    fn resolve_profile_explicit() {
+        let reg = make_registry();
+        let id = AgentProfileId::from("auto");
+        let (resolved_id, profile) = resolve_profile_for_prompt(Some(&id), &reg).unwrap();
+        assert_eq!(resolved_id, AgentProfileId::from("auto"));
+        assert_eq!(profile.approval, AgentApproval::AutoApprove);
+    }
+
+    #[test]
+    fn resolve_profile_defaults_to_default() {
+        let reg = make_registry();
+        let (resolved_id, profile) = resolve_profile_for_prompt(None, &reg).unwrap();
+        assert_eq!(resolved_id, AgentProfileId::from("default"));
+        assert_eq!(profile.approval, AgentApproval::PerTool);
+    }
+
+    #[test]
+    fn resolve_profile_not_found() {
+        let reg = make_registry();
+        let id = AgentProfileId::from("missing");
+        let result = resolve_profile_for_prompt(Some(&id), &reg);
+        assert!(matches!(result, Err(ResolutionError::ProfileNotFound(_))));
+    }
+
+    // ---- is_headless_safe ----
+
+    #[test]
+    fn headless_safe_autoapprove() {
+        assert!(is_headless_safe(AgentApproval::AutoApprove));
+    }
+
+    #[test]
+    fn headless_not_safe_pertool() {
+        assert!(!is_headless_safe(AgentApproval::PerTool));
+    }
+
+    // ---- effective_skills ----
+
+    #[test]
+    fn effective_skills_inherit() {
+        let now = Utc::now();
+        let task = AutomationTask {
+            id: "t1".to_string(),
+            name: "T".to_string(),
+            stored_prompt_id: "p1".to_string(),
+            expected_outcome: "done".to_string(),
+            created_at: now,
+            updated_at: now,
+        };
+        let prompt = StoredPrompt {
+            instructions: "do thing".to_string(),
+            skills: vec!["s1".to_string(), "s2".to_string()],
+            profile: None,
+        };
+        let profile = AgentProfile {
+            skills: SkillFilter::Inherit,
+            ..AgentProfile::with_name("default")
+        };
+        let input = ResolvedExecutionInput {
+            task,
+            prompt,
+            profile_id: AgentProfileId::from("default"),
+            profile,
+            user_goal: "do thing\n\ndone".to_string(),
+            effective_skills: vec!["s1".to_string(), "s2".to_string()],
+            workspace: PathBuf::from("/tmp"),
+            resolved_at: now,
+        };
+        let skills = effective_skills(&input);
+        assert_eq!(skills, vec!["s1", "s2"]);
+    }
+
+    #[test]
+    fn effective_skills_none_filter() {
+        let now = Utc::now();
+        let prompt = StoredPrompt {
+            instructions: "do".to_string(),
+            skills: vec!["s1".to_string()],
+            profile: None,
+        };
+        let profile = AgentProfile {
+            skills: SkillFilter::None,
+            ..AgentProfile::with_name("default")
+        };
+        let input = ResolvedExecutionInput {
+            task: AutomationTask {
+                id: "t".to_string(),
+                name: "T".to_string(),
+                stored_prompt_id: "p".to_string(),
+                expected_outcome: "o".to_string(),
+                created_at: now,
+                updated_at: now,
+            },
+            prompt,
+            profile_id: AgentProfileId::from("default"),
+            profile,
+            user_goal: "do\n\no".to_string(),
+            effective_skills: Vec::new(),
+            workspace: PathBuf::from("/tmp"),
+            resolved_at: now,
+        };
+        assert!(effective_skills(&input).is_empty());
+    }
+
+    #[test]
+    fn effective_skills_allow_filter() {
+        let now = Utc::now();
+        let prompt = StoredPrompt {
+            instructions: "do".to_string(),
+            skills: vec!["s1".to_string(), "s2".to_string(), "s3".to_string()],
+            profile: None,
+        };
+        let profile = AgentProfile {
+            skills: SkillFilter::Allow(vec!["s1".to_string(), "s3".to_string()]),
+            ..AgentProfile::with_name("default")
+        };
+        let input = ResolvedExecutionInput {
+            task: AutomationTask {
+                id: "t".to_string(),
+                name: "T".to_string(),
+                stored_prompt_id: "p".to_string(),
+                expected_outcome: "o".to_string(),
+                created_at: now,
+                updated_at: now,
+            },
+            prompt,
+            profile_id: AgentProfileId::from("default"),
+            profile,
+            user_goal: "do\n\no".to_string(),
+            effective_skills: vec!["s1".to_string(), "s3".to_string()],
+            workspace: PathBuf::from("/tmp"),
+            resolved_at: now,
+        };
+        let skills = effective_skills(&input);
+        assert_eq!(skills, vec!["s1", "s3"]);
+    }
+
+    // ---- AutomationRunResult builder ----
+
+    #[test]
+    fn run_result_started_has_task_identity() {
+        let now = Utc::now();
+        let task = AutomationTask {
+            id: "daily".to_string(),
+            name: "Daily".to_string(),
+            stored_prompt_id: "p".to_string(),
+            expected_outcome: "report".to_string(),
+            created_at: now,
+            updated_at: now,
+        };
+        let result = AutomationRunResult::started(&task, PathBuf::from("/work"));
+        assert_eq!(result.task_id, "daily");
+        assert_eq!(result.task_name, "Daily");
+        assert_eq!(result.expected_outcome, "report");
+        assert_eq!(result.workspace, PathBuf::from("/work"));
+        assert!(!result.run_id.is_empty());
+    }
+
+    #[test]
+    fn run_result_complete() {
+        let now = Utc::now();
+        let task = AutomationTask {
+            id: "t".to_string(),
+            name: "T".to_string(),
+            stored_prompt_id: "p".to_string(),
+            expected_outcome: "o".to_string(),
+            created_at: now,
+            updated_at: now,
+        };
+        let mut result = AutomationRunResult::started(&task, PathBuf::from("/w"));
+        result.complete("final output".to_string());
+        assert_eq!(result.status, AutomationRunStatus::Completed);
+        assert_eq!(result.output, "final output");
+        assert!(result.error.is_none());
+    }
+
+    #[test]
+    fn run_result_fail_sets_error() {
+        let now = Utc::now();
+        let task = AutomationTask {
+            id: "t".to_string(),
+            name: "T".to_string(),
+            stored_prompt_id: "p".to_string(),
+            expected_outcome: "o".to_string(),
+            created_at: now,
+            updated_at: now,
+        };
+        let mut result = AutomationRunResult::started(&task, PathBuf::from("/w"));
+        result.fail(
+            AutomationRunErrorCategory::Execution,
+            "provider error".to_string(),
+        );
+        assert_eq!(result.status, AutomationRunStatus::Failed);
+        assert_eq!(
+            result.error.as_ref().unwrap().category,
+            AutomationRunErrorCategory::Execution
+        );
+    }
+
+    #[test]
+    fn run_result_cancel_and_timeout() {
+        let now = Utc::now();
+        let task = AutomationTask {
+            id: "t".to_string(),
+            name: "T".to_string(),
+            stored_prompt_id: "p".to_string(),
+            expected_outcome: "o".to_string(),
+            created_at: now,
+            updated_at: now,
+        };
+
+        let mut r1 = AutomationRunResult::started(&task, PathBuf::from("/w"));
+        r1.cancel("SIGINT".to_string());
+        assert_eq!(r1.status, AutomationRunStatus::Cancelled);
+        assert_eq!(
+            r1.error.as_ref().unwrap().category,
+            AutomationRunErrorCategory::Cancelled
+        );
+
+        let mut r2 = AutomationRunResult::started(&task, PathBuf::from("/w"));
+        r2.timeout("exceeded 30s".to_string());
+        assert_eq!(r2.status, AutomationRunStatus::TimedOut);
+        assert_eq!(
+            r2.error.as_ref().unwrap().category,
+            AutomationRunErrorCategory::TimedOut
+        );
+    }
+
+    #[test]
+    fn run_result_serializes_to_json() {
+        let now = Utc::now();
+        let task = AutomationTask {
+            id: "t".to_string(),
+            name: "T".to_string(),
+            stored_prompt_id: "p".to_string(),
+            expected_outcome: "o".to_string(),
+            created_at: now,
+            updated_at: now,
+        };
+        let mut result = AutomationRunResult::started(&task, PathBuf::from("/w"));
+        result.complete("done".to_string());
+        result.set_resolved_metadata(
+            "auto",
+            Some("openai".to_string()),
+            Some("gpt-4".to_string()),
+            vec!["webfetch".to_string()],
+        );
+
+        let json = serde_json::to_string(&result).unwrap();
+        let restored: AutomationRunResult = serde_json::from_str(&json).unwrap();
+        assert_eq!(result, restored);
+    }
+
+    #[test]
+    fn status_serializes_snake_case() {
+        let json = serde_json::to_string(&AutomationRunStatus::TimedOut).unwrap();
+        assert_eq!(json, "\"timed_out\"");
+        let restored: AutomationRunStatus = serde_json::from_str("\"completed\"").unwrap();
+        assert_eq!(restored, AutomationRunStatus::Completed);
+    }
+
+    #[test]
+    fn json_includes_null_provider_model_error_for_cli_failure() {
+        let result = AutomationRunResult::cli_failure(
+            "missing-task",
+            PathBuf::from("/w"),
+            AutomationRunErrorCategory::Reference,
+            "task not found".to_string(),
+        );
+        let json = serde_json::to_string(&result).unwrap();
+        // provider, model, and error must be present (not omitted) even when null
+        assert!(
+            json.contains("\"provider\":null"),
+            "provider should be null, got: {}",
+            json
+        );
+        assert!(
+            json.contains("\"model\":null"),
+            "model should be null, got: {}",
+            json
+        );
+    }
+
+    #[test]
+    fn json_includes_null_error_for_completed_run() {
+        let now = Utc::now();
+        let task = AutomationTask {
+            id: "t".to_string(),
+            name: "T".to_string(),
+            stored_prompt_id: "p".to_string(),
+            expected_outcome: "o".to_string(),
+            created_at: now,
+            updated_at: now,
+        };
+        let mut result = AutomationRunResult::started(&task, PathBuf::from("/w"));
+        result.complete("done".to_string());
+        let json = serde_json::to_string(&result).unwrap();
+        assert!(
+            json.contains("\"error\":null"),
+            "error should be null for completed run, got: {}",
+            json
+        );
+    }
+
+    // ---- resolve_task_execution integration ----
+
+    async fn setup_store_with_task_and_prompt() -> ConfigStore {
+        let store = ConfigStore::open_in_memory().await.unwrap();
+
+        // Register a prompt.
+        let prompt = StoredPrompt {
+            instructions: "Generate a daily report".to_string(),
+            skills: Vec::new(),
+            profile: None,
+        };
+        let payload = serde_json::to_value(&prompt).unwrap();
+        store
+            .set_prompt(&crate::config::PromptInput {
+                id: "report-prompt".to_string(),
+                schema_version: STORED_PROMPT_SCHEMA_VERSION,
+                payload,
+            })
+            .await
+            .unwrap();
+
+        // Register a task referencing the prompt.
+        store
+            .set_automation_task(&AutomationTaskInput {
+                id: "daily-report".to_string(),
+                name: "Daily Report".to_string(),
+                stored_prompt_id: "report-prompt".to_string(),
+                expected_outcome: "A summary of today's activity".to_string(),
+            })
+            .await
+            .unwrap();
+
+        store
+    }
+
+    fn default_registry() -> HashMap<AgentProfileId, AgentProfile> {
+        let mut reg = HashMap::new();
+        reg.insert(
+            AgentProfileId::from("default"),
+            AgentProfile::with_name("default"),
+        );
+        reg
+    }
+
+    #[tokio::test]
+    async fn resolve_task_execution_success() {
+        let store = setup_store_with_task_and_prompt().await;
+        let reg = default_registry();
+
+        let input =
+            resolve_task_execution(&store, &reg, "daily-report", PathBuf::from("/workspace"))
+                .await
+                .unwrap();
+
+        assert_eq!(input.task.id, "daily-report");
+        assert_eq!(input.task.expected_outcome, "A summary of today's activity");
+        assert_eq!(input.prompt.instructions, "Generate a daily report");
+        assert_eq!(input.profile_id, AgentProfileId::from("default"));
+        assert_eq!(
+            input.user_goal,
+            "Generate a daily report\n\nA summary of today's activity"
+        );
+        assert_eq!(input.workspace, PathBuf::from("/workspace"));
+    }
+
+    #[tokio::test]
+    async fn resolve_task_execution_task_not_found() {
+        let store = setup_store_with_task_and_prompt().await;
+        let reg = default_registry();
+
+        let result = resolve_task_execution(&store, &reg, "missing", PathBuf::from("/w")).await;
+        assert!(matches!(result, Err(ResolutionError::TaskNotFound(_))));
+    }
+
+    #[tokio::test]
+    async fn resolve_task_execution_prompt_not_found() {
+        let store = ConfigStore::open_in_memory().await.unwrap();
+
+        // Creating a task referencing a nonexistent prompt is rejected at
+        // write time, so the resolver's PromptNotFound can only occur from
+        // manual DB tampering. Verify the write-time guard works.
+        let result = store
+            .set_automation_task(&AutomationTaskInput {
+                id: "orphan-task".to_string(),
+                name: "Orphan".to_string(),
+                stored_prompt_id: "nonexistent".to_string(),
+                expected_outcome: "nothing".to_string(),
+            })
+            .await;
+
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            crate::config::ConfigError::UnknownStoredPrompt(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn resolve_task_execution_profile_not_found() {
+        let store = setup_store_with_task_and_prompt().await;
+        let reg: HashMap<AgentProfileId, AgentProfile> = HashMap::new();
+
+        let result =
+            resolve_task_execution(&store, &reg, "daily-report", PathBuf::from("/w")).await;
+        assert!(matches!(result, Err(ResolutionError::ProfileNotFound(_))));
+    }
+
+    #[tokio::test]
+    async fn resolve_task_execution_snapshot_is_stable() {
+        let store = setup_store_with_task_and_prompt().await;
+        let reg = default_registry();
+
+        // Resolve.
+        let input1 = resolve_task_execution(&store, &reg, "daily-report", PathBuf::from("/w"))
+            .await
+            .unwrap();
+
+        // Update the task's expected outcome.
+        store
+            .set_automation_task(&AutomationTaskInput {
+                id: "daily-report".to_string(),
+                name: "Daily Report".to_string(),
+                stored_prompt_id: "report-prompt".to_string(),
+                expected_outcome: "Updated outcome".to_string(),
+            })
+            .await
+            .unwrap();
+
+        // Original snapshot is unchanged.
+        assert_eq!(
+            input1.task.expected_outcome,
+            "A summary of today's activity"
+        );
+
+        // New resolution sees the update.
+        let input2 = resolve_task_execution(&store, &reg, "daily-report", PathBuf::from("/w"))
+            .await
+            .unwrap();
+        assert_eq!(input2.task.expected_outcome, "Updated outcome");
+    }
+
+    #[tokio::test]
+    async fn resolve_task_execution_with_explicit_profile() {
+        let store = ConfigStore::open_in_memory().await.unwrap();
+
+        // Register a prompt with an explicit profile.
+        let prompt = StoredPrompt {
+            instructions: "Do work".to_string(),
+            skills: Vec::new(),
+            profile: Some(AgentProfileId::from("automation")),
+        };
+        let payload = serde_json::to_value(&prompt).unwrap();
+        store
+            .set_prompt(&crate::config::PromptInput {
+                id: "work-prompt".to_string(),
+                schema_version: STORED_PROMPT_SCHEMA_VERSION,
+                payload,
+            })
+            .await
+            .unwrap();
+
+        store
+            .set_automation_task(&AutomationTaskInput {
+                id: "work-task".to_string(),
+                name: "Work".to_string(),
+                stored_prompt_id: "work-prompt".to_string(),
+                expected_outcome: "Work done".to_string(),
+            })
+            .await
+            .unwrap();
+
+        let mut reg = HashMap::new();
+        reg.insert(
+            AgentProfileId::from("automation"),
+            AgentProfile {
+                name: "Automation".to_string(),
+                approval: AgentApproval::AutoApprove,
+                ..AgentProfile::with_name("automation")
+            },
+        );
+
+        let input = resolve_task_execution(&store, &reg, "work-task", PathBuf::from("/w"))
+            .await
+            .unwrap();
+
+        assert_eq!(input.profile_id, AgentProfileId::from("automation"));
+        assert_eq!(input.profile.approval, AgentApproval::AutoApprove);
+    }
+}

--- a/src/facade.rs
+++ b/src/facade.rs
@@ -1063,6 +1063,21 @@ impl IronAgent {
         self.stored_prompt_registry.write().unregister(id.trim())
     }
 
+    /// Delete a stored prompt from both the runtime registry and ConfigStore.
+    ///
+    /// Returns `ConfigError::PromptReferencedByTasks` if one or more
+    /// automation tasks reference this prompt. The prompt is removed from
+    /// the in-memory registry only after the durable deletion succeeds.
+    pub async fn delete_stored_prompt(
+        &self,
+        store: &ConfigStore,
+        id: &str,
+    ) -> Result<(), crate::config::ConfigError> {
+        store.delete_prompt(id).await?;
+        self.stored_prompt_registry.write().unregister(id.trim());
+        Ok(())
+    }
+
     /// List all registered stored prompts with deterministic ordering.
     pub fn list_stored_prompts(&self) -> Vec<StoredPromptEntry> {
         self.stored_prompt_registry.read().list()
@@ -1862,6 +1877,20 @@ impl AgentSession {
     /// Returns the terminal [`PromptOutcome`]. For incremental event access,
     /// use [`prompt_stream`](AgentSession::prompt_stream).
     pub async fn prompt(&self, text: &str) -> PromptOutcome {
+        self.try_prompt(text)
+            .await
+            .unwrap_or(PromptOutcome::EndTurn)
+    }
+
+    /// Send a text prompt and await completion, returning errors instead of
+    /// swallowing them.
+    ///
+    /// Unlike [`prompt`](AgentSession::prompt), this method surfaces
+    /// connection-level errors as `Err`. After the prompt completes, callers
+    /// should also check [`profile_unavailable`](AgentSession::profile_unavailable)
+    /// to detect injected provider/auth errors that the runtime converts to
+    /// successful-lookahead completions with error text.
+    pub async fn try_prompt(&self, text: &str) -> Result<PromptOutcome, String> {
         let acp_session_id = acp::SessionId::new(self.id.to_string());
         let request = acp::PromptRequest::new(
             acp_session_id,
@@ -1872,9 +1901,18 @@ impl AgentSession {
             .handle_prompt(request, self.profile_id.as_ref())
             .await
         {
-            Ok(response) => response.stop_reason.into(),
-            Err(_) => PromptOutcome::EndTurn,
+            Ok(response) => Ok(response.stop_reason.into()),
+            Err(e) => Err(format!("prompt failed: {}", e)),
         }
+    }
+
+    /// Returns the profile-unavailable diagnostic if the runtime injected a
+    /// provider/auth error during the last prompt.
+    ///
+    /// When `Some`, the prompt technically completed but the output contains
+    /// injected error text rather than a genuine model response.
+    pub fn profile_unavailable(&self) -> Option<String> {
+        self.durable.lock().profile_unavailable.clone()
     }
 
     /// Send a multimodal prompt and await completion.

--- a/src/facade.rs
+++ b/src/facade.rs
@@ -1073,8 +1073,11 @@ impl IronAgent {
         store: &ConfigStore,
         id: &str,
     ) -> Result<(), crate::config::ConfigError> {
-        store.delete_prompt(id).await?;
-        self.stored_prompt_registry.write().unregister(id.trim());
+        let normalized_id = id.trim();
+        store.delete_prompt(normalized_id).await?;
+        self.stored_prompt_registry
+            .write()
+            .unregister(normalized_id);
         Ok(())
     }
 

--- a/src/headless/mod.rs
+++ b/src/headless/mod.rs
@@ -1,0 +1,1590 @@
+//! Headless runtime bootstrap and safety preflight for non-interactive
+//! automation task execution.
+//!
+//! This module reconstructs a fully functional runtime from persisted
+//! [`ConfigStore`] state, resolves the saved default provider/model through
+//! stored credentials, validates headless safety policy, and produces a
+//! [`HeadlessRuntime`] ready for root-session execution.
+//!
+//! ## Bootstrap flow
+//!
+//! 1. Load runtime settings from ConfigStore.
+//! 2. Resolve the saved default provider/model through credentials.
+//! 3. Construct `Config` and `IronAgent` with the resolved provider.
+//! 4. Load provider profiles, agent profiles, stored prompts, built-in tools,
+//!    and MCP server definitions.
+//! 5. Resolve the automation task into an immutable [`ResolvedExecutionInput`].
+//! 6. Run headless safety preflight.
+//!
+//! ## Plugin exclusion
+//!
+//! WASM plugins are not scanned, registered, or loaded. A profile that
+//! explicitly allow-lists a plugin tool fails preflight with an
+//! [`UnavailableTool`] error.
+
+use crate::builtin::BuiltinToolConfig;
+use crate::config::records::{McpServerConfigRecord, RuntimeSettingsSnapshot};
+use crate::config::{Config, ConfigError, ConfigStore, McpConfig, SkillConfig};
+use crate::execution::{is_headless_safe, resolve_task_execution, ResolvedExecutionInput};
+use crate::facade::IronAgent;
+use crate::mcp::McpServerConfig;
+use crate::profile::{AgentProfileProvider, DefaultProfileSeedPolicy, ToolFilter};
+use crate::provider_credential::{
+    CredentialResolver, DurableCredentialStore, DynCredentialStore, FallibleCredentialStore,
+    ProviderAuthError, ProviderPromptContext, ProviderSlug,
+};
+use crate::provider_profile::build_effective_registry;
+use iron_providers::{
+    InferenceRequest, Provider, ProviderEvent, ProviderFuture, ProviderRegistry, ProviderResult,
+    RuntimeConfig,
+};
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use crate::execution::{AutomationRunErrorCategory, AutomationRunResult, ResolutionError};
+use crate::profile::{AgentProfile, AgentProfileId};
+use futures::stream::BoxStream;
+
+// ============================================================================
+// Provider wrapper
+// ============================================================================
+
+/// Wrapper that allows a `Box<dyn Provider>` to be passed through the generic
+/// `P: Provider + 'static` bound on `IronAgent` constructors.
+struct ResolvedProvider(Box<dyn Provider>);
+
+impl Provider for ResolvedProvider {
+    fn infer(&self, request: InferenceRequest) -> ProviderFuture<'_, Vec<ProviderEvent>> {
+        self.0.infer(request)
+    }
+
+    fn infer_stream(
+        &self,
+        request: InferenceRequest,
+    ) -> ProviderFuture<'_, BoxStream<'static, ProviderResult<ProviderEvent>>> {
+        self.0.infer_stream(request)
+    }
+}
+
+// ============================================================================
+// Bootstrap error
+// ============================================================================
+
+/// Typed failure during headless runtime bootstrap.
+#[derive(Debug, thiserror::Error)]
+pub enum HeadlessBootstrapError {
+    /// No default provider/model saved in ConfigStore.
+    #[error("no default provider/model saved in configuration")]
+    MissingDefaultProvider,
+    /// Provider construction failed after credential resolution.
+    #[error("provider initialization failed for '{provider}': {reason}")]
+    ProviderInit { provider: String, reason: String },
+    /// Credential is missing, unreadable, or otherwise unusable.
+    #[error("credential failure for provider '{provider}': {reason}")]
+    CredentialFailure { provider: String, reason: String },
+    /// Credential exists but requires interactive re-authentication.
+    #[error("interactive authentication required for provider '{provider}': {reason}")]
+    InteractiveAuthRequired { provider: String, reason: String },
+    /// Profile approval or tool policy is unsafe for headless execution.
+    #[error("unsafe policy for headless execution: {0}")]
+    UnsafePolicy(String),
+    /// Profile explicitly requires a tool that is not available.
+    #[error("required tool '{0}' is not available in the reconstructed runtime")]
+    UnavailableTool(String),
+    /// ConfigStore error.
+    #[error(transparent)]
+    Config(#[from] ConfigError),
+    /// Execution-input resolution error.
+    #[error(transparent)]
+    Resolution(#[from] ResolutionError),
+}
+
+// ============================================================================
+// Bootstrapped runtime
+// ============================================================================
+
+/// Fully bootstrapped headless runtime ready for root-session execution.
+///
+/// Produced by [`bootstrap_headless`] after resolving all persisted state,
+/// constructing the agent, and passing safety preflight. Phase 4 root-session
+/// execution consumes this struct.
+pub struct HeadlessRuntime {
+    /// Fully initialized agent with provider, credentials, profiles, prompts,
+    /// built-in tools, and MCP servers loaded.
+    pub agent: IronAgent,
+    /// Immutable execution-input snapshot resolved at run start.
+    pub resolved: ResolvedExecutionInput,
+    /// Resolved provider slug (from saved default model).
+    pub provider_slug: String,
+    /// Resolved model identifier (from saved default model).
+    pub model: String,
+    /// Sorted effective tool names after applying the profile's tool filter
+    /// to the reconstructed base tool inventory.
+    pub effective_tools: Vec<String>,
+}
+
+// ============================================================================
+// Bootstrap entry point
+// ============================================================================
+
+/// Bootstrap a headless runtime from persisted ConfigStore state.
+///
+/// This is the main entry point for headless automation. It:
+///
+/// 1. Loads runtime settings (default model, MCP servers, skill settings).
+/// 2. Resolves the saved default provider/model through stored credentials.
+/// 3. Constructs the runtime with built-in tools, MCP servers, skills,
+///    profiles, and stored prompts.
+/// 4. Resolves the named automation task into an immutable snapshot.
+/// 5. Runs headless safety preflight (AutoApprove, tool availability).
+///
+/// WASM plugins are never scanned, registered, or loaded.
+pub async fn bootstrap_headless(
+    store: ConfigStore,
+    task_id: &str,
+    workspace: PathBuf,
+) -> Result<HeadlessRuntime, HeadlessBootstrapError> {
+    // 1. Load persisted settings.
+    let settings = store.load_runtime_settings().await?;
+
+    // 2. Resolve saved default provider/model through credentials.
+    let (provider, default_slug, default_model) =
+        resolve_default_provider(&store, &settings).await?;
+
+    // 3. Build Config from persisted settings.
+    let skill_settings = &settings.skill_settings;
+    let config = Config::default()
+        .with_model(default_model.clone())
+        .with_provider_name(default_slug.clone())
+        .with_workspace_roots(vec![workspace.clone()])
+        .with_mcp(McpConfig {
+            enabled: true,
+            enabled_by_default: true,
+        })
+        .with_skills(SkillConfig {
+            enabled: true,
+            trust_project_skills: skill_settings.trust_project_skills,
+            additional_skill_dirs: skill_settings.additional_skill_dirs.clone(),
+        });
+
+    // 4. Create credential store for runtime-level managed provider resolution.
+    let runtime_cred_store: DynCredentialStore =
+        Arc::new(DurableCredentialStore::new(store.clone()));
+
+    // 5. Construct the agent with the resolved provider.
+    let provider_wrapper = ResolvedProvider(provider);
+    let agent = IronAgent::new_with_credential_store(config, provider_wrapper, runtime_cred_store);
+
+    // 6. Load persisted state into the runtime.
+    agent.load_provider_profiles(&store).await?;
+    agent
+        .seed_default_profiles(&store, DefaultProfileSeedPolicy::FirstRunOnly)
+        .await?;
+    agent.load_profiles(&store).await?;
+    agent.load_stored_prompts(&store).await?;
+
+    // 7. Register built-in tools with the resolved workspace as allowed root.
+    let builtin_config = BuiltinToolConfig::new(vec![workspace.clone()]);
+    agent.register_builtin_tools(&builtin_config);
+
+    // 8. Register persisted MCP servers.
+    for record in &settings.mcp_servers {
+        let mcp_config = mcp_record_to_config(record);
+        agent.register_mcp_server(mcp_config);
+    }
+
+    // 9. Build profile registry HashMap for task resolution.
+    let profiles: HashMap<AgentProfileId, AgentProfile> = agent
+        .list_profiles()
+        .into_iter()
+        .map(|entry| (entry.id, entry.profile))
+        .collect();
+
+    // 10. Resolve the automation task.
+    let resolved = resolve_task_execution(&store, &profiles, task_id, workspace).await?;
+
+    // 11. Preflight: approval check only. Tool availability is checked in
+    //     run_automation after session creation so MCP tools are included.
+    if !is_headless_safe(resolved.profile.approval) {
+        return Err(HeadlessBootstrapError::UnsafePolicy(format!(
+            "profile '{}' uses {:?}, but headless execution requires AutoApprove",
+            resolved.profile_id.as_str(),
+            resolved.profile.approval
+        )));
+    }
+
+    // 12. Determine reported provider/model based on the resolved profile
+    //     variant (F1). Managed profiles report their configured provider/model;
+    //     RuntimeDefault profiles report the saved default.
+    let (provider_slug, model) = match &resolved.profile.provider {
+        AgentProfileProvider::RuntimeDefault => (default_slug, default_model),
+        AgentProfileProvider::Managed {
+            provider_slug,
+            model,
+        } => (provider_slug.as_str().to_string(), model.clone()),
+    };
+
+    Ok(HeadlessRuntime {
+        agent,
+        resolved,
+        provider_slug,
+        model,
+        effective_tools: Vec::new(),
+    })
+}
+
+// ============================================================================
+// Default provider resolution
+// ============================================================================
+
+/// Resolve the saved default provider/model through credentials and the
+/// effective provider registry.
+///
+/// Returns the constructed provider, provider slug, and model. Fails closed
+/// if the default is missing, credentials are unavailable, or the provider
+/// cannot be constructed.
+async fn resolve_default_provider(
+    store: &ConfigStore,
+    settings: &RuntimeSettingsSnapshot,
+) -> Result<(Box<dyn Provider>, String, String), HeadlessBootstrapError> {
+    let default = settings
+        .default_model
+        .as_ref()
+        .ok_or(HeadlessBootstrapError::MissingDefaultProvider)?;
+
+    let provider_slug = default.provider_slug.clone();
+    let model = default.model_id.clone();
+
+    // Build effective provider registry (built-ins + persisted profiles).
+    let registry: ProviderRegistry = build_effective_registry(store).await?;
+
+    // Build credential resolver with fallible store for actionable errors.
+    let durable = Arc::new(DurableCredentialStore::new(store.clone()));
+    let cred_store: DynCredentialStore = durable.clone();
+    let fallible: Arc<dyn FallibleCredentialStore> = durable.clone();
+    let resolver = CredentialResolver::with_fallible_store(cred_store, fallible);
+
+    // Merge support from persisted provider profiles.
+    let profile_records = store.list_provider_profiles().await?;
+    let provider_profiles: Vec<iron_providers::ProviderProfile> = profile_records
+        .into_iter()
+        .filter_map(|r| serde_json::from_str(&r.profile_json).ok())
+        .collect();
+    resolver.merge_support_from_profiles(&provider_profiles);
+
+    // Resolve credential.
+    let context = ProviderPromptContext {
+        provider_slug: ProviderSlug::new(&provider_slug),
+        model: model.clone(),
+        api_key: None,
+    };
+
+    let resolved_credential = resolver
+        .resolve(&context, None)
+        .await
+        .map_err(map_auth_error)?;
+
+    // Construct provider.
+    let runtime_config = RuntimeConfig::from_credential(resolved_credential.provider_credential);
+    let provider = registry.get(&provider_slug, runtime_config).map_err(|e| {
+        HeadlessBootstrapError::ProviderInit {
+            provider: provider_slug.clone(),
+            reason: e.to_string(),
+        }
+    })?;
+
+    Ok((provider, provider_slug, model))
+}
+
+/// Map a `ProviderAuthError` to the appropriate `HeadlessBootstrapError`.
+fn map_auth_error(e: ProviderAuthError) -> HeadlessBootstrapError {
+    match e {
+        ProviderAuthError::NotConfigured(slug) => HeadlessBootstrapError::CredentialFailure {
+            provider: slug,
+            reason: "no credential configured".to_string(),
+        },
+        ProviderAuthError::UnsupportedCredential { provider, mode } => {
+            HeadlessBootstrapError::CredentialFailure {
+                provider,
+                reason: format!("unsupported credential mode: {:?}", mode),
+            }
+        }
+        ProviderAuthError::Expired(slug) => HeadlessBootstrapError::CredentialFailure {
+            provider: slug,
+            reason: "token expired".to_string(),
+        },
+        ProviderAuthError::RefreshFailed { provider, reason } => {
+            HeadlessBootstrapError::InteractiveAuthRequired {
+                provider,
+                reason: format!("token refresh failed: {}", reason),
+            }
+        }
+        ProviderAuthError::Revoked(slug) => HeadlessBootstrapError::InteractiveAuthRequired {
+            provider: slug,
+            reason: "credential revoked, re-authentication required".to_string(),
+        },
+        ProviderAuthError::StoreError { provider, reason } => {
+            HeadlessBootstrapError::CredentialFailure { provider, reason }
+        }
+    }
+}
+
+// ============================================================================
+// Headless safety preflight
+// ============================================================================
+
+/// Validate that the resolved profile and tool inventory are safe for
+/// non-interactive headless execution.
+///
+/// Checks:
+/// - Profile approval must be `AutoApprove` (rejects `PerTool`).
+/// - All explicitly allow-listed tools must be available in the base registry.
+/// - `Inherit` and `Deny` filters are accepted without additional checks.
+pub fn preflight_headless_safety(
+    input: &ResolvedExecutionInput,
+    tool_names: &[String],
+) -> Result<(), HeadlessBootstrapError> {
+    if !is_headless_safe(input.profile.approval) {
+        return Err(HeadlessBootstrapError::UnsafePolicy(format!(
+            "profile '{}' uses {:?}, but headless execution requires AutoApprove",
+            input.profile_id.as_str(),
+            input.profile.approval
+        )));
+    }
+
+    if let ToolFilter::Allow(allowed) = &input.profile.tools {
+        for tool in allowed {
+            if !tool_names.iter().any(|n| n == tool) {
+                return Err(HeadlessBootstrapError::UnavailableTool(tool.clone()));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+// ============================================================================
+// Effective tools computation
+// ============================================================================
+
+/// Compute the effective tool set after applying a tool filter to available
+/// tool names.
+///
+/// - `Inherit`: all available tools.
+/// - `Allow`: only tools in both the allow-list and the available set.
+/// - `Deny`: available tools minus the denied set.
+///
+/// Results are sorted for deterministic output.
+pub fn compute_effective_tools(filter: &ToolFilter, available: &[String]) -> Vec<String> {
+    let mut tools: Vec<String> = match filter {
+        ToolFilter::Inherit => available.to_vec(),
+        ToolFilter::Allow(allowed) => available
+            .iter()
+            .filter(|n| allowed.iter().any(|a| a == *n))
+            .cloned()
+            .collect(),
+        ToolFilter::Deny(denied) => available
+            .iter()
+            .filter(|n| !denied.iter().any(|d| d == *n))
+            .cloned()
+            .collect(),
+    };
+    tools.sort();
+    tools
+}
+
+// ============================================================================
+// Root-session automation execution
+// ============================================================================
+
+/// Execute an automation task as a root session with timeout and cancellation.
+///
+/// This is the main entry point for Phase 4 root-session execution. It:
+///
+/// 1. Connects to the agent and creates a root session with the resolved
+///    profile.
+/// 2. Applies the canonical workspace as session roots.
+/// 3. Sends the composed user goal as a single prompt.
+/// 4. Races the prompt against a timeout and an external cancellation token.
+/// 5. Extracts the final assistant text and returns a structured result.
+///
+/// The function does not create a synthetic parent session — the resolved
+/// profile's tool filter and approval mode are snapshotted directly into the
+/// root session via `create_session_with_profile`.
+///
+/// **Must run on a `tokio::task::LocalSet`** because `AgentSession` uses `Rc`
+/// internally and is `!Send`.
+pub async fn run_automation(
+    headless: HeadlessRuntime,
+    timeout: std::time::Duration,
+    cancel: tokio_util::sync::CancellationToken,
+) -> AutomationRunResult {
+    let HeadlessRuntime {
+        agent,
+        resolved,
+        provider_slug,
+        model,
+        ..
+    } = headless;
+
+    let mut result = AutomationRunResult::started(&resolved.task, resolved.workspace.clone());
+
+    // Connect and create root session.
+    let connection = agent.connect();
+    let session = match connection.create_session_with_profile(resolved.profile_id.clone()) {
+        Ok(s) => s,
+        Err(e) => {
+            result.fail(
+                AutomationRunErrorCategory::Execution,
+                format!("failed to create root session: {}", e),
+            );
+            return result;
+        }
+    };
+
+    // Apply canonical workspace explicitly (F10: surface failures).
+    if let Err(e) = session.set_workspace_roots(vec![resolved.workspace.clone()]) {
+        result.fail(
+            AutomationRunErrorCategory::Execution,
+            format!("failed to set workspace roots: {}", e),
+        );
+        return result;
+    }
+
+    // Activate effective skills on the root session (F2).
+    for skill_name in &resolved.effective_skills {
+        if let Err(e) = session.activate_skill(skill_name) {
+            result.fail(
+                AutomationRunErrorCategory::Execution,
+                format!("failed to activate skill '{}': {}", skill_name, e),
+            );
+            return result;
+        }
+    }
+
+    // Compute effective tools from the session-effective catalog (F3).
+    // This includes MCP tools that are invisible to the base registry.
+    let session_tool_names: Vec<String> = agent
+        .get_effective_tools(session.id())
+        .into_iter()
+        .map(|d| d.name)
+        .collect();
+
+    // Preflight: check allow-listed tools against the full session catalog.
+    if let ToolFilter::Allow(allowed) = &resolved.profile.tools {
+        for tool in allowed {
+            if !session_tool_names.iter().any(|n| n == tool) {
+                result.fail(
+                    AutomationRunErrorCategory::UnsafePolicy,
+                    format!(
+                        "required tool '{}' is not available in the session tool catalog",
+                        tool
+                    ),
+                );
+                return result;
+            }
+        }
+    }
+
+    let effective_tools = compute_effective_tools(&resolved.profile.tools, &session_tool_names);
+
+    result.set_resolved_metadata(
+        resolved.profile_id.as_str(),
+        if provider_slug.is_empty() {
+            None
+        } else {
+            Some(provider_slug)
+        },
+        if model.is_empty() { None } else { Some(model) },
+        effective_tools,
+    );
+
+    // Execute with timeout and cancellation.
+    let cancel_session = session.clone();
+    let cancel_token = cancel.clone();
+
+    tokio::select! {
+        biased;
+
+        _ = cancel_token.cancelled() => {
+            cancel_session.cancel().await;
+            result.cancel("cancelled by signal".to_string());
+        }
+
+        _ = tokio::time::sleep(timeout) => {
+            cancel_session.cancel().await;
+            result.timeout(format!("exceeded {} timeout", format_duration(timeout)));
+        }
+
+        prompt_result = session.try_prompt(&resolved.user_goal) => {
+            match prompt_result {
+                Err(e) => {
+                    result.fail(
+                        AutomationRunErrorCategory::Execution,
+                        format!("prompt error: {}", e),
+                    );
+                }
+                Ok(crate::facade::PromptOutcome::Cancelled) => {
+                    result.cancel("prompt was cancelled".to_string());
+                }
+                Ok(_outcome) => {
+                    // Check for injected provider/auth errors (F4).
+                    if let Some(diagnostic) = session.profile_unavailable() {
+                        result.fail(
+                            AutomationRunErrorCategory::Execution,
+                            format!("provider unavailable: {}", diagnostic),
+                        );
+                    } else {
+                        let text = extract_final_text(&session.messages());
+                        result.complete(text);
+                    }
+                }
+            }
+        }
+    }
+
+    result
+}
+
+/// Extract the final assistant text from conversation messages.
+///
+/// Scans messages in reverse and returns the text content of the last
+/// agent message. Returns an empty string if no agent message exists.
+pub fn extract_final_text(messages: &[crate::durable::StructuredMessage]) -> String {
+    for msg in messages.iter().rev() {
+        if msg.is_agent() {
+            return msg.text_content();
+        }
+    }
+    String::new()
+}
+
+/// Format a duration for human-readable timeout messages.
+fn format_duration(d: std::time::Duration) -> String {
+    let secs = d.as_secs();
+    if secs >= 3600 && secs.is_multiple_of(3600) {
+        format!("{}h", secs / 3600)
+    } else if secs >= 60 && secs.is_multiple_of(60) {
+        format!("{}m", secs / 60)
+    } else {
+        format!("{}s", secs)
+    }
+}
+
+// ============================================================================
+// MCP record conversion
+// ============================================================================
+
+/// Convert a persisted `McpServerConfigRecord` to a runtime `McpServerConfig`.
+fn mcp_record_to_config(record: &McpServerConfigRecord) -> McpServerConfig {
+    McpServerConfig {
+        id: record.id.clone(),
+        label: record.label.clone(),
+        description: record.description.clone(),
+        transport: record.transport.clone(),
+        enabled_by_default: record.enabled_by_default,
+        working_dir: record.working_dir.clone(),
+        inherited_env_vars: record.inherited_env_vars.clone(),
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::automation_task::AutomationTaskInput;
+    use crate::config::{
+        ConfigStore, DefaultModelInput, McpServerConfigInput, ProfileInput, PromptInput,
+        SkillSettingsInput,
+    };
+    use crate::mcp::{HttpConfig, McpTransport};
+    use crate::profile::{
+        AgentApproval, AgentProfile, AgentProfileProvider, PROFILE_SCHEMA_VERSION,
+    };
+    use crate::provider_credential::{ProviderCredentialStore, ProviderSlug, StoredCredential};
+    use crate::stored_prompt::{StoredPrompt, STORED_PROMPT_SCHEMA_VERSION};
+
+    // ---- compute_effective_tools ----
+
+    #[test]
+    fn effective_tools_inherit_returns_all_sorted() {
+        let filter = ToolFilter::Inherit;
+        let available = vec!["z_tool".to_string(), "a_tool".to_string()];
+        let result = compute_effective_tools(&filter, &available);
+        assert_eq!(result, vec!["a_tool", "z_tool"]);
+    }
+
+    #[test]
+    fn effective_tools_allow_filters_to_intersection() {
+        let filter = ToolFilter::Allow(vec!["a_tool".to_string(), "missing".to_string()]);
+        let available = vec!["a_tool".to_string(), "z_tool".to_string()];
+        let result = compute_effective_tools(&filter, &available);
+        assert_eq!(result, vec!["a_tool"]);
+    }
+
+    #[test]
+    fn effective_tools_deny_excludes_denied() {
+        let filter = ToolFilter::Deny(vec!["z_tool".to_string()]);
+        let available = vec![
+            "a_tool".to_string(),
+            "z_tool".to_string(),
+            "m_tool".to_string(),
+        ];
+        let result = compute_effective_tools(&filter, &available);
+        assert_eq!(result, vec!["a_tool", "m_tool"]);
+    }
+
+    #[test]
+    fn effective_tools_empty_available() {
+        let filter = ToolFilter::Inherit;
+        let result = compute_effective_tools(&filter, &[]);
+        assert!(result.is_empty());
+    }
+
+    // ---- preflight_headless_safety ----
+
+    fn make_resolved_input(approval: AgentApproval, tools: ToolFilter) -> ResolvedExecutionInput {
+        let now = chrono::Utc::now();
+        let task = crate::automation_task::AutomationTask {
+            id: "test".to_string(),
+            name: "Test".to_string(),
+            stored_prompt_id: "p".to_string(),
+            expected_outcome: "done".to_string(),
+            created_at: now,
+            updated_at: now,
+        };
+        let prompt = StoredPrompt {
+            instructions: "do".to_string(),
+            skills: Vec::new(),
+            profile: None,
+        };
+        let profile = AgentProfile {
+            name: "test".to_string(),
+            provider: AgentProfileProvider::RuntimeDefault,
+            tools,
+            skills: crate::profile::SkillFilter::Inherit,
+            approval,
+            identity_prompt: None,
+        };
+        ResolvedExecutionInput {
+            task,
+            prompt,
+            profile_id: AgentProfileId::from("test"),
+            profile,
+            user_goal: "do\n\ndone".to_string(),
+            effective_skills: Vec::new(),
+            workspace: PathBuf::from("/tmp"),
+            resolved_at: now,
+        }
+    }
+
+    #[test]
+    fn preflight_autoapprove_inherit_passes() {
+        let input = make_resolved_input(AgentApproval::AutoApprove, ToolFilter::Inherit);
+        let tools = vec!["tool_a".to_string()];
+        assert!(preflight_headless_safety(&input, &tools).is_ok());
+    }
+
+    #[test]
+    fn preflight_pertool_fails() {
+        let input = make_resolved_input(AgentApproval::PerTool, ToolFilter::Inherit);
+        let tools = vec!["tool_a".to_string()];
+        let err = preflight_headless_safety(&input, &tools).unwrap_err();
+        assert!(matches!(err, HeadlessBootstrapError::UnsafePolicy(_)));
+    }
+
+    #[test]
+    fn preflight_autoapprove_allow_available_passes() {
+        let input = make_resolved_input(
+            AgentApproval::AutoApprove,
+            ToolFilter::Allow(vec!["tool_a".to_string()]),
+        );
+        let tools = vec!["tool_a".to_string(), "tool_b".to_string()];
+        assert!(preflight_headless_safety(&input, &tools).is_ok());
+    }
+
+    #[test]
+    fn preflight_autoapprove_allow_missing_fails() {
+        let input = make_resolved_input(
+            AgentApproval::AutoApprove,
+            ToolFilter::Allow(vec!["plugin_tool".to_string()]),
+        );
+        let tools = vec!["tool_a".to_string()];
+        let err = preflight_headless_safety(&input, &tools).unwrap_err();
+        assert!(matches!(err, HeadlessBootstrapError::UnavailableTool(t) if t == "plugin_tool"));
+    }
+
+    #[test]
+    fn preflight_autoapprove_deny_passes_regardless() {
+        let input = make_resolved_input(
+            AgentApproval::AutoApprove,
+            ToolFilter::Deny(vec!["missing".to_string()]),
+        );
+        let tools = vec!["tool_a".to_string()];
+        assert!(preflight_headless_safety(&input, &tools).is_ok());
+    }
+
+    // ---- mcp_record_to_config ----
+
+    #[test]
+    fn mcp_record_converts_to_config() {
+        let now = chrono::Utc::now();
+        let record = McpServerConfigRecord {
+            id: "test-server".to_string(),
+            label: "Test".to_string(),
+            description: Some("A test server".to_string()),
+            transport: McpTransport::Http {
+                config: HttpConfig::new("https://example.com/mcp".to_string()),
+            },
+            working_dir: None,
+            enabled_by_default: true,
+            inherited_env_vars: vec!["PATH".to_string()],
+            created_at: now,
+            updated_at: now,
+        };
+        let config = mcp_record_to_config(&record);
+        assert_eq!(config.id, "test-server");
+        assert_eq!(config.label, "Test");
+        assert_eq!(config.description.as_deref(), Some("A test server"));
+        assert!(config.enabled_by_default);
+        assert_eq!(config.inherited_env_vars, vec!["PATH"]);
+    }
+
+    // ---- resolve_default_provider ----
+
+    #[tokio::test]
+    async fn resolve_default_provider_success() {
+        let store = ConfigStore::open_in_memory().await.unwrap();
+
+        // Store credential.
+        let durable = Arc::new(DurableCredentialStore::new(store.clone()));
+        ProviderCredentialStore::set(
+            &*durable,
+            &ProviderSlug::new("openai"),
+            StoredCredential::ApiKey("sk-test".to_string()),
+        )
+        .await;
+
+        // Set default model.
+        store
+            .set_default_model(&DefaultModelInput {
+                provider_slug: "openai".to_string(),
+                model_id: "gpt-4o".to_string(),
+            })
+            .await
+            .unwrap();
+
+        let settings = store.load_runtime_settings().await.unwrap();
+        let (provider, slug, model) = resolve_default_provider(&store, &settings)
+            .await
+            .expect("provider resolution should succeed");
+
+        assert_eq!(slug, "openai");
+        assert_eq!(model, "gpt-4o");
+        // Provider object exists — we can't do much with it without a network call.
+        let _ = provider;
+    }
+
+    #[tokio::test]
+    async fn resolve_default_provider_missing_default() {
+        let store = ConfigStore::open_in_memory().await.unwrap();
+        let settings = store.load_runtime_settings().await.unwrap();
+
+        let result = resolve_default_provider(&store, &settings).await;
+        assert!(matches!(
+            result,
+            Err(HeadlessBootstrapError::MissingDefaultProvider)
+        ));
+    }
+
+    #[tokio::test]
+    async fn resolve_default_provider_missing_credential() {
+        let store = ConfigStore::open_in_memory().await.unwrap();
+
+        store
+            .set_default_model(&DefaultModelInput {
+                provider_slug: "openai".to_string(),
+                model_id: "gpt-4o".to_string(),
+            })
+            .await
+            .unwrap();
+
+        let settings = store.load_runtime_settings().await.unwrap();
+        let result = resolve_default_provider(&store, &settings).await;
+        assert!(matches!(
+            result,
+            Err(HeadlessBootstrapError::CredentialFailure { .. })
+        ));
+    }
+
+    // ---- map_auth_error ----
+
+    #[test]
+    fn map_not_configured_to_credential_failure() {
+        let err = map_auth_error(ProviderAuthError::NotConfigured("openai".to_string()));
+        assert!(matches!(
+            err,
+            HeadlessBootstrapError::CredentialFailure { provider, .. } if provider == "openai"
+        ));
+    }
+
+    #[test]
+    fn map_revoked_to_interactive_auth() {
+        let err = map_auth_error(ProviderAuthError::Revoked("openai".to_string()));
+        assert!(matches!(
+            err,
+            HeadlessBootstrapError::InteractiveAuthRequired { provider, .. } if provider == "openai"
+        ));
+    }
+
+    #[test]
+    fn map_refresh_failed_to_interactive_auth() {
+        let err = map_auth_error(ProviderAuthError::RefreshFailed {
+            provider: "openai".to_string(),
+            reason: "network error".to_string(),
+        });
+        assert!(matches!(
+            err,
+            HeadlessBootstrapError::InteractiveAuthRequired { .. }
+        ));
+    }
+
+    // ---- bootstrap_headless full flow ----
+
+    /// Helper: set up a complete ConfigStore with provider credential,
+    /// default model, AutoApprove profile, prompt, and task.
+    async fn setup_complete_store() -> ConfigStore {
+        let store = ConfigStore::open_in_memory().await.unwrap();
+
+        // 1. Store API key credential for openai.
+        let durable = Arc::new(DurableCredentialStore::new(store.clone()));
+        ProviderCredentialStore::set(
+            &*durable,
+            &ProviderSlug::new("openai"),
+            StoredCredential::ApiKey("sk-test".to_string()),
+        )
+        .await;
+
+        // 2. Set default model.
+        store
+            .set_default_model(&DefaultModelInput {
+                provider_slug: "openai".to_string(),
+                model_id: "gpt-4o".to_string(),
+            })
+            .await
+            .unwrap();
+
+        // 3. Create an AutoApprove profile.
+        let auto_profile = AgentProfile {
+            name: "automation".to_string(),
+            provider: AgentProfileProvider::RuntimeDefault,
+            tools: ToolFilter::Inherit,
+            skills: crate::profile::SkillFilter::Inherit,
+            approval: AgentApproval::AutoApprove,
+            identity_prompt: None,
+        };
+        store
+            .set_profile(&ProfileInput {
+                id: "automation".to_string(),
+                schema_version: PROFILE_SCHEMA_VERSION,
+                payload: serde_json::to_value(&auto_profile).unwrap(),
+            })
+            .await
+            .unwrap();
+
+        // 4. Create a stored prompt referencing the automation profile.
+        let prompt = StoredPrompt {
+            instructions: "Generate a daily report".to_string(),
+            skills: Vec::new(),
+            profile: Some(AgentProfileId::from("automation")),
+        };
+        store
+            .set_prompt(&PromptInput {
+                id: "report-prompt".to_string(),
+                schema_version: STORED_PROMPT_SCHEMA_VERSION,
+                payload: serde_json::to_value(&prompt).unwrap(),
+            })
+            .await
+            .unwrap();
+
+        // 5. Create an automation task.
+        store
+            .set_automation_task(&AutomationTaskInput {
+                id: "daily-report".to_string(),
+                name: "Daily Report".to_string(),
+                stored_prompt_id: "report-prompt".to_string(),
+                expected_outcome: "A summary of today's activity".to_string(),
+            })
+            .await
+            .unwrap();
+
+        store
+    }
+
+    #[tokio::test]
+    async fn bootstrap_success() {
+        let store = setup_complete_store().await;
+        let workspace = std::env::temp_dir();
+
+        let runtime = bootstrap_headless(store, "daily-report", workspace.clone())
+            .await
+            .expect("bootstrap should succeed");
+
+        assert_eq!(runtime.provider_slug, "openai");
+        assert_eq!(runtime.model, "gpt-4o");
+        assert_eq!(runtime.resolved.task.id, "daily-report");
+        assert_eq!(
+            runtime.resolved.profile_id,
+            AgentProfileId::from("automation")
+        );
+        assert_eq!(
+            runtime.resolved.profile.approval,
+            AgentApproval::AutoApprove
+        );
+        // effective_tools is empty after bootstrap — computed in run_automation
+        // after session creation so MCP tools are included.
+        assert!(runtime.effective_tools.is_empty());
+    }
+
+    #[tokio::test]
+    async fn bootstrap_missing_default_provider() {
+        let store = ConfigStore::open_in_memory().await.unwrap();
+
+        let result = bootstrap_headless(store, "any-task", std::env::temp_dir()).await;
+        assert!(matches!(
+            result,
+            Err(HeadlessBootstrapError::MissingDefaultProvider)
+        ));
+    }
+
+    #[tokio::test]
+    async fn bootstrap_missing_credential() {
+        let store = ConfigStore::open_in_memory().await.unwrap();
+        store
+            .set_default_model(&DefaultModelInput {
+                provider_slug: "openai".to_string(),
+                model_id: "gpt-4o".to_string(),
+            })
+            .await
+            .unwrap();
+
+        let result = bootstrap_headless(store, "any-task", std::env::temp_dir()).await;
+        assert!(matches!(
+            result,
+            Err(HeadlessBootstrapError::CredentialFailure { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn bootstrap_unsafe_profile_fails_preflight() {
+        let store = setup_complete_store().await;
+
+        // Override the profile to PerTool (unsafe for headless).
+        let pertool_profile = AgentProfile {
+            name: "automation".to_string(),
+            provider: AgentProfileProvider::RuntimeDefault,
+            tools: ToolFilter::Inherit,
+            skills: crate::profile::SkillFilter::Inherit,
+            approval: AgentApproval::PerTool,
+            identity_prompt: None,
+        };
+        store
+            .set_profile(&ProfileInput {
+                id: "automation".to_string(),
+                schema_version: PROFILE_SCHEMA_VERSION,
+                payload: serde_json::to_value(&pertool_profile).unwrap(),
+            })
+            .await
+            .unwrap();
+
+        let result = bootstrap_headless(store, "daily-report", std::env::temp_dir()).await;
+        assert!(matches!(
+            result,
+            Err(HeadlessBootstrapError::UnsafePolicy(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn bootstrap_default_profile_not_headless_safe() {
+        let store = ConfigStore::open_in_memory().await.unwrap();
+
+        // Credential + default model.
+        let durable = Arc::new(DurableCredentialStore::new(store.clone()));
+        ProviderCredentialStore::set(
+            &*durable,
+            &ProviderSlug::new("openai"),
+            StoredCredential::ApiKey("sk-test".to_string()),
+        )
+        .await;
+        store
+            .set_default_model(&DefaultModelInput {
+                provider_slug: "openai".to_string(),
+                model_id: "gpt-4o".to_string(),
+            })
+            .await
+            .unwrap();
+
+        // Prompt WITHOUT explicit profile — resolves to built-in "default"
+        // which has PerTool → fails preflight.
+        let prompt = StoredPrompt {
+            instructions: "Do something".to_string(),
+            skills: Vec::new(),
+            profile: None,
+        };
+        store
+            .set_prompt(&PromptInput {
+                id: "p1".to_string(),
+                schema_version: STORED_PROMPT_SCHEMA_VERSION,
+                payload: serde_json::to_value(&prompt).unwrap(),
+            })
+            .await
+            .unwrap();
+
+        store
+            .set_automation_task(&AutomationTaskInput {
+                id: "t1".to_string(),
+                name: "T1".to_string(),
+                stored_prompt_id: "p1".to_string(),
+                expected_outcome: "done".to_string(),
+            })
+            .await
+            .unwrap();
+
+        let result = bootstrap_headless(store, "t1", std::env::temp_dir()).await;
+        assert!(matches!(
+            result,
+            Err(HeadlessBootstrapError::UnsafePolicy(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn bootstrap_task_not_found() {
+        let store = setup_complete_store().await;
+        let result = bootstrap_headless(store, "nonexistent", std::env::temp_dir()).await;
+        assert!(matches!(
+            result,
+            Err(HeadlessBootstrapError::Resolution(
+                ResolutionError::TaskNotFound(_)
+            ))
+        ));
+    }
+
+    #[tokio::test]
+    async fn bootstrap_allow_listed_unavailable_tool() {
+        // Tool availability is checked in run_automation (after session
+        // creation), not in bootstrap. Bootstrap should succeed; the
+        // tool check failure surfaces as a Failed result from run_automation.
+        let store = setup_complete_store().await;
+
+        // Override the profile to allow-list a nonexistent plugin tool.
+        let allow_profile = AgentProfile {
+            name: "automation".to_string(),
+            provider: AgentProfileProvider::RuntimeDefault,
+            tools: ToolFilter::Allow(vec!["plugin_imaginary_tool".to_string()]),
+            skills: crate::profile::SkillFilter::Inherit,
+            approval: AgentApproval::AutoApprove,
+            identity_prompt: None,
+        };
+        store
+            .set_profile(&ProfileInput {
+                id: "automation".to_string(),
+                schema_version: PROFILE_SCHEMA_VERSION,
+                payload: serde_json::to_value(&allow_profile).unwrap(),
+            })
+            .await
+            .unwrap();
+
+        // Bootstrap succeeds — tool check is deferred to run_automation.
+        let runtime = bootstrap_headless(store, "daily-report", std::env::temp_dir())
+            .await
+            .expect("bootstrap should succeed (tool check deferred)");
+
+        let result = run_automation(
+            runtime,
+            std::time::Duration::from_secs(5),
+            tokio_util::sync::CancellationToken::new(),
+        )
+        .await;
+
+        assert_eq!(result.status, AutomationRunStatus::Failed);
+        assert!(result
+            .error
+            .as_ref()
+            .map(|e| e.message.contains("plugin_imaginary_tool"))
+            .unwrap_or(false));
+    }
+
+    #[tokio::test]
+    async fn bootstrap_with_mcp_server() {
+        let store = setup_complete_store().await;
+
+        // Add an MCP server record.
+        store
+            .set_mcp_server(&McpServerConfigInput {
+                id: "test-mcp".to_string(),
+                label: "Test MCP".to_string(),
+                description: None,
+                transport: McpTransport::Http {
+                    config: HttpConfig::new("https://example.com/mcp".to_string()),
+                },
+                working_dir: None,
+                enabled_by_default: true,
+                inherited_env_vars: Vec::new(),
+            })
+            .await
+            .unwrap();
+
+        let runtime = bootstrap_headless(store, "daily-report", std::env::temp_dir())
+            .await
+            .expect("bootstrap should succeed with MCP");
+
+        // MCP server is registered in the runtime.
+        let mcp_registry = runtime.agent.mcp_registry();
+        assert!(mcp_registry
+            .list_servers()
+            .iter()
+            .any(|s| s.config.id == "test-mcp"));
+    }
+
+    #[tokio::test]
+    async fn bootstrap_skill_settings_preserved() {
+        let store = setup_complete_store().await;
+
+        // Set skill settings with trust_project_skills.
+        store
+            .set_skill_settings(&SkillSettingsInput {
+                trust_project_skills: true,
+                additional_skill_dirs: vec![PathBuf::from("/custom/skills")],
+            })
+            .await
+            .unwrap();
+
+        let runtime = bootstrap_headless(store, "daily-report", std::env::temp_dir())
+            .await
+            .expect("bootstrap should succeed");
+
+        // Verify skill catalog was refreshed with workspace roots (not empty
+        // would be fine too, just verify it didn't crash).
+        let _catalog = runtime.agent.runtime().skill_catalog();
+    }
+
+    #[tokio::test]
+    async fn bootstrap_managed_profile_reports_its_provider_model() {
+        let store = setup_complete_store().await;
+
+        // Override the profile to Managed with a different model.
+        let managed_profile = AgentProfile {
+            name: "automation".to_string(),
+            provider: AgentProfileProvider::Managed {
+                provider_slug: ProviderSlug::new("openai"),
+                model: "gpt-4o-mini".to_string(),
+            },
+            tools: ToolFilter::Inherit,
+            skills: crate::profile::SkillFilter::Inherit,
+            approval: AgentApproval::AutoApprove,
+            identity_prompt: None,
+        };
+        store
+            .set_profile(&ProfileInput {
+                id: "automation".to_string(),
+                schema_version: PROFILE_SCHEMA_VERSION,
+                payload: serde_json::to_value(&managed_profile).unwrap(),
+            })
+            .await
+            .unwrap();
+
+        let runtime = bootstrap_headless(store, "daily-report", std::env::temp_dir())
+            .await
+            .expect("bootstrap should succeed");
+
+        // Provider/model must come from the Managed profile, not the saved default.
+        assert_eq!(runtime.provider_slug, "openai");
+        assert_eq!(runtime.model, "gpt-4o-mini");
+    }
+
+    #[tokio::test]
+    async fn bootstrap_plugin_exclusion_no_plugin_tools() {
+        let store = setup_complete_store().await;
+        let runtime = bootstrap_headless(store, "daily-report", std::env::temp_dir())
+            .await
+            .expect("bootstrap should succeed");
+
+        // Verify no plugin namespaced tools are in the base tool registry.
+        // Plugins are never registered during headless bootstrap.
+        for def in runtime.agent.runtime().tool_registry().definitions() {
+            assert!(
+                !def.name.starts_with("plugin_"),
+                "plugin tool '{}' should not be present",
+                def.name
+            );
+        }
+    }
+
+    // ---- Phase 4: run_automation tests ----
+
+    use crate::durable::StructuredMessage;
+    use crate::execution::AutomationRunStatus;
+    use crate::profile::SkillFilter;
+    use futures::stream::{self, StreamExt};
+    use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+
+    /// Provider that emits text output then completes.
+    #[derive(Clone)]
+    struct TextProvider {
+        text: Arc<String>,
+    }
+
+    impl Provider for TextProvider {
+        fn infer(&self, _: InferenceRequest) -> ProviderFuture<'_, Vec<ProviderEvent>> {
+            let text = self.text.clone();
+            Box::pin(async move {
+                Ok(vec![
+                    ProviderEvent::Output {
+                        content: (*text).clone(),
+                    },
+                    ProviderEvent::Complete,
+                ])
+            })
+        }
+
+        fn infer_stream(
+            &self,
+            _: InferenceRequest,
+        ) -> ProviderFuture<'_, BoxStream<'static, ProviderResult<ProviderEvent>>> {
+            let text = self.text.clone();
+            Box::pin(async move {
+                Ok(stream::iter(vec![
+                    Ok(ProviderEvent::Output {
+                        content: (*text).clone(),
+                    }),
+                    Ok(ProviderEvent::Complete),
+                ])
+                .boxed())
+            })
+        }
+    }
+
+    /// Provider that only emits Complete (no text output).
+    #[derive(Clone, Default)]
+    struct EmptyProvider;
+
+    impl Provider for EmptyProvider {
+        fn infer(&self, _: InferenceRequest) -> ProviderFuture<'_, Vec<ProviderEvent>> {
+            Box::pin(async move { Ok(vec![ProviderEvent::Complete]) })
+        }
+
+        fn infer_stream(
+            &self,
+            _: InferenceRequest,
+        ) -> ProviderFuture<'_, BoxStream<'static, ProviderResult<ProviderEvent>>> {
+            Box::pin(async move { Ok(stream::iter(vec![Ok(ProviderEvent::Complete)]).boxed()) })
+        }
+    }
+
+    /// Provider that hangs indefinitely (for timeout/cancellation tests).
+    #[derive(Clone, Default)]
+    struct HangingProvider {
+        call_count: Arc<AtomicUsize>,
+    }
+
+    impl Provider for HangingProvider {
+        fn infer(&self, _: InferenceRequest) -> ProviderFuture<'_, Vec<ProviderEvent>> {
+            self.call_count.fetch_add(1, AtomicOrdering::SeqCst);
+            Box::pin(async move {
+                std::future::pending::<()>().await;
+                unreachable!()
+            })
+        }
+
+        fn infer_stream(
+            &self,
+            _: InferenceRequest,
+        ) -> ProviderFuture<'_, BoxStream<'static, ProviderResult<ProviderEvent>>> {
+            self.call_count.fetch_add(1, AtomicOrdering::SeqCst);
+            Box::pin(async move {
+                std::future::pending::<()>().await;
+                unreachable!()
+            })
+        }
+    }
+
+    /// Provider that emits a transport error (tests technical completion
+    /// with injected error text).
+    #[derive(Clone, Default)]
+    struct ErrorProvider;
+
+    impl Provider for ErrorProvider {
+        fn infer(&self, _: InferenceRequest) -> ProviderFuture<'_, Vec<ProviderEvent>> {
+            Box::pin(async move { Ok(vec![ProviderEvent::Complete]) })
+        }
+
+        fn infer_stream(
+            &self,
+            _: InferenceRequest,
+        ) -> ProviderFuture<'_, BoxStream<'static, ProviderResult<ProviderEvent>>> {
+            Box::pin(async move {
+                Err(iron_providers::ProviderError::transport(
+                    "connection refused",
+                ))
+            })
+        }
+    }
+
+    /// Build a HeadlessRuntime with a custom test provider, bypassing
+    /// bootstrap_headless. The runtime has an AutoApprove profile named
+    /// "automation", a prompt "test-prompt" with that profile, and a task
+    /// "test-task".
+    async fn build_test_runtime(provider: impl Provider + 'static) -> HeadlessRuntime {
+        let workspace = std::env::temp_dir();
+
+        let store = ConfigStore::open_in_memory().await.unwrap();
+
+        let prompt = StoredPrompt {
+            instructions: "Generate a report".to_string(),
+            skills: Vec::new(),
+            profile: Some(AgentProfileId::from("automation")),
+        };
+        store
+            .set_prompt(&PromptInput {
+                id: "test-prompt".to_string(),
+                schema_version: STORED_PROMPT_SCHEMA_VERSION,
+                payload: serde_json::to_value(&prompt).unwrap(),
+            })
+            .await
+            .unwrap();
+
+        store
+            .set_automation_task(&AutomationTaskInput {
+                id: "test-task".to_string(),
+                name: "Test Task".to_string(),
+                stored_prompt_id: "test-prompt".to_string(),
+                expected_outcome: "A summary of activity".to_string(),
+            })
+            .await
+            .unwrap();
+
+        let config = Config::default()
+            .with_model("test-model")
+            .with_provider_name("test")
+            .with_workspace_roots(vec![workspace.clone()]);
+
+        let agent = IronAgent::new(config, provider);
+
+        let auto_profile = AgentProfile {
+            name: "automation".to_string(),
+            provider: AgentProfileProvider::RuntimeDefault,
+            tools: ToolFilter::Inherit,
+            skills: SkillFilter::Inherit,
+            approval: AgentApproval::AutoApprove,
+            identity_prompt: None,
+        };
+        agent
+            .register_profile(AgentProfileId::from("automation"), auto_profile)
+            .unwrap();
+
+        agent.load_stored_prompts(&store).await.unwrap();
+
+        let builtin_config = BuiltinToolConfig::new(vec![workspace.clone()]);
+        agent.register_builtin_tools(&builtin_config);
+
+        let profiles: HashMap<AgentProfileId, AgentProfile> = agent
+            .list_profiles()
+            .into_iter()
+            .map(|e| (e.id, e.profile))
+            .collect();
+        let resolved = resolve_task_execution(&store, &profiles, "test-task", workspace)
+            .await
+            .unwrap();
+
+        let tool_names: Vec<String> = agent
+            .runtime()
+            .tool_registry()
+            .definitions()
+            .into_iter()
+            .map(|d| d.name)
+            .collect();
+        let effective_tools = compute_effective_tools(&resolved.profile.tools, &tool_names);
+
+        HeadlessRuntime {
+            agent,
+            resolved,
+            provider_slug: "test".to_string(),
+            model: "test-model".to_string(),
+            effective_tools,
+        }
+    }
+
+    #[tokio::test]
+    async fn run_completes_with_text_output() {
+        let runtime = build_test_runtime(TextProvider {
+            text: Arc::new("Report: all systems operational.".to_string()),
+        })
+        .await;
+
+        let result = run_automation(
+            runtime,
+            std::time::Duration::from_secs(30),
+            tokio_util::sync::CancellationToken::new(),
+        )
+        .await;
+
+        assert_eq!(result.status, AutomationRunStatus::Completed);
+        assert!(
+            result.output.contains("Report: all systems operational."),
+            "expected output text, got: {:?}",
+            result.output
+        );
+        assert_eq!(result.task_id, "test-task");
+        assert_eq!(result.task_name, "Test Task");
+        assert_eq!(result.expected_outcome, "A summary of activity");
+        assert!(result.error.is_none());
+        // timing was set (duration_ms is u64, always >= 0)
+    }
+
+    #[tokio::test]
+    async fn run_completes_with_empty_output() {
+        let runtime = build_test_runtime(EmptyProvider).await;
+
+        let result = run_automation(
+            runtime,
+            std::time::Duration::from_secs(30),
+            tokio_util::sync::CancellationToken::new(),
+        )
+        .await;
+
+        assert_eq!(result.status, AutomationRunStatus::Completed);
+        assert!(result.output.is_empty() || result.output.contains("Complete"));
+    }
+
+    #[tokio::test]
+    async fn run_provider_error_completes_technically() {
+        let runtime = build_test_runtime(ErrorProvider).await;
+
+        let result = run_automation(
+            runtime,
+            std::time::Duration::from_secs(10),
+            tokio_util::sync::CancellationToken::new(),
+        )
+        .await;
+
+        // Provider errors are handled gracefully — the turn completes
+        // (technical completion) with injected error text.
+        assert_eq!(result.status, AutomationRunStatus::Completed);
+    }
+
+    #[tokio::test]
+    async fn run_times_out() {
+        let runtime = build_test_runtime(HangingProvider::default()).await;
+
+        let result = run_automation(
+            runtime,
+            std::time::Duration::from_millis(200),
+            tokio_util::sync::CancellationToken::new(),
+        )
+        .await;
+
+        assert_eq!(result.status, AutomationRunStatus::TimedOut);
+        assert!(result.error.is_some());
+        assert_eq!(
+            result.error.as_ref().unwrap().category,
+            crate::execution::AutomationRunErrorCategory::TimedOut
+        );
+    }
+
+    #[tokio::test]
+    async fn run_cancelled_by_signal() {
+        let runtime = build_test_runtime(HangingProvider::default()).await;
+
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let cancel_clone = cancel.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            cancel_clone.cancel();
+        });
+
+        let result = run_automation(runtime, std::time::Duration::from_secs(30), cancel).await;
+
+        assert_eq!(result.status, AutomationRunStatus::Cancelled);
+        assert_eq!(
+            result.error.as_ref().unwrap().category,
+            crate::execution::AutomationRunErrorCategory::Cancelled
+        );
+    }
+
+    // ---- extract_final_text tests ----
+
+    #[test]
+    fn extract_final_text_finds_last_agent_message() {
+        use crate::durable::ContentBlock;
+
+        let messages = vec![
+            StructuredMessage::User {
+                content: vec![ContentBlock::text("hello")],
+            },
+            StructuredMessage::Agent {
+                content: vec![ContentBlock::text("first response")],
+            },
+            StructuredMessage::User {
+                content: vec![ContentBlock::text("again")],
+            },
+            StructuredMessage::Agent {
+                content: vec![ContentBlock::text("final response")],
+            },
+        ];
+
+        assert_eq!(extract_final_text(&messages), "final response");
+    }
+
+    #[test]
+    fn extract_final_text_empty_when_no_agent() {
+        use crate::durable::ContentBlock;
+
+        let messages = vec![StructuredMessage::User {
+            content: vec![ContentBlock::text("hello")],
+        }];
+
+        assert_eq!(extract_final_text(&messages), "");
+    }
+
+    #[test]
+    fn extract_final_text_empty_messages() {
+        assert_eq!(extract_final_text(&[]), "");
+    }
+
+    #[test]
+    fn extract_final_text_concatates_text_blocks() {
+        use crate::durable::ContentBlock;
+
+        let messages = vec![StructuredMessage::Agent {
+            content: vec![ContentBlock::text("part 1 "), ContentBlock::text("part 2")],
+        }];
+
+        assert_eq!(extract_final_text(&messages), "part 1 part 2");
+    }
+
+    // ---- format_duration tests ----
+
+    #[test]
+    fn format_duration_seconds() {
+        assert_eq!(format_duration(std::time::Duration::from_secs(45)), "45s");
+    }
+
+    #[test]
+    fn format_duration_minutes() {
+        assert_eq!(format_duration(std::time::Duration::from_secs(300)), "5m");
+    }
+
+    #[test]
+    fn format_duration_hours() {
+        assert_eq!(format_duration(std::time::Duration::from_secs(3600)), "1h");
+    }
+
+    #[test]
+    fn format_duration_mixed_minutes_seconds() {
+        assert_eq!(format_duration(std::time::Duration::from_secs(90)), "90s");
+    }
+}

--- a/src/headless/mod.rs
+++ b/src/headless/mod.rs
@@ -119,8 +119,13 @@ pub struct HeadlessRuntime {
     pub provider_slug: String,
     /// Resolved model identifier (from saved default model).
     pub model: String,
-    /// Sorted effective tool names after applying the profile's tool filter
-    /// to the reconstructed base tool inventory.
+    /// Reserved effective tool names.
+    ///
+    /// [`bootstrap_headless`] leaves this empty because the full session tool
+    /// catalog (including MCP tools) is not available until a session is
+    /// created. [`run_automation`] computes the authoritative effective tool
+    /// set separately after session creation. Test helpers may populate this
+    /// field directly.
     pub effective_tools: Vec<String>,
 }
 
@@ -206,13 +211,7 @@ pub async fn bootstrap_headless(
 
     // 11. Preflight: approval check only. Tool availability is checked in
     //     run_automation after session creation so MCP tools are included.
-    if !is_headless_safe(resolved.profile.approval) {
-        return Err(HeadlessBootstrapError::UnsafePolicy(format!(
-            "profile '{}' uses {:?}, but headless execution requires AutoApprove",
-            resolved.profile_id.as_str(),
-            resolved.profile.approval
-        )));
-    }
+    check_approval_safe(&resolved)?;
 
     // 12. Determine reported provider/model based on the resolved profile
     //     variant (F1). Managed profiles report their configured provider/model;
@@ -334,6 +333,22 @@ fn map_auth_error(e: ProviderAuthError) -> HeadlessBootstrapError {
 // Headless safety preflight
 // ============================================================================
 
+/// Validate that the resolved profile's approval mode is safe for
+/// non-interactive headless execution (must be `AutoApprove`).
+///
+/// This is the single source of truth for the approval check, shared by
+/// [`bootstrap_headless`] and [`preflight_headless_safety`].
+fn check_approval_safe(input: &ResolvedExecutionInput) -> Result<(), HeadlessBootstrapError> {
+    if !is_headless_safe(input.profile.approval) {
+        return Err(HeadlessBootstrapError::UnsafePolicy(format!(
+            "profile '{}' uses {:?}, but headless execution requires AutoApprove",
+            input.profile_id.as_str(),
+            input.profile.approval
+        )));
+    }
+    Ok(())
+}
+
 /// Validate that the resolved profile and tool inventory are safe for
 /// non-interactive headless execution.
 ///
@@ -345,13 +360,7 @@ pub fn preflight_headless_safety(
     input: &ResolvedExecutionInput,
     tool_names: &[String],
 ) -> Result<(), HeadlessBootstrapError> {
-    if !is_headless_safe(input.profile.approval) {
-        return Err(HeadlessBootstrapError::UnsafePolicy(format!(
-            "profile '{}' uses {:?}, but headless execution requires AutoApprove",
-            input.profile_id.as_str(),
-            input.profile.approval
-        )));
-    }
+    check_approval_safe(input)?;
 
     if let ToolFilter::Allow(allowed) = &input.profile.tools {
         for tool in allowed {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,8 +161,10 @@
 //! Sync handlers are automatically routed through `spawn_blocking`. Custom async
 //! [`Tool`] implementations must not block the orchestration runtime.
 
+pub mod automation_task;
 pub mod builtin;
 pub mod capability;
+pub mod cli;
 pub mod config;
 pub mod connection;
 pub mod context;
@@ -172,7 +174,9 @@ pub mod durable;
 pub mod embedded_python;
 pub mod ephemeral;
 pub mod error;
+pub mod execution;
 pub mod facade;
+pub mod headless;
 pub mod mcp;
 pub mod plugin;
 pub mod profile;
@@ -219,9 +223,19 @@ pub use durable::{
 };
 pub use ephemeral::{EphemeralTurn, TurnPhase};
 pub use error::{RuntimeError, RuntimeResult};
+pub use execution::{
+    compose_user_goal, effective_skills, effective_tool_filter, is_headless_safe,
+    resolve_profile_for_prompt, resolve_task_execution, AutomationRunError,
+    AutomationRunErrorCategory, AutomationRunResult, AutomationRunStatus, ResolutionError,
+    ResolvedExecutionInput, AUTOMATION_RUN_SCHEMA_VERSION,
+};
 pub use facade::{
     AgentConnection, AgentSession, IronAgent, PermissionRequest, PermissionVerdict, PromptEvent,
     PromptEvents, PromptHandle, PromptOutcome, PromptStatus, ToolResultStatus,
+};
+pub use headless::{
+    bootstrap_headless, compute_effective_tools, extract_final_text, preflight_headless_safety,
+    run_automation, HeadlessBootstrapError, HeadlessRuntime,
 };
 pub use profile::{
     default_identity_prompt, managed_profile_prompt_context, normalize_profile_name, AgentApproval,

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -50,10 +50,20 @@ fn test_key_b64() -> String {
 // Store fixture helpers
 // ============================================================================
 
+/// Serializes tests that mutate the process-global encryption-key env var so
+/// that parallel `cargo test` execution cannot race on `AGENTIRON_CONFIG_ENCRYPTION_KEY`.
+static ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
 /// Set the process-level encryption key so `ConfigStore::open_at` can decrypt
 /// credentials stored by the same key.
-fn set_encryption_key() {
+///
+/// Returns a guard that must be held for the duration of any code path that
+/// reads the env var. This serializes the env-dependent tests under parallel
+/// `cargo test` execution to avoid races on the process-global env var.
+async fn set_encryption_key() -> tokio::sync::MutexGuard<'static, ()> {
+    let guard = ENV_LOCK.lock().await;
     std::env::set_var("AGENTIRON_CONFIG_ENCRYPTION_KEY", test_key_b64());
+    guard
 }
 
 /// Build a cipher matching the env-var key.
@@ -477,6 +487,48 @@ async fn json_failure_for_usage_error() {
 }
 
 #[tokio::test]
+async fn json_failure_for_pre_parse_usage_error() {
+    // Missing task-id with --format json: parse_args fails before format
+    // resolution, but the JSON output contract must still be honored.
+    let args = vec![
+        "run".to_string(),
+        "--format".to_string(),
+        "json".to_string(),
+    ];
+    let env = vec![];
+    let (code, stdout, stderr) = run_cli(&args, &mut env.clone()).await;
+    assert_eq!(code, EXIT_USAGE);
+
+    let v: serde_json::Value = serde_json::from_str(stdout.trim())
+        .expect("stdout should be a JSON object even for pre-parse usage errors");
+    assert_eq!(v["status"], "failed");
+    assert_eq!(v["error"]["category"], "config");
+    assert!(
+        v["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("missing required <task-id>"),
+        "message should describe the usage error: {:?}",
+        v["error"]["message"]
+    );
+    assert!(stderr.is_empty(), "stderr should be empty in JSON mode");
+}
+
+#[tokio::test]
+async fn json_failure_for_pre_parse_usage_error_via_env() {
+    // AGENTIRON_FORMAT=json in env should also trigger JSON for usage errors.
+    let args = vec!["run".to_string()];
+    let env = vec![("AGENTIRON_FORMAT".to_string(), "json".to_string())];
+    let (code, stdout, stderr) = run_cli(&args, &mut env.clone()).await;
+    assert_eq!(code, EXIT_USAGE);
+
+    let v: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("stdout should be JSON via env override");
+    assert_eq!(v["status"], "failed");
+    assert!(stderr.is_empty(), "stderr should be empty in JSON mode");
+}
+
+#[tokio::test]
 async fn json_failure_for_config_error() {
     let args = vec![
         "run".to_string(),
@@ -499,7 +551,7 @@ async fn json_failure_for_config_error() {
 
 #[tokio::test]
 async fn json_failure_for_unsafe_policy() {
-    set_encryption_key();
+    let _env_guard = set_encryption_key().await;
     let dir = tempfile::tempdir().unwrap();
     let db_path = dir.path().join("config.db");
     let store = open_store(&db_path).await;
@@ -530,7 +582,7 @@ async fn json_failure_for_unsafe_policy() {
 
 #[tokio::test]
 async fn text_failure_for_unsafe_policy() {
-    set_encryption_key();
+    let _env_guard = set_encryption_key().await;
     let dir = tempfile::tempdir().unwrap();
     let db_path = dir.path().join("config.db");
     let store = open_store(&db_path).await;
@@ -599,7 +651,7 @@ async fn e2e_missing_credential_exit5() {
 
 #[tokio::test]
 async fn e2e_task_not_found_exit3() {
-    set_encryption_key();
+    let _env_guard = set_encryption_key().await;
     let dir = tempfile::tempdir().unwrap();
     let db_path = dir.path().join("config.db");
     let store = open_store(&db_path).await;
@@ -618,7 +670,7 @@ async fn e2e_task_not_found_exit3() {
 
 #[tokio::test]
 async fn e2e_auto_approve_preflight_blocks_pertool() {
-    set_encryption_key();
+    let _env_guard = set_encryption_key().await;
     let dir = tempfile::tempdir().unwrap();
     let db_path = dir.path().join("config.db");
     let store = open_store(&db_path).await;
@@ -639,7 +691,7 @@ async fn e2e_auto_approve_preflight_blocks_pertool() {
 
 #[tokio::test]
 async fn e2e_plugin_tool_excluded_from_allow_list() {
-    set_encryption_key();
+    let _env_guard = set_encryption_key().await;
     let dir = tempfile::tempdir().unwrap();
     let db_path = dir.path().join("config.db");
     let store = open_store(&db_path).await;
@@ -676,7 +728,7 @@ async fn e2e_plugin_tool_excluded_from_allow_list() {
 
 #[tokio::test]
 async fn e2e_uses_saved_default_provider_and_model() {
-    set_encryption_key();
+    let _env_guard = set_encryption_key().await;
     let dir = tempfile::tempdir().unwrap();
     let db_path = dir.path().join("config.db");
     let store = open_store(&db_path).await;
@@ -709,7 +761,7 @@ async fn e2e_uses_saved_default_provider_and_model() {
 
 #[tokio::test]
 async fn e2e_json_success_contract() {
-    set_encryption_key();
+    let _env_guard = set_encryption_key().await;
     let dir = tempfile::tempdir().unwrap();
     let db_path = dir.path().join("config.db");
     let store = open_store(&db_path).await;
@@ -760,7 +812,7 @@ async fn e2e_json_success_contract() {
 
 #[tokio::test]
 async fn e2e_text_mode_output_is_final_text_only() {
-    set_encryption_key();
+    let _env_guard = set_encryption_key().await;
     let dir = tempfile::tempdir().unwrap();
     let db_path = dir.path().join("config.db");
     let store = open_store(&db_path).await;

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -1,0 +1,791 @@
+//! Integration tests for the `agent-iron` CLI binary.
+//!
+//! These tests exercise [`iron_core::cli::execute_run_with_streams`] — the
+//! core CLI implementation that accepts generic writers — covering:
+//!
+//! - Command-level usage failures and env/CLI precedence (task 6.2)
+//! - JSON output contract: exactly one stdout object, required fields,
+//!   structured failure results (task 6.3)
+//! - End-to-end bootstrap and preflight paths: saved default provider/model,
+//!   AutoApprove preflight enforcement, plugin exclusion, task resolution
+//!   (task 6.4)
+
+use base64::Engine;
+use iron_core::automation_task::AutomationTaskInput;
+use iron_core::cli;
+use iron_core::config::crypto::XChaCha20Poly1305Cipher;
+use iron_core::config::{ConfigStore, DefaultModelInput, OpenOptions, ProfileInput, PromptInput};
+use iron_core::profile::{
+    AgentApproval, AgentProfile, AgentProfileId, AgentProfileProvider, SkillFilter, ToolFilter,
+    PROFILE_SCHEMA_VERSION,
+};
+use iron_core::provider_credential::{
+    DurableCredentialStore, ProviderCredentialStore, ProviderSlug, StoredCredential,
+};
+use iron_core::stored_prompt::{StoredPrompt, STORED_PROMPT_SCHEMA_VERSION};
+use std::path::Path;
+use std::sync::Arc;
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const EXIT_COMPLETED: i32 = 0;
+const EXIT_USAGE: i32 = 2;
+const EXIT_CONFIG: i32 = 3;
+const EXIT_UNSAFE_POLICY: i32 = 4;
+const EXIT_PROVIDER_INIT: i32 = 5;
+
+/// Deterministic test encryption key (32 bytes of 0x42).
+fn test_key() -> [u8; 32] {
+    [0x42u8; 32]
+}
+
+/// Base64-encode the test key for the env var.
+fn test_key_b64() -> String {
+    base64::engine::general_purpose::STANDARD.encode(test_key())
+}
+
+// ============================================================================
+// Store fixture helpers
+// ============================================================================
+
+/// Set the process-level encryption key so `ConfigStore::open_at` can decrypt
+/// credentials stored by the same key.
+fn set_encryption_key() {
+    std::env::set_var("AGENTIRON_CONFIG_ENCRYPTION_KEY", test_key_b64());
+}
+
+/// Build a cipher matching the env-var key.
+fn test_cipher() -> Arc<dyn iron_core::config::crypto::CredentialCipher> {
+    Arc::new(XChaCha20Poly1305Cipher::new(&test_key()))
+}
+
+/// Open a file-based ConfigStore at `path` using the test cipher.
+async fn open_store(path: impl AsRef<Path>) -> ConfigStore {
+    let options = OpenOptions {
+        cipher: Some(test_cipher()),
+        busy_timeout: None,
+    };
+    ConfigStore::open_at_with_options(path, options)
+        .await
+        .expect("failed to open test store")
+}
+
+/// Seed a store with credential + default model + AutoApprove profile + prompt + task.
+async fn seed_complete_store(store: &ConfigStore) {
+    seed_credential_and_model(store, "openai", "gpt-4o", "sk-test-key").await;
+    seed_auto_approve_profile(store).await;
+    seed_prompt_and_task(store, "automation").await;
+}
+
+/// Store a provider API-key credential and set the default model.
+async fn seed_credential_and_model(
+    store: &ConfigStore,
+    provider: &str,
+    model: &str,
+    api_key: &str,
+) {
+    let durable = Arc::new(DurableCredentialStore::new(store.clone()));
+    ProviderCredentialStore::set(
+        &*durable,
+        &ProviderSlug::new(provider),
+        StoredCredential::ApiKey(api_key.to_string()),
+    )
+    .await;
+
+    store
+        .set_default_model(&DefaultModelInput {
+            provider_slug: provider.to_string(),
+            model_id: model.to_string(),
+        })
+        .await
+        .unwrap();
+}
+
+/// Create an AutoApprove profile named "automation".
+async fn seed_auto_approve_profile(store: &ConfigStore) {
+    let profile = AgentProfile {
+        name: "automation".to_string(),
+        provider: AgentProfileProvider::RuntimeDefault,
+        tools: ToolFilter::Inherit,
+        skills: SkillFilter::Inherit,
+        approval: AgentApproval::AutoApprove,
+        identity_prompt: None,
+    };
+    store
+        .set_profile(&ProfileInput {
+            id: "automation".to_string(),
+            schema_version: PROFILE_SCHEMA_VERSION,
+            payload: serde_json::to_value(&profile).unwrap(),
+        })
+        .await
+        .unwrap();
+}
+
+/// Create a PerTool profile named "automation".
+async fn seed_pertool_profile(store: &ConfigStore) {
+    let profile = AgentProfile {
+        name: "automation".to_string(),
+        provider: AgentProfileProvider::RuntimeDefault,
+        tools: ToolFilter::Inherit,
+        skills: SkillFilter::Inherit,
+        approval: AgentApproval::PerTool,
+        identity_prompt: None,
+    };
+    store
+        .set_profile(&ProfileInput {
+            id: "automation".to_string(),
+            schema_version: PROFILE_SCHEMA_VERSION,
+            payload: serde_json::to_value(&profile).unwrap(),
+        })
+        .await
+        .unwrap();
+}
+
+/// Create a stored prompt (referencing the given profile) and an automation task.
+async fn seed_prompt_and_task(store: &ConfigStore, profile_id: &str) {
+    let prompt = StoredPrompt {
+        instructions: "Generate a daily report".to_string(),
+        skills: Vec::new(),
+        profile: Some(AgentProfileId::from(profile_id)),
+    };
+    store
+        .set_prompt(&PromptInput {
+            id: "report-prompt".to_string(),
+            schema_version: STORED_PROMPT_SCHEMA_VERSION,
+            payload: serde_json::to_value(&prompt).unwrap(),
+        })
+        .await
+        .unwrap();
+
+    store
+        .set_automation_task(&AutomationTaskInput {
+            id: "daily-report".to_string(),
+            name: "Daily Report".to_string(),
+            stored_prompt_id: "report-prompt".to_string(),
+            expected_outcome: "A summary of today's activity".to_string(),
+        })
+        .await
+        .unwrap();
+}
+
+/// Run the CLI with the given args, env, and return (exit_code, stdout, stderr).
+async fn run_cli(args: &[String], env: &mut [(String, String)]) -> (i32, String, String) {
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+    let code = cli::execute_run_with_streams(args, env, &mut stdout, &mut stderr).await;
+    let stdout_str = String::from_utf8_lossy(&stdout).to_string();
+    let stderr_str = String::from_utf8_lossy(&stderr).to_string();
+    (code, stdout_str, stderr_str)
+}
+
+/// Build args for `run <task>` with workspace, config, and timeout.
+/// NOTE: args do NOT include the program name (the binary does skip(1)).
+fn run_args(task_id: &str, workspace: &str, config: &str, timeout: &str) -> Vec<String> {
+    vec![
+        "run".to_string(),
+        task_id.to_string(),
+        "--workspace".to_string(),
+        workspace.to_string(),
+        "--config".to_string(),
+        config.to_string(),
+        "--timeout".to_string(),
+        timeout.to_string(),
+    ]
+}
+
+// ============================================================================
+// 6.2 Command-level tests
+// ============================================================================
+
+#[tokio::test]
+async fn usage_no_args() {
+    let env = vec![];
+    let (code, _out, err) = run_cli(&[], &mut env.clone()).await;
+    assert_eq!(code, EXIT_USAGE);
+    assert!(!err.is_empty());
+}
+
+#[tokio::test]
+async fn usage_no_subcommand() {
+    let env = vec![];
+    let args = vec!["bogus".to_string()];
+    let (code, _out, err) = run_cli(&args, &mut env.clone()).await;
+    assert_eq!(code, EXIT_USAGE);
+    assert!(!err.is_empty());
+}
+
+#[tokio::test]
+async fn usage_missing_task_id() {
+    let env = vec![];
+    let args = vec!["run".to_string()];
+    let (code, _out, err) = run_cli(&args, &mut env.clone()).await;
+    assert_eq!(code, EXIT_USAGE);
+    assert!(!err.is_empty());
+}
+
+#[tokio::test]
+async fn usage_missing_timeout() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("config.db");
+    let store = open_store(&db_path).await;
+    seed_complete_store(&store).await;
+
+    let args = vec![
+        "run".to_string(),
+        "daily-report".to_string(),
+        "--workspace".to_string(),
+        dir.path().to_str().unwrap().to_string(),
+        "--config".to_string(),
+        db_path.to_str().unwrap().to_string(),
+    ];
+    let env = vec![];
+    let (code, _out, _err) = run_cli(&args, &mut env.clone()).await;
+    assert_eq!(code, EXIT_USAGE);
+}
+
+#[tokio::test]
+async fn usage_invalid_timeout() {
+    let dir = tempfile::tempdir().unwrap();
+    let args = vec![
+        "run".to_string(),
+        "task".to_string(),
+        "--workspace".to_string(),
+        dir.path().to_str().unwrap().to_string(),
+        "--timeout".to_string(),
+        "notaduration".to_string(),
+    ];
+    let env = vec![];
+    let (code, _out, _err) = run_cli(&args, &mut env.clone()).await;
+    assert_eq!(code, EXIT_USAGE);
+}
+
+#[tokio::test]
+async fn config_invalid_workspace() {
+    let args = vec![
+        "run".to_string(),
+        "task".to_string(),
+        "--workspace".to_string(),
+        "/nonexistent/path/that/should/not/exist".to_string(),
+        "--timeout".to_string(),
+        "30s".to_string(),
+    ];
+    let env = vec![];
+    let (code, _out, _err) = run_cli(&args, &mut env.clone()).await;
+    assert_eq!(code, EXIT_CONFIG);
+}
+
+#[tokio::test]
+async fn precedence_timeout_cli_over_env() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("config.db");
+    let _store = open_store(&db_path).await;
+
+    let args = vec![
+        "run".to_string(),
+        "task".to_string(),
+        "--workspace".to_string(),
+        dir.path().to_str().unwrap().to_string(),
+        "--config".to_string(),
+        db_path.to_str().unwrap().to_string(),
+        "--timeout".to_string(),
+        "1m".to_string(),
+    ];
+    let mut env = vec![("AGENTIRON_TIMEOUT".to_string(), "30s".to_string())];
+    let (code, _out, _err) = run_cli(&args, &mut env).await;
+    assert_eq!(code, EXIT_PROVIDER_INIT);
+}
+
+#[tokio::test]
+async fn precedence_workspace_cli_over_env() {
+    let dir = tempfile::tempdir().unwrap();
+    let env_workspace = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("config.db");
+    let _store = open_store(&db_path).await;
+
+    let args = vec![
+        "run".to_string(),
+        "task".to_string(),
+        "--workspace".to_string(),
+        dir.path().to_str().unwrap().to_string(),
+        "--config".to_string(),
+        db_path.to_str().unwrap().to_string(),
+        "--timeout".to_string(),
+        "30s".to_string(),
+    ];
+    let mut env = vec![(
+        "AGENTIRON_WORKSPACE".to_string(),
+        env_workspace.path().to_str().unwrap().to_string(),
+    )];
+    let (code, _out, _stderr) = run_cli(&args, &mut env).await;
+    assert_eq!(code, EXIT_PROVIDER_INIT);
+}
+
+#[tokio::test]
+async fn precedence_format_cli_over_env() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("config.db");
+    let _store = open_store(&db_path).await;
+
+    let args = vec![
+        "run".to_string(),
+        "task".to_string(),
+        "--workspace".to_string(),
+        dir.path().to_str().unwrap().to_string(),
+        "--config".to_string(),
+        db_path.to_str().unwrap().to_string(),
+        "--timeout".to_string(),
+        "30s".to_string(),
+        "--format".to_string(),
+        "json".to_string(),
+    ];
+    let mut env = vec![("AGENTIRON_FORMAT".to_string(), "text".to_string())];
+    let (code, stdout, _stderr) = run_cli(&args, &mut env).await;
+    assert_eq!(code, EXIT_PROVIDER_INIT);
+    let v: serde_json::Value = serde_json::from_str(stdout.trim()).expect("valid JSON");
+    assert_eq!(v["status"], "failed");
+}
+
+#[tokio::test]
+async fn quiet_suppresses_progress() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("config.db");
+    let _store = open_store(&db_path).await;
+
+    let args = vec![
+        "run".to_string(),
+        "task".to_string(),
+        "--workspace".to_string(),
+        dir.path().to_str().unwrap().to_string(),
+        "--config".to_string(),
+        db_path.to_str().unwrap().to_string(),
+        "--timeout".to_string(),
+        "30s".to_string(),
+        "--quiet".to_string(),
+    ];
+    let env = vec![];
+    let (_code, _out, stderr) = run_cli(&args, &mut env.clone()).await;
+    assert!(!stderr.contains("workspace:"));
+    assert!(!stderr.contains("timeout:"));
+}
+
+// ============================================================================
+// 6.3 JSON contract tests
+// ============================================================================
+
+#[tokio::test]
+async fn json_failure_has_one_stdout_object() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("config.db");
+    let _store = open_store(&db_path).await;
+
+    let args = vec![
+        "run".to_string(),
+        "task".to_string(),
+        "--workspace".to_string(),
+        dir.path().to_str().unwrap().to_string(),
+        "--config".to_string(),
+        db_path.to_str().unwrap().to_string(),
+        "--timeout".to_string(),
+        "30s".to_string(),
+        "--format".to_string(),
+        "json".to_string(),
+    ];
+    let env = vec![];
+    let (code, stdout, _stderr) = run_cli(&args, &mut env.clone()).await;
+    assert_eq!(code, EXIT_PROVIDER_INIT);
+
+    let trimmed = stdout.trim();
+    assert!(
+        trimmed.starts_with('{') && trimmed.ends_with('}'),
+        "stdout should be a single JSON object"
+    );
+    let _v: serde_json::Value = serde_json::from_str(trimmed).expect("stdout should be valid JSON");
+}
+
+#[tokio::test]
+async fn json_failure_has_required_fields() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("config.db");
+    let _store = open_store(&db_path).await;
+
+    let args = vec![
+        "run".to_string(),
+        "task".to_string(),
+        "--workspace".to_string(),
+        dir.path().to_str().unwrap().to_string(),
+        "--config".to_string(),
+        db_path.to_str().unwrap().to_string(),
+        "--timeout".to_string(),
+        "30s".to_string(),
+        "--format".to_string(),
+        "json".to_string(),
+    ];
+    let env = vec![];
+    let (code, stdout, _stderr) = run_cli(&args, &mut env.clone()).await;
+    assert_eq!(code, EXIT_PROVIDER_INIT);
+
+    let v: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+
+    assert!(v.get("schema_version").is_some(), "missing schema_version");
+    assert!(v.get("run_id").is_some(), "missing run_id");
+    assert!(v.get("task_id").is_some(), "missing task_id");
+    assert!(v.get("task_name").is_some(), "missing task_name");
+    assert!(v.get("status").is_some(), "missing status");
+    assert!(v.get("output").is_some(), "missing output");
+    assert!(
+        v.get("expected_outcome").is_some(),
+        "missing expected_outcome"
+    );
+    assert!(v.get("profile_id").is_some(), "missing profile_id");
+    assert!(v.get("workspace").is_some(), "missing workspace");
+    assert!(v.get("started_at").is_some(), "missing started_at");
+    assert!(v.get("ended_at").is_some(), "missing ended_at");
+    assert!(v.get("duration_ms").is_some(), "missing duration_ms");
+
+    assert!(v.get("error").is_some(), "missing error");
+    assert!(
+        v["error"].get("category").is_some(),
+        "missing error.category"
+    );
+    assert!(v["error"].get("message").is_some(), "missing error.message");
+
+    assert_eq!(v["status"], "failed");
+    assert_eq!(v["error"]["category"], "provider_init");
+}
+
+#[tokio::test]
+async fn json_failure_for_usage_error() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let args = vec![
+        "run".to_string(),
+        "task".to_string(),
+        "--workspace".to_string(),
+        dir.path().to_str().unwrap().to_string(),
+        "--format".to_string(),
+        "json".to_string(),
+    ];
+    let env = vec![];
+    let (code, stdout, _stderr) = run_cli(&args, &mut env.clone()).await;
+    assert_eq!(code, EXIT_USAGE);
+
+    let v: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert_eq!(v["status"], "failed");
+    assert_eq!(v["error"]["category"], "config");
+}
+
+#[tokio::test]
+async fn json_failure_for_config_error() {
+    let args = vec![
+        "run".to_string(),
+        "task".to_string(),
+        "--workspace".to_string(),
+        "/nonexistent/path".to_string(),
+        "--timeout".to_string(),
+        "30s".to_string(),
+        "--format".to_string(),
+        "json".to_string(),
+    ];
+    let env = vec![];
+    let (code, stdout, _stderr) = run_cli(&args, &mut env.clone()).await;
+    assert_eq!(code, EXIT_CONFIG);
+
+    let v: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert_eq!(v["status"], "failed");
+    assert_eq!(v["error"]["category"], "config");
+}
+
+#[tokio::test]
+async fn json_failure_for_unsafe_policy() {
+    set_encryption_key();
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("config.db");
+    let store = open_store(&db_path).await;
+    seed_credential_and_model(&store, "openai", "gpt-4o", "sk-test").await;
+    seed_pertool_profile(&store).await;
+    seed_prompt_and_task(&store, "automation").await;
+
+    let args = vec![
+        "run".to_string(),
+        "daily-report".to_string(),
+        "--workspace".to_string(),
+        dir.path().to_str().unwrap().to_string(),
+        "--config".to_string(),
+        db_path.to_str().unwrap().to_string(),
+        "--timeout".to_string(),
+        "30s".to_string(),
+        "--format".to_string(),
+        "json".to_string(),
+    ];
+    let env = vec![];
+    let (code, stdout, _stderr) = run_cli(&args, &mut env.clone()).await;
+    assert_eq!(code, EXIT_UNSAFE_POLICY);
+
+    let v: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert_eq!(v["status"], "failed");
+    assert_eq!(v["error"]["category"], "unsafe_policy");
+}
+
+#[tokio::test]
+async fn text_failure_for_unsafe_policy() {
+    set_encryption_key();
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("config.db");
+    let store = open_store(&db_path).await;
+    seed_credential_and_model(&store, "openai", "gpt-4o", "sk-test").await;
+    seed_pertool_profile(&store).await;
+    seed_prompt_and_task(&store, "automation").await;
+
+    let args = run_args(
+        "daily-report",
+        dir.path().to_str().unwrap(),
+        db_path.to_str().unwrap(),
+        "30s",
+    );
+    let env = vec![];
+    let (code, _stdout, stderr) = run_cli(&args, &mut env.clone()).await;
+    assert_eq!(code, EXIT_UNSAFE_POLICY);
+    assert!(!stderr.is_empty());
+}
+
+// ============================================================================
+// 6.4 End-to-end bootstrap and preflight tests
+// ============================================================================
+
+#[tokio::test]
+async fn e2e_missing_default_provider_exit5() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("config.db");
+    let _store = open_store(&db_path).await;
+
+    let args = run_args(
+        "daily-report",
+        dir.path().to_str().unwrap(),
+        db_path.to_str().unwrap(),
+        "30s",
+    );
+    let env = vec![];
+    let (code, _out, _err) = run_cli(&args, &mut env.clone()).await;
+    assert_eq!(code, EXIT_PROVIDER_INIT);
+}
+
+#[tokio::test]
+async fn e2e_missing_credential_exit5() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("config.db");
+    let store = open_store(&db_path).await;
+    store
+        .set_default_model(&DefaultModelInput {
+            provider_slug: "openai".to_string(),
+            model_id: "gpt-4o".to_string(),
+        })
+        .await
+        .unwrap();
+    seed_auto_approve_profile(&store).await;
+    seed_prompt_and_task(&store, "automation").await;
+
+    let args = run_args(
+        "daily-report",
+        dir.path().to_str().unwrap(),
+        db_path.to_str().unwrap(),
+        "30s",
+    );
+    let env = vec![];
+    let (code, _out, _err) = run_cli(&args, &mut env.clone()).await;
+    assert_eq!(code, EXIT_PROVIDER_INIT);
+}
+
+#[tokio::test]
+async fn e2e_task_not_found_exit3() {
+    set_encryption_key();
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("config.db");
+    let store = open_store(&db_path).await;
+    seed_complete_store(&store).await;
+
+    let args = run_args(
+        "nonexistent-task",
+        dir.path().to_str().unwrap(),
+        db_path.to_str().unwrap(),
+        "30s",
+    );
+    let env = vec![];
+    let (code, _out, _err) = run_cli(&args, &mut env.clone()).await;
+    assert_eq!(code, EXIT_CONFIG);
+}
+
+#[tokio::test]
+async fn e2e_auto_approve_preflight_blocks_pertool() {
+    set_encryption_key();
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("config.db");
+    let store = open_store(&db_path).await;
+    seed_credential_and_model(&store, "openai", "gpt-4o", "sk-test").await;
+    seed_pertool_profile(&store).await;
+    seed_prompt_and_task(&store, "automation").await;
+
+    let args = run_args(
+        "daily-report",
+        dir.path().to_str().unwrap(),
+        db_path.to_str().unwrap(),
+        "30s",
+    );
+    let env = vec![];
+    let (code, _out, _err) = run_cli(&args, &mut env.clone()).await;
+    assert_eq!(code, EXIT_UNSAFE_POLICY);
+}
+
+#[tokio::test]
+async fn e2e_plugin_tool_excluded_from_allow_list() {
+    set_encryption_key();
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("config.db");
+    let store = open_store(&db_path).await;
+    seed_credential_and_model(&store, "openai", "gpt-4o", "sk-test").await;
+
+    let profile = AgentProfile {
+        name: "automation".to_string(),
+        provider: AgentProfileProvider::RuntimeDefault,
+        tools: ToolFilter::Allow(vec!["plugin_my_plugin_some_tool".to_string()]),
+        skills: SkillFilter::Inherit,
+        approval: AgentApproval::AutoApprove,
+        identity_prompt: None,
+    };
+    store
+        .set_profile(&ProfileInput {
+            id: "automation".to_string(),
+            schema_version: PROFILE_SCHEMA_VERSION,
+            payload: serde_json::to_value(&profile).unwrap(),
+        })
+        .await
+        .unwrap();
+    seed_prompt_and_task(&store, "automation").await;
+
+    let args = run_args(
+        "daily-report",
+        dir.path().to_str().unwrap(),
+        db_path.to_str().unwrap(),
+        "30s",
+    );
+    let env = vec![];
+    let (code, _out, _err) = run_cli(&args, &mut env.clone()).await;
+    assert_eq!(code, EXIT_UNSAFE_POLICY);
+}
+
+#[tokio::test]
+async fn e2e_uses_saved_default_provider_and_model() {
+    set_encryption_key();
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("config.db");
+    let store = open_store(&db_path).await;
+
+    seed_credential_and_model(&store, "openai", "gpt-4o-mini", "sk-test-key").await;
+    seed_auto_approve_profile(&store).await;
+    seed_prompt_and_task(&store, "automation").await;
+
+    let args = vec![
+        "run".to_string(),
+        "daily-report".to_string(),
+        "--workspace".to_string(),
+        dir.path().to_str().unwrap().to_string(),
+        "--config".to_string(),
+        db_path.to_str().unwrap().to_string(),
+        "--timeout".to_string(),
+        "5s".to_string(),
+        "--format".to_string(),
+        "json".to_string(),
+    ];
+    let env = vec![];
+    let (code, stdout, _stderr) = run_cli(&args, &mut env.clone()).await;
+
+    let v: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert_eq!(v["status"], "completed");
+    assert_eq!(v["provider"], "openai");
+    assert_eq!(v["model"], "gpt-4o-mini");
+    assert_eq!(code, EXIT_COMPLETED);
+}
+
+#[tokio::test]
+async fn e2e_json_success_contract() {
+    set_encryption_key();
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("config.db");
+    let store = open_store(&db_path).await;
+    seed_credential_and_model(&store, "openai", "gpt-4o", "sk-test").await;
+    seed_auto_approve_profile(&store).await;
+    seed_prompt_and_task(&store, "automation").await;
+
+    let args = vec![
+        "run".to_string(),
+        "daily-report".to_string(),
+        "--workspace".to_string(),
+        dir.path().to_str().unwrap().to_string(),
+        "--config".to_string(),
+        db_path.to_str().unwrap().to_string(),
+        "--timeout".to_string(),
+        "5s".to_string(),
+        "--format".to_string(),
+        "json".to_string(),
+    ];
+    let env = vec![];
+    let (code, stdout, stderr) = run_cli(&args, &mut env.clone()).await;
+    assert_eq!(code, EXIT_COMPLETED);
+
+    let v: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("stdout should be valid JSON");
+
+    assert_eq!(v["schema_version"], 1);
+    assert!(v["run_id"].is_string());
+    assert_eq!(v["task_id"], "daily-report");
+    assert_eq!(v["task_name"], "Daily Report");
+    assert_eq!(v["status"], "completed");
+    assert!(v["output"].is_string());
+    assert_eq!(v["expected_outcome"], "A summary of today's activity");
+    assert!(v["profile_id"].is_string());
+    assert_eq!(v["provider"], "openai");
+    assert_eq!(v["model"], "gpt-4o");
+    assert!(v["workspace"].is_string());
+    assert!(v["effective_tools"].is_array());
+    assert!(v["started_at"].is_string());
+    assert!(v["ended_at"].is_string());
+    assert!(v["duration_ms"].is_number());
+    assert!(v["error"].is_null());
+
+    let _single: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("exactly one JSON object");
+    let _ = stderr;
+}
+
+#[tokio::test]
+async fn e2e_text_mode_output_is_final_text_only() {
+    set_encryption_key();
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("config.db");
+    let store = open_store(&db_path).await;
+    seed_credential_and_model(&store, "openai", "gpt-4o", "sk-test").await;
+    seed_auto_approve_profile(&store).await;
+    seed_prompt_and_task(&store, "automation").await;
+
+    let args = vec![
+        "run".to_string(),
+        "daily-report".to_string(),
+        "--workspace".to_string(),
+        dir.path().to_str().unwrap().to_string(),
+        "--config".to_string(),
+        db_path.to_str().unwrap().to_string(),
+        "--timeout".to_string(),
+        "5s".to_string(),
+        "--quiet".to_string(),
+    ];
+    let env = vec![];
+    let (code, stdout, stderr) = run_cli(&args, &mut env.clone()).await;
+    assert_eq!(code, EXIT_COMPLETED);
+
+    assert!(stderr.is_empty(), "stderr should be empty in quiet mode");
+    assert!(
+        !stdout.trim().starts_with('{'),
+        "text mode should not output JSON"
+    );
+}

--- a/tests/config_store_tests.rs
+++ b/tests/config_store_tests.rs
@@ -1016,7 +1016,7 @@ async fn test_migrations_v1_to_v2() {
         .fetch_one(&mut *conn)
         .await
         .unwrap();
-    assert_eq!(version, 6);
+    assert_eq!(version, 7);
 
     // Verify v2/v3 tables exist by using the new APIs
     store
@@ -1368,7 +1368,7 @@ async fn test_migrations_v2_to_v3_custom_models_columns() {
         .fetch_one(&mut *conn)
         .await
         .unwrap();
-    assert_eq!(version, 6);
+    assert_eq!(version, 7);
 
     // Verify the new columns have correct defaults for existing rows
     let retrieved = store


### PR DESCRIPTION
## Summary

- add durable, schema-versioned automation tasks with typed ConfigStore CRUD and stored-prompt referential integrity
- add safe store-backed headless runtime bootstrap, profile/provider resolution, root-session execution, cancellation, and timeout handling
- add the run-only `agent-iron run <task-id>` binary with deterministic configuration precedence, text/JSON contracts, and stable exit codes
- sync and archive the completed `add-agent-iron-headless-cli` OpenSpec change

## Safety and scope

- requires an explicit `AutoApprove` profile and preserves `Inherit`, `Allow`, or `Deny` tool filters
- uses persisted providers, credentials, MCP servers, and skills; WASM plugin bootstrap remains excluded because plugin inventory is not core-persisted
- does not add scheduling, run-history persistence, CLI mutation commands, arbitrary prompt variables, built-in web search, or independent expected-outcome verification

## Verification

- `cargo test --all-targets --all-features` (1,170 tests passed)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --check`
- strict OpenSpec validation for the change and synced specifications

Closes #63

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `agent-iron` headless CLI with `run <task-id>` for non-interactive automation.
  * Introduced durable automation tasks with stored-prompt linkage, validation, and deterministic listing/upsert behavior.
  * Added configurable workspace/timeout/output format/quiet mode with environment-variable support, plus stable text and JSON results.
* **Bug Fixes**
  * Enforced referential safety for stored prompts referenced by automation tasks (deletion conflicts instead of cascading changes).
  * Improved handling of context construction and surfaced profile availability diagnostics.
* **Tests**
  * Added/expanded unit, integration, migration, safety preflight, output-contract, and end-to-end CLI tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->