### PR TITLE
feat(scheduler): add scheduled automation tasks

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,2 +1,8 @@
 [advisories]
-ignore = []
+ignore = [
+    # pyo3 0.28.x is pulled transitively via monty -> jiter 0.15.0.
+    # jiter 0.16.0 uses pyo3 0.29, but monty 0.0.19-beta.4 caps jiter at ^0.15.0.
+    # Remove these ignores once monty bumps its jiter dependency.
+    "RUSTSEC-2026-0176", # OOB read in PyList/PyTuple iterators
+    "RUSTSEC-2026-0177", # Missing Sync bound on PyCFunction closures
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2883,7 +2883,8 @@ dependencies = [
 [[package]]
 name = "monty"
 version = "0.0.19-beta.4"
-source = "git+https://github.com/pydantic/monty?tag=0.0.19-beta.4#c9c17d697e9394dc44cbeac2eb080f5deee4ec5f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "156b9f1b312cb12215f8b138af9703eda771069954e6b51636641ad53faaa3ff"
 dependencies = [
  "ahash",
  "chrono",
@@ -2915,7 +2916,8 @@ dependencies = [
 [[package]]
 name = "monty-macros"
 version = "0.0.19-beta.4"
-source = "git+https://github.com/pydantic/monty?tag=0.0.19-beta.4#c9c17d697e9394dc44cbeac2eb080f5deee4ec5f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf89141e91b353a7060663c2a8bf3c09f6b6a3cddd046a51cc839c80c159fb3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,16 +68,12 @@ cfg-if = "1"
 
 # Embedded Python runtime (Monty)
 #
-# Position B adoption: pinned to a specific upstream commit for reproducibility.
-# crates.io only has a 0.0.0 placeholder, so a git dep is the only viable path.
-# Re-evaluate once Monty publishes a usable semver release.
-# Do NOT fork unless upstream cannot resolve a real Level 3 portability blocker.
+# Sourced from crates.io (0.0.19-beta.4). The transitive dependency
+# pyo3 0.28.x (via jiter 0.15.0) has known advisories suppressed in
+# .cargo/audit.toml until monty bumps jiter to ^0.16.0 (which uses pyo3 0.29).
 #
-# Publication of iron-core to crates.io is deferred until monty is available
-# there, because crates.io rejects manifests containing git dependencies.
-#
-# Bump `rev` deliberately after verifying against the iron-core test suite.
-monty = { git = "https://github.com/pydantic/monty", tag = "0.0.19-beta.4", optional = true }
+# Bump version deliberately after verifying against the iron-core test suite.
+monty = { version = "0.0.19-beta.4", optional = true }
 num-bigint = { version = "0.4", optional = true }
 num-traits = { version = "0.2", optional = true }
 

--- a/openspec/changes/add-scheduled-automation-tasks/.openspec.yaml
+++ b/openspec/changes/add-scheduled-automation-tasks/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-12

--- a/openspec/changes/add-scheduled-automation-tasks/design.md
+++ b/openspec/changes/add-scheduled-automation-tasks/design.md
@@ -1,0 +1,138 @@
+## Context
+
+The repository already has durable `AutomationTask` records, stored-prompt references, immutable execution resolution, headless policy checks, and `agent-iron run <task-id>`. ConfigStore also has an opaque `schedule` table, but there is no typed schedule model or host integration.
+
+Issue 64 originally proposed scheduling saved prompts directly. That would bypass the automation-task aggregate and conflict with the shipped headless CLI. This design instead schedules existing automation tasks. A UI may combine task creation and scheduling for convenience, but core performs and reports them as distinct operations.
+
+Host schedulers are external mutable systems with different recurrence semantics. ConfigStore and a host scheduler cannot participate in one transaction, so the API must distinguish desired state, observed state, read-only inspection, and mutating reconciliation.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Persist typed schedules that reference existing automation tasks.
+- Prevent arbitrary commands, prompts, executable paths, arguments, and environment payloads from entering scheduled-task definitions.
+- Compile numeric five-field cron expressions faithfully on Linux, macOS, and Windows or fail actionably.
+- Preserve non-AgentIron host entries and identify AgentIron entries through platform-specific ownership markers.
+- Provide UI-safe status reports that combine ConfigStore, automation-task validity, headless preflight, and host state.
+- Make automation tasks deterministic when invoked without an interactive caller by storing project root and timeout on the task.
+- Keep platform code testable through injected command and filesystem boundaries.
+
+**Non-Goals:**
+
+- General-purpose cron, launchd, or Task Scheduler management.
+- Direct scheduling of stored prompts.
+- Arbitrary command scheduling or user-controlled command templates.
+- Cross-platform emulation of schedules a host cannot represent exactly.
+- Timezone selection or normalization of daylight-saving behavior.
+- Durable run history, output retention, missed-run recovery, or normalized last/next-run reporting.
+- Windows COM integration in the first implementation.
+- Scheduler UI implementation.
+
+## Decisions
+
+### Scheduled tasks reference automation tasks
+
+`ScheduledTask` contains a stable schedule ID, an `automation_task_id`, a validated cron expression, enabled state, and store-maintained timestamps. It does not duplicate prompt, profile, workspace, timeout, provider, model, tool, or approval settings.
+
+Automation tasks have three identity concerns: an immutable internal ID, a unique case-insensitive normalized name used for convenient lookup, and mutable display text. The referenced automation-task ID is authoritative for schedules and host ownership. Renaming does not rewrite schedule references. Normalized-name collisions are rejected rather than silently suffixed.
+
+Alternative considered: reference stored prompts directly. Rejected because stored prompts are reusable instruction definitions rather than complete unattended executions, and the existing CLI already executes automation tasks.
+
+### Automation tasks own project root and timeout
+
+An automation task gains a canonical project root and positive execution timeout. These values are resolved with the task so manual and scheduled executions mean the same thing. CLI workspace and timeout options remain explicit operator overrides; when omitted, the task values are used.
+
+Alternative considered: persist workspace and timeout on each schedule. Rejected because two schedules for one task would execute the nominally same task with different hidden semantics.
+
+### ConfigStore is desired state
+
+Typed schedule records in ConfigStore are the desired state. Host entries are observed state. `inspect` compares both without mutation. `reconcile` attempts to move owned host state toward desired state and returns the resulting report.
+
+Saving desired state and reconciling are not presented as one atomic operation. A host failure leaves the schedule persisted with an actionable desired-but-not-installed or drifted status that can be retried.
+
+Orphaned owned host entries are reported during inspection. They are removed only by an explicit reconciliation policy or removal operation, never as a side effect of status reads.
+
+### Separate application and host layers
+
+The public shape is two-layered:
+
+```text
+ScheduleManager
+  - typed ConfigStore CRUD
+  - automation-task and headless preflight validation
+  - inspect and reconcile
+  - status synthesis
+
+HostScheduler
+  - install or replace one owned entry
+  - disable or enable one owned entry
+  - remove one owned entry
+  - list and inspect all owned entries
+  - report platform capability failures
+```
+
+`HostScheduler` receives a compiled, core-owned invocation rather than arbitrary caller input. A factory selects the host implementation for the compilation target and returns an unsupported-platform error elsewhere.
+
+### Installation context is manager-owned
+
+`ScheduleManager` is constructed with trusted installation context containing an absolute `agent-iron` runner path and ConfigStore path. The desktop application or embedding process supplies the companion runner location; core does not assume `current_exe()` is the runner and host entries do not rely on `PATH`.
+
+The installed action is derived exclusively by core from installation context and the referenced immutable automation-task ID. Task payloads cannot override the executable, config path, arguments, working directory, shell, or environment.
+
+Executable relocation and upgrade repair are deferred, but drift inspection exposes a stale generated invocation so reconciliation can replace it when the application supplies updated installation context.
+
+### Cron has language validity and platform validity
+
+Core parses exactly five numeric fields: minute, hour, day of month, month, and day of week. Fields support wildcard, numeric value, numeric range, numeric list, and steps over wildcards or ranges. Seconds, macros, names, and non-cron schedule kinds are rejected.
+
+Parsing establishes language validity. Each adapter separately establishes whether it can represent the parsed expression faithfully. Unsupported combinations return a typed platform-capability error; adapters never broaden, narrow, or approximate occurrence semantics.
+
+Schedules use the host scheduler's local system timezone and native daylight-saving behavior. No timezone is persisted.
+
+### Platform ownership and rendering
+
+- Linux uses marker-delimited blocks in the user crontab. Enabled blocks contain generated cron lines. Disabled blocks retain the same generated lines as comments. Rewrites preserve all text outside valid AgentIron-owned blocks byte-for-byte where practical. Malformed and duplicate owned blocks are reported rather than guessed at.
+- macOS uses user LaunchAgent plists with labels prefixed by `com.agentiron.task.` in the user LaunchAgents directory. Expressions may expand to multiple calendar intervals only when expansion is finite and semantically faithful.
+- Windows uses tasks under `\AgentIron\Tasks\<id>`. Core generates Task Scheduler XML and invokes `schtasks.exe` to create, query, enable, disable, and delete definitions. XML allows one owned task to contain multiple triggers without adding a COM dependency.
+
+Ownership identifies the namespace core may mutate; it is not a security assertion because a local user can forge markers or files.
+
+### Disabled definitions remain installed
+
+Disabling retains an owned host entry. Cron represents it as a commented marker-delimited block; launchd and Windows use host disabled state. This preserves discoverability and allows disabled desired state to reconcile as healthy.
+
+### Status is compositional
+
+A report contains an overall health summary plus independent desired, reference, execution, and host states and zero or more diagnostics. This permits simultaneous findings, such as an invalid automation-task reference and a corrupt owned host entry.
+
+Optional host metadata may include last run time, next run time, or result when cheaply available. Missing metadata is not an error and fields remain optional.
+
+## Risks / Trade-offs
+
+- [Cron semantics differ between platforms] -> Require faithful adapter compilation and reject unsupported expressions with platform-specific diagnostics.
+- [ConfigStore and host state diverge after partial failure] -> Persist desired state, expose drift, and make reconciliation explicitly retryable.
+- [Crontab rewriting damages unrelated entries] -> Mutate only well-formed marker-delimited owned blocks, preserve outside content, and test round trips with mixed fixtures.
+- [Runner paths become stale after upgrades] -> Include generated invocation in drift comparison and defer automated relocation repair to a follow-up issue.
+- [Scheduled processes cannot access desktop-session credentials] -> Run normal headless preflight where possible and surface initialization failures; document credential-session limitations.
+- [Trigger expansion becomes excessive] -> Bound expansion and reject expressions that exceed the platform adapter's safe trigger limit.
+- [Local timezone or DST produces surprising runs] -> Document that native host behavior is authoritative and do not claim identical edge behavior across platforms.
+- [Task schema evolution breaks existing records] -> Add a compiled migration with explicit defaults or migration validation and preserve old records transactionally.
+- [Concurrent reconciliation races] -> Make host replacement idempotent, use stable ownership identities, and return observed post-operation state.
+
+## Migration Plan
+
+1. Add project-root and timeout fields to automation-task persistence with a compiled ConfigStore migration. Existing tasks that cannot receive safe deterministic values remain readable for management but report incomplete execution configuration until updated.
+2. Add typed scheduled-task payload decoding over the existing opaque schedule table. Unsupported or malformed existing payloads remain stored and surface diagnostics rather than being silently rewritten.
+3. Add the fake host adapter and manager reconciliation tests before enabling concrete platform factories.
+4. Add platform adapters independently, with unsupported targets returning typed errors.
+5. Existing headless CLI invocations with explicit workspace and timeout continue to work. New fallback behavior applies only when those options are absent.
+
+Rollback removes host entries through the version that created them before reverting binaries. ConfigStore migrations are forward-only; persisted schedule records remain opaque to older versions, and automation-task schema rollback requires restoring a pre-migration database backup.
+
+## Open Questions
+
+- What bounded trigger-expansion limit should launchd and Windows adapters enforce?
+- Should reconciliation of all tasks remove orphaned owned entries by default, or require an explicit `remove_orphans` policy flag?
+- What conservative concurrent-run policy can all three host schedulers represent faithfully? This may need a focused follow-up before platform installation is enabled.
+- Which follow-up issue should own durable scheduled-run history, output retention, and normalized last/next-run reporting?

--- a/openspec/changes/add-scheduled-automation-tasks/proposal.md
+++ b/openspec/changes/add-scheduled-automation-tasks/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+AgentIron can execute durable automation tasks non-interactively, but it cannot yet persist when those tasks should run or reconcile them with the host operating system's scheduler. Scheduling must build on the existing automation-task boundary so convenience workflows create an automation task first and never turn the scheduler into an arbitrary command or prompt runner.
+
+## What Changes
+
+- Add typed scheduled-task definitions that reference immutable automation-task IDs and contain only a five-field cron expression and enabled state.
+- Give automation tasks unique case-insensitive normalized names for user-facing lookup while schedules and host ownership continue to use immutable task IDs.
+- Treat ConfigStore schedule records as desired state and expose separate inspection and reconciliation operations against host scheduler state.
+- Add rich status and diagnostics for missing references, unsafe headless policy, absent or drifted host entries, corrupt owned entries, orphaned entries, unsupported schedules, and unavailable platform services.
+- Add a host-scheduler abstraction with Linux cron, macOS launchd, and Windows Task Scheduler implementations.
+- Install only core-generated `agent-iron run <task-id>` invocations; callers cannot supply executables, arguments, shell fragments, environment variables, or command templates as task payloads.
+- Compile a common numeric five-field cron language where a platform can represent it faithfully and reject unsupported expressions without approximation.
+- Use the host's local timezone and native daylight-saving behavior.
+- Preserve disabled tasks as disabled host entries, including marker-delimited commented blocks in user crontabs.
+- Extend automation tasks with a normalized user-facing name plus deterministic project-root and timeout execution settings needed for unattended execution.
+- Allow the headless CLI to derive project root and timeout from the selected automation task while retaining explicit invocation overrides for direct operators.
+- Add best-effort host run metadata to status while deferring durable run history and normalized cross-platform observability to follow-up work.
+
+## Capabilities
+
+### New Capabilities
+- `scheduled-automation-tasks`: Typed scheduled-task persistence, validation, host ownership, platform compilation, inspection, reconciliation, and status reporting.
+
+### Modified Capabilities
+- `automation-tasks`: Make each automation task self-contained for unattended execution by persisting its project root and timeout.
+- `headless-task-cli`: Permit scheduled invocations to derive deterministic project root and timeout from the automation task instead of requiring scheduler-owned command customization.
+
+## Impact
+
+- Adds scheduler domain and manager modules plus platform-specific cron, launchd, and Windows Task Scheduler adapters.
+- Adds typed interpretation of existing ConfigStore schedule records and automation-task schema evolution.
+- Changes automation-task inputs and persisted records to include project root and timeout.
+- Changes headless CLI resolution precedence for workspace and timeout while preserving task-only execution and non-interactive safety checks.
+- Introduces command-runner and filesystem boundaries so host integrations can be tested without mutating a developer's scheduler.
+- Requires follow-up issues for durable scheduled-run history, normalized last/next-run reporting, output retention, missed-run policy, and executable relocation or upgrade repair.

--- a/openspec/changes/add-scheduled-automation-tasks/specs/automation-tasks/spec.md
+++ b/openspec/changes/add-scheduled-automation-tasks/specs/automation-tasks/spec.md
@@ -1,0 +1,69 @@
+## MODIFIED Requirements
+
+### Requirement: Core SHALL define durable automation tasks
+The system SHALL define a typed `AutomationTask` with an immutable internal ID, unique normalized name, user-facing display name, stored-prompt ID, expected-outcome text, canonical project root, positive execution timeout, creation timestamp, and update timestamp. Normalized names SHALL be case-insensitive for lookup and SHALL reject collisions rather than silently generating suffixes. The task SHALL reference its profile, instructions, skills, provider, model, tools, and approval policy indirectly through its stored prompt and that prompt's optional profile.
+
+#### Scenario: Automation task captures durable automation identity
+- **WHEN** a caller creates an automation task
+- **THEN** it includes an immutable task ID
+- **AND** includes a unique normalized name suitable for convenient lookup
+- **AND** includes a user-facing display name suitable for GUI display
+- **AND** references a stored prompt by ID
+- **AND** includes required expected-outcome text
+- **AND** includes the project root and timeout required for deterministic unattended execution
+
+#### Scenario: Multiple tasks reuse one stored prompt
+- **WHEN** multiple automation tasks reference the same stored prompt
+- **THEN** each task retains its own ID, normalized name, display name, expected outcome, project root, and timeout
+- **AND** the stored prompt's instructions, skills, and optional profile are not duplicated into either task
+
+#### Scenario: Display name changes without breaking schedules
+- **WHEN** a caller renames an automation task
+- **THEN** its immutable internal ID remains unchanged
+- **AND** schedules continue to reference the same task without rewriting their references
+
+### Requirement: Core SHALL validate automation-task identity and content
+The system SHALL validate the immutable task ID, normalize the task name into the supported user-facing form, trim the display name, stored-prompt ID, and expected outcome, and reject a task when any required resulting value is empty or when a textual identifier contains control characters. Core SHALL canonicalize the project root, require it to be an existing directory, and require a positive bounded execution timeout. Task IDs SHALL remain stable across updates, and normalized-name uniqueness SHALL be enforced case-insensitively.
+
+#### Scenario: Valid automation task is accepted
+- **WHEN** a caller supplies valid identity and content fields, an existing stored-prompt ID, an existing project-root directory, and a positive supported timeout
+- **THEN** the system accepts the automation task
+- **AND** preserves its immutable task ID
+- **AND** stores its normalized lookup name
+- **AND** persists the canonical project root and timeout
+
+#### Scenario: Invalid automation task is rejected
+- **WHEN** a required task field is empty after normalization, a textual identifier contains control characters, the project root is invalid, or the timeout is invalid
+- **THEN** the system returns a typed validation error
+- **AND** does not persist a partial task
+
+#### Scenario: Normalized name collides case-insensitively
+- **WHEN** a caller creates or renames a task to a normalized name already used by another task regardless of case
+- **THEN** the system returns a typed conflict
+- **AND** does not silently suffix or replace either task
+
+### Requirement: Core SHALL resolve an immutable execution input for a task run
+At run start, the system SHALL resolve the automation task, stored prompt, selected agent profile, expected outcome, requested skills, effective tools, provider, model, canonical project root, and timeout into an execution input used for that run. Resolution SHALL use current persisted values, and later configuration edits SHALL not alter the in-progress run.
+
+#### Scenario: Run resolves current dependencies
+- **WHEN** execution of an automation task begins
+- **THEN** the system resolves the task's current stored prompt and profile references
+- **AND** combines stored instructions with the task's expected outcome as the model-visible user goal
+- **AND** resolves the task's canonical project root as the session workspace
+- **AND** resolves the task's timeout for complete execution
+- **AND** keeps profile identity instructions in the system prompt layers
+
+#### Scenario: Concurrent edit does not mutate active run
+- **WHEN** a referenced task, prompt, profile, project root, or timeout changes after run resolution completes
+- **THEN** the active run continues with its resolved execution input
+- **AND** a later run observes the updated configuration
+
+#### Scenario: Missing named dependency fails resolution
+- **WHEN** a task references a missing or malformed stored prompt or named profile
+- **THEN** resolution fails with an actionable typed error
+- **AND** no model request or tool execution begins
+
+#### Scenario: Stored execution context becomes invalid
+- **WHEN** a task's persisted project root no longer exists or its timeout cannot be decoded
+- **THEN** resolution fails with an actionable configuration error
+- **AND** no model request or tool execution begins

--- a/openspec/changes/add-scheduled-automation-tasks/specs/headless-task-cli/spec.md
+++ b/openspec/changes/add-scheduled-automation-tasks/specs/headless-task-cli/spec.md
@@ -1,0 +1,40 @@
+## MODIFIED Requirements
+
+### Requirement: Every headless run SHALL have a validated workspace
+Each automation task SHALL provide a persisted project root used as the default headless workspace. The CLI SHALL support `--workspace` and `AGENTIRON_WORKSPACE` as explicit operator overrides, resolving workspace in the order command line, environment, then automation task. Before runtime execution, it SHALL canonicalize the selected path, require it to be an existing directory, and use it as both the session workspace root and the allowed root for workspace-scoped built-in tools. It SHALL NOT use the process working directory as an implicit fallback.
+
+#### Scenario: Explicit workspace is used
+- **WHEN** a caller supplies an existing directory through `--workspace`
+- **THEN** the CLI canonicalizes that directory
+- **AND** uses it as the run's session workspace and built-in-tool allowed root
+
+#### Scenario: Task supplies workspace
+- **WHEN** neither `--workspace` nor `AGENTIRON_WORKSPACE` is supplied
+- **THEN** the CLI uses the selected automation task's persisted project root
+
+#### Scenario: Workspace is invalid
+- **WHEN** the resolved workspace does not exist, is not a directory, or cannot be canonicalized
+- **THEN** the CLI returns a configuration error
+- **AND** no model request or tool execution begins
+
+### Requirement: Every headless run SHALL have an execution timeout
+Each automation task SHALL provide a persisted positive timeout used by default for headless execution. The CLI SHALL support `--timeout` and `AGENTIRON_TIMEOUT` as explicit operator overrides using documented duration values such as `30s`, `5m`, and `1h`, resolving timeout in the order command line, environment, then automation task. Timeout expiration SHALL request cancellation and produce the `timed_out` status even if cleanup continues afterward.
+
+#### Scenario: Timeout is supplied on command line
+- **WHEN** a caller supplies a valid positive `--timeout`
+- **THEN** the CLI applies it to the complete task execution
+
+#### Scenario: Task supplies timeout
+- **WHEN** neither `--timeout` nor `AGENTIRON_TIMEOUT` is supplied
+- **THEN** the CLI applies the selected automation task's persisted timeout
+
+#### Scenario: Timeout is invalid
+- **WHEN** the resolved timeout is absent, malformed, zero, negative, or exceeds the supported bound
+- **THEN** the CLI reports a configuration error
+- **AND** does not begin task execution
+
+#### Scenario: Timeout expires
+- **WHEN** execution exceeds the resolved timeout
+- **THEN** the CLI requests cancellation of the run
+- **AND** reports status `timed_out`
+- **AND** exits with the timeout exit code

--- a/openspec/changes/add-scheduled-automation-tasks/specs/scheduled-automation-tasks/spec.md
+++ b/openspec/changes/add-scheduled-automation-tasks/specs/scheduled-automation-tasks/spec.md
@@ -1,0 +1,186 @@
+## ADDED Requirements
+
+### Requirement: Core SHALL define typed scheduled automation tasks
+The system SHALL define a schema-versioned `ScheduledTask` with a stable schedule ID, an existing automation-task ID, a numeric five-field cron expression, enabled state, and store-maintained creation and update timestamps. A scheduled task SHALL NOT contain prompt text, a stored-prompt reference as its execution target, an executable, arguments, shell text, environment variables, or a user-provided command template.
+
+#### Scenario: Existing automation task is scheduled
+- **WHEN** a caller creates a schedule with a valid ID, existing automation-task ID, valid cron expression, and enabled state
+- **THEN** core persists the typed scheduled task
+- **AND** the schedule references the automation task by its stable ID
+
+#### Scenario: Arbitrary execution payload is not representable
+- **WHEN** a caller constructs a scheduled-task input
+- **THEN** the typed input provides no field for an arbitrary command, prompt, executable, argument list, shell fragment, environment map, or stored-prompt execution target
+
+### Requirement: Scheduled tasks SHALL preserve automation-task referential integrity
+Core SHALL require the referenced automation task to exist when a scheduled task is created or updated. Deleting an automation task referenced by one or more desired schedules SHALL fail with a typed conflict that identifies the referencing schedule IDs.
+
+#### Scenario: Missing automation task rejects schedule
+- **WHEN** a caller saves a scheduled task whose automation-task ID does not exist
+- **THEN** core returns a typed reference error
+- **AND** does not persist a partial scheduled task
+
+#### Scenario: Referenced automation task cannot be deleted
+- **WHEN** a caller deletes an automation task referenced by a desired schedule
+- **THEN** core returns a typed conflict identifying the schedule
+- **AND** preserves both records
+
+### Requirement: Core SHALL validate the common cron language
+Core SHALL accept exactly five fields in minute, hour, day-of-month, month, and day-of-week order. Fields SHALL support wildcard, numeric values, numeric ranges, numeric lists, wildcard steps, and range steps within the field's valid numeric bounds. Core SHALL reject seconds fields, macros, named months or weekdays, malformed lists or ranges, zero steps, and non-cron schedule kinds.
+
+#### Scenario: Numeric stepped expression is accepted
+- **WHEN** a caller supplies `*/15 9-17/2 * 1,6,12 1-5`
+- **THEN** common-language validation succeeds
+
+#### Scenario: Unsupported syntax is rejected
+- **WHEN** a caller supplies a macro, named weekday, seconds field, malformed range, out-of-bounds value, or zero step
+- **THEN** validation returns an actionable field-specific error
+- **AND** no host entry is installed
+
+### Requirement: Host adapters SHALL compile schedules faithfully or reject them
+Each host adapter SHALL either represent every occurrence of a valid common cron expression without introducing additional occurrences or omitting required occurrences, or return a typed unsupported-schedule error. Adapters SHALL NOT approximate an unsupported schedule.
+
+#### Scenario: Platform supports expression
+- **WHEN** the selected host adapter can represent a parsed expression faithfully
+- **THEN** it compiles the expression into one or more native triggers belonging to one owned task
+
+#### Scenario: Platform cannot preserve semantics
+- **WHEN** the selected host adapter cannot represent a parsed expression faithfully or within its bounded expansion limit
+- **THEN** installation fails with an unsupported-schedule diagnostic
+- **AND** desired ConfigStore state remains available for inspection and retry
+
+### Requirement: Schedules SHALL use native local-time behavior
+Host entries SHALL use the host scheduler's current local system timezone and native daylight-saving behavior. Scheduled-task records SHALL NOT persist or emulate a separate timezone.
+
+#### Scenario: System timezone changes
+- **WHEN** the host system timezone changes after installation
+- **THEN** future occurrences follow the host scheduler's native local-time interpretation
+- **AND** core does not translate the schedule back to the former timezone
+
+#### Scenario: Daylight-saving transition occurs
+- **WHEN** local time skips or repeats during a daylight-saving transition
+- **THEN** execution follows the native host scheduler behavior
+
+### Requirement: ConfigStore SHALL be desired schedule state
+Typed scheduled-task records in ConfigStore SHALL represent desired state, while owned host entries SHALL represent observed state. Saving desired state SHALL remain successful when subsequent host reconciliation fails, and the failure SHALL be visible through status.
+
+#### Scenario: Host installation fails after save
+- **WHEN** a valid scheduled task is persisted and host installation fails
+- **THEN** the desired scheduled task remains persisted
+- **AND** status reports that the desired task is not installed with the host failure diagnostic
+
+### Requirement: Inspection SHALL be read-only and reconciliation SHALL be explicit
+The application-facing scheduler API SHALL provide a read-only inspection operation and a distinct mutating reconciliation operation. Inspection SHALL NOT install, replace, disable, enable, or remove host entries. Reconciliation SHALL operate only on AgentIron-owned host entries.
+
+#### Scenario: UI refresh inspects status
+- **WHEN** a caller requests schedule status through inspection
+- **THEN** core compares desired and observed state
+- **AND** performs no host mutation
+
+#### Scenario: Caller requests reconciliation
+- **WHEN** a caller explicitly reconciles a valid desired schedule
+- **THEN** core installs, replaces, enables, or disables its owned host entry as needed
+- **AND** returns the observed post-operation status
+
+### Requirement: Status reports SHALL compose desired, reference, execution, and host state
+Core SHALL return a status report with an overall health summary, desired-state status, automation-task reference status, headless-execution readiness, host-entry status, diagnostics, and optional host run metadata. The report SHALL support multiple simultaneous diagnostics.
+
+#### Scenario: Healthy task is reported
+- **WHEN** desired state is valid, its automation task is headless-safe, and a matching enabled or disabled owned host entry exists
+- **THEN** status reports healthy with the corresponding enabled state
+
+#### Scenario: Multiple invariant failures exist
+- **WHEN** a desired record references an invalid task and an owned host entry is corrupt
+- **THEN** one report describes both failures
+- **AND** does not collapse them into an ambiguous boolean
+
+#### Scenario: Host metadata is unavailable
+- **WHEN** a host adapter cannot report last run, next run, or last result
+- **THEN** those fields are absent
+- **AND** their absence alone does not make an otherwise matching entry unhealthy
+
+### Requirement: Scheduled invocation SHALL be generated exclusively by core
+The schedule manager SHALL derive an absolute runner invocation from trusted installation context and the referenced automation-task ID. Host entries SHALL invoke `agent-iron run <task-id>` against the intended ConfigStore and SHALL NOT rely on `PATH`, process working directory, or caller-provided command payloads.
+
+#### Scenario: Owned invocation is installed
+- **WHEN** a valid desired schedule is reconciled
+- **THEN** the host entry uses the manager's absolute `agent-iron` runner path
+- **AND** selects the intended ConfigStore
+- **AND** names only the referenced automation task as user-controlled execution identity
+
+#### Scenario: Runner path changes
+- **WHEN** the trusted installation context contains a different runner path than an existing owned entry
+- **THEN** inspection reports drift
+- **AND** explicit reconciliation replaces the generated invocation
+
+### Requirement: HostScheduler factory SHALL select the current platform
+Core SHALL provide a factory that selects the Linux cron adapter, macOS launchd adapter, or Windows Task Scheduler adapter for supported compilation targets and returns a typed unsupported-platform error for other targets.
+
+#### Scenario: Supported platform creates adapter
+- **WHEN** the factory runs on Linux, macOS, or Windows
+- **THEN** it returns the corresponding host adapter
+
+#### Scenario: Unsupported platform requests scheduler
+- **WHEN** the factory runs on another target
+- **THEN** it returns an unsupported-platform error without host mutation
+
+### Requirement: Linux scheduling SHALL preserve non-owned crontab content
+The Linux adapter SHALL manage only marker-delimited AgentIron blocks in the current user's crontab. Enabled tasks SHALL contain generated active lines, disabled tasks SHALL retain generated lines as comments, and content outside valid owned blocks SHALL be preserved. Malformed or duplicate owned blocks SHALL produce diagnostics rather than guessed mutation.
+
+#### Scenario: Task is installed beside user entries
+- **WHEN** reconciliation installs a task into a crontab containing non-AgentIron entries
+- **THEN** the adapter adds or replaces only the task's owned marker-delimited block
+- **AND** preserves non-owned entries
+
+#### Scenario: Cron task is disabled
+- **WHEN** desired state changes from enabled to disabled
+- **THEN** reconciliation retains the owned block with generated cron lines commented
+- **AND** later inspection recognizes it as installed and disabled
+
+#### Scenario: Owned markers are malformed
+- **WHEN** inspection finds unbalanced or duplicate markers for an AgentIron task
+- **THEN** status reports a corrupt owned entry
+- **AND** reconciliation does not remove unrelated or ambiguously bounded text
+
+### Requirement: macOS scheduling SHALL use owned user LaunchAgents
+The macOS adapter SHALL manage user-level LaunchAgent plists whose labels use the `com.agentiron.task.` prefix. It SHALL mutate only plists in the expected user LaunchAgents location with valid owned labels and definitions.
+
+#### Scenario: LaunchAgent is installed
+- **WHEN** a schedule can be compiled faithfully for launchd
+- **THEN** reconciliation writes a user LaunchAgent with an owned label and core-generated invocation
+
+#### Scenario: Unowned plist is present
+- **WHEN** the LaunchAgents directory contains a plist without a valid AgentIron task label
+- **THEN** listing, reconciliation, and removal leave it unchanged
+
+### Requirement: Windows scheduling SHALL use owned Task Scheduler XML definitions
+The Windows adapter SHALL manage tasks under `\AgentIron\Tasks\<id>`, generate Task Scheduler XML with one or more triggers as needed, and use `schtasks.exe` for lifecycle operations. It SHALL NOT mutate tasks outside the AgentIron task folder.
+
+#### Scenario: Windows task is installed
+- **WHEN** a schedule can be compiled faithfully for Task Scheduler
+- **THEN** reconciliation registers generated XML under the owned task path
+- **AND** the action contains only the core-generated task invocation
+
+#### Scenario: Windows task is disabled
+- **WHEN** desired state is disabled
+- **THEN** the owned task remains registered in disabled state
+
+#### Scenario: Unowned Windows task exists
+- **WHEN** another task exists outside `\AgentIron\Tasks\`
+- **THEN** AgentIron listing, reconciliation, and removal leave it unchanged
+
+### Requirement: Host integrations SHALL be testable without real scheduler mutation
+Platform adapters SHALL use injectable command-runner and filesystem boundaries sufficient to test rendering, parsing, command construction, ownership filtering, disabled state, and failure handling without changing the test user's real scheduler.
+
+#### Scenario: Adapter test installs a task
+- **WHEN** a test reconciles through mocked command and filesystem boundaries
+- **THEN** the test can assert generated native definitions and commands
+- **AND** no real crontab, LaunchAgent, or Windows task is changed
+
+### Requirement: Orphaned owned entries SHALL remain observable
+Inspection SHALL report an owned host entry whose schedule ID has no desired ConfigStore record. Status reads SHALL NOT remove orphaned entries, and removal SHALL require explicit reconciliation policy or an explicit remove operation.
+
+#### Scenario: ConfigStore record is missing
+- **WHEN** an owned host entry exists without a corresponding desired schedule
+- **THEN** inspection reports the entry as orphaned
+- **AND** leaves it installed

--- a/openspec/changes/add-scheduled-automation-tasks/tasks.md
+++ b/openspec/changes/add-scheduled-automation-tasks/tasks.md
@@ -1,0 +1,70 @@
+## 1. Automation Execution Context
+
+- [ ] 1.1 Add immutable ID, unique normalized name, display name, canonical project-root, and positive bounded timeout fields to automation-task domain and input types
+- [ ] 1.2 Add normalized-name generation, case-insensitive lookup, collision rejection, and rename tests
+- [ ] 1.3 Add a compiled ConfigStore migration and typed CRUD support for automation-task identity and execution context
+- [ ] 1.4 Define migration behavior and diagnostics for existing automation tasks without normalized names or deterministic execution context
+- [ ] 1.5 Resolve project root and timeout into immutable automation execution input and validate stale roots at run start
+- [ ] 1.6 Update automation-task persistence, validation, reference-integrity, rename, and execution-resolution tests
+
+## 2. Headless CLI Defaults
+
+- [ ] 2.1 Change workspace precedence to CLI, environment, then persisted automation-task project root
+- [ ] 2.2 Change timeout precedence to CLI, environment, then persisted automation-task timeout
+- [ ] 2.3 Remove process-current-directory workspace fallback and preserve explicit override behavior
+- [ ] 2.4 Add CLI unit and integration tests for task defaults, explicit overrides, invalid stored context, and scheduled-style invocation
+
+## 3. Schedule Domain And Persistence
+
+- [ ] 3.1 Define schema-versioned scheduled-task, input, status, diagnostic, host metadata, and error types
+- [ ] 3.2 Implement five-field numeric cron parsing and validation for wildcards, values, ranges, lists, and steps
+- [ ] 3.3 Add exhaustive cron boundary and unsupported-syntax tests, including day-of-month and day-of-week semantics
+- [ ] 3.4 Add typed ConfigStore schedule CRUD over existing schedule records with deterministic listing and schema diagnostics
+- [ ] 3.5 Enforce schedule-to-automation-task references and block automation-task deletion with referencing schedule IDs
+- [ ] 3.6 Add persistence tests for reference integrity, replacement timestamps, malformed payloads, unsupported schema versions, and delete conflicts
+
+## 4. Host Scheduler Contract
+
+- [ ] 4.1 Define trusted scheduler installation context and core-generated runner invocation
+- [ ] 4.2 Define async HostScheduler operations and observed host-entry types without arbitrary command inputs
+- [ ] 4.3 Add injectable command-runner and filesystem boundaries with fake implementations for tests
+- [ ] 4.4 Implement platform factory selection and unsupported-platform errors
+- [ ] 4.5 Test that generated invocations use absolute runner and ConfigStore paths and expose no caller-controlled command surface
+
+## 5. Schedule Manager And Reconciliation
+
+- [ ] 5.1 Implement read-only inspection across desired schedules, automation-task references, headless preflight, and observed host entries
+- [ ] 5.2 Implement compositional health, drift, corruption, unavailable-platform, missing-reference, unsafe-policy, and orphan diagnostics
+- [ ] 5.3 Implement explicit idempotent reconciliation for install, replace, enable, disable, remove, and unchanged states
+- [ ] 5.4 Define and implement explicit orphan-removal policy without mutation during inspection
+- [ ] 5.5 Add fake-adapter tests for partial failures, retries, simultaneous diagnostics, runner-path drift, and optional host metadata
+
+## 6. Linux Cron Adapter
+
+- [ ] 6.1 Implement marker-delimited owned-block rendering for enabled and commented disabled tasks
+- [ ] 6.2 Implement user-crontab parsing that preserves non-owned content and reports malformed or duplicate owned blocks
+- [ ] 6.3 Implement cron install, replace, enable, disable, list, inspect, and remove through the command-runner boundary
+- [ ] 6.4 Add mixed crontab fixtures covering unrelated entries, multiple owned blocks, malformed markers, disabled tasks, and exact-target removal
+- [ ] 6.5 Verify Linux schedule compilation preserves common cron occurrence semantics without approximation
+
+## 7. macOS Launchd Adapter
+
+- [ ] 7.1 Define bounded faithful cron-to-StartCalendarInterval expansion and actionable unsupported cases
+- [ ] 7.2 Implement owned user LaunchAgent plist rendering and parsing with `com.agentiron.task.` labels
+- [ ] 7.3 Implement launchd install, replace, enable, disable, list, inspect, and remove through injectable boundaries
+- [ ] 7.4 Add plist and command fixtures for multiple intervals, disabled state, drift, corruption, ownership filtering, and expansion limits
+
+## 8. Windows Task Scheduler Adapter
+
+- [ ] 8.1 Define bounded faithful cron-to-Task-Scheduler-trigger expansion and actionable unsupported cases
+- [ ] 8.2 Implement owned Task Scheduler XML rendering and parsing under `\AgentIron\Tasks\<id>`
+- [ ] 8.3 Implement `schtasks.exe` create, query, enable, disable, delete, list, and inspect operations through the command-runner boundary
+- [ ] 8.4 Add mocked `schtasks.exe` and XML fixtures for multiple triggers, disabled state, drift, corruption, ownership filtering, and expansion limits
+
+## 9. Cross-Platform Verification And Documentation
+
+- [ ] 9.1 Add contract tests shared by all host adapters for ownership isolation, faithful-or-fail compilation, disabled retention, and idempotent reconciliation
+- [ ] 9.2 Document local-system-timezone and native daylight-saving behavior plus platform capability failures
+- [ ] 9.3 Document that scheduling accepts automation tasks only and that create-and-schedule UI flows remain two core operations
+- [ ] 9.4 Run formatting, linting, unit tests, integration tests, and supported platform checks
+- [ ] 9.5 File follow-up issues for durable run history, output retention, normalized host run metadata, missed-run policy, concurrent-run policy, credential-session limitations, and executable relocation repair

--- a/openspec/changes/add-scheduled-automation-tasks/tasks.md
+++ b/openspec/changes/add-scheduled-automation-tasks/tasks.md
@@ -41,30 +41,30 @@
 
 ## 6. Linux Cron Adapter
 
-- [ ] 6.1 Implement marker-delimited owned-block rendering for enabled and commented disabled tasks
-- [ ] 6.2 Implement user-crontab parsing that preserves non-owned content and reports malformed or duplicate owned blocks
-- [ ] 6.3 Implement cron install, replace, enable, disable, list, inspect, and remove through the command-runner boundary
-- [ ] 6.4 Add mixed crontab fixtures covering unrelated entries, multiple owned blocks, malformed markers, disabled tasks, and exact-target removal
-- [ ] 6.5 Verify Linux schedule compilation preserves common cron occurrence semantics without approximation
+- [x] 6.1 Implement marker-delimited owned-block rendering for enabled and commented disabled tasks
+- [x] 6.2 Implement user-crontab parsing that preserves non-owned content and reports malformed or duplicate owned blocks
+- [x] 6.3 Implement cron install, replace, enable, disable, list, inspect, and remove through the command-runner boundary
+- [x] 6.4 Add mixed crontab fixtures covering unrelated entries, multiple owned blocks, malformed markers, disabled tasks, and exact-target removal
+- [x] 6.5 Verify Linux schedule compilation preserves common cron occurrence semantics without approximation
 
 ## 7. macOS Launchd Adapter
 
-- [ ] 7.1 Define bounded faithful cron-to-StartCalendarInterval expansion and actionable unsupported cases
-- [ ] 7.2 Implement owned user LaunchAgent plist rendering and parsing with `com.agentiron.task.` labels
-- [ ] 7.3 Implement launchd install, replace, enable, disable, list, inspect, and remove through injectable boundaries
-- [ ] 7.4 Add plist and command fixtures for multiple intervals, disabled state, drift, corruption, ownership filtering, and expansion limits
+- [x] 7.1 Define bounded faithful cron-to-StartCalendarInterval expansion and actionable unsupported cases
+- [x] 7.2 Implement owned user LaunchAgent plist rendering and parsing with `com.agentiron.task.` labels
+- [x] 7.3 Implement launchd install, replace, enable, disable, list, inspect, and remove through injectable boundaries
+- [x] 7.4 Add plist and command fixtures for multiple intervals, disabled state, drift, corruption, ownership filtering, and expansion limits
 
 ## 8. Windows Task Scheduler Adapter
 
-- [ ] 8.1 Define bounded faithful cron-to-Task-Scheduler-trigger expansion and actionable unsupported cases
-- [ ] 8.2 Implement owned Task Scheduler XML rendering and parsing under `\AgentIron\Tasks\<id>`
-- [ ] 8.3 Implement `schtasks.exe` create, query, enable, disable, delete, list, and inspect operations through the command-runner boundary
-- [ ] 8.4 Add mocked `schtasks.exe` and XML fixtures for multiple triggers, disabled state, drift, corruption, ownership filtering, and expansion limits
+- [x] 8.1 Define bounded faithful cron-to-Task-Scheduler-trigger expansion and actionable unsupported cases
+- [x] 8.2 Implement owned Task Scheduler XML rendering and parsing under `\AgentIron\Tasks\<id>`
+- [x] 8.3 Implement `schtasks.exe` create, query, enable, disable, delete, list, and inspect operations through the command-runner boundary
+- [x] 8.4 Add mocked `schtasks.exe` and XML fixtures for multiple triggers, disabled state, drift, corruption, ownership filtering, and expansion limits
 
 ## 9. Cross-Platform Verification And Documentation
 
-- [ ] 9.1 Add contract tests shared by all host adapters for ownership isolation, faithful-or-fail compilation, disabled retention, and idempotent reconciliation
-- [ ] 9.2 Document local-system-timezone and native daylight-saving behavior plus platform capability failures
-- [ ] 9.3 Document that scheduling accepts automation tasks only and that create-and-schedule UI flows remain two core operations
-- [ ] 9.4 Run formatting, linting, unit tests, integration tests, and supported platform checks
+- [x] 9.1 Add contract tests shared by all host adapters for ownership isolation, faithful-or-fail compilation, disabled retention, and idempotent reconciliation
+- [x] 9.2 Document local-system-timezone and native daylight-saving behavior plus platform capability failures
+- [x] 9.3 Document that scheduling accepts automation tasks only and that create-and-schedule UI flows remain two core operations
+- [x] 9.4 Run formatting, linting, unit tests, integration tests, and supported platform checks
 - [ ] 9.5 File follow-up issues for durable run history, output retention, normalized host run metadata, missed-run policy, concurrent-run policy, credential-session limitations, and executable relocation repair

--- a/openspec/changes/add-scheduled-automation-tasks/tasks.md
+++ b/openspec/changes/add-scheduled-automation-tasks/tasks.md
@@ -67,4 +67,4 @@
 - [x] 9.2 Document local-system-timezone and native daylight-saving behavior plus platform capability failures
 - [x] 9.3 Document that scheduling accepts automation tasks only and that create-and-schedule UI flows remain two core operations
 - [x] 9.4 Run formatting, linting, unit tests, integration tests, and supported platform checks
-- [ ] 9.5 File follow-up issues for durable run history, output retention, normalized host run metadata, missed-run policy, concurrent-run policy, credential-session limitations, and executable relocation repair
+- [x] 9.5 File follow-up issues for durable run history, output retention, normalized host run metadata, missed-run policy, concurrent-run policy, credential-session limitations, and executable relocation repair

--- a/openspec/changes/add-scheduled-automation-tasks/tasks.md
+++ b/openspec/changes/add-scheduled-automation-tasks/tasks.md
@@ -1,43 +1,43 @@
 ## 1. Automation Execution Context
 
-- [ ] 1.1 Add immutable ID, unique normalized name, display name, canonical project-root, and positive bounded timeout fields to automation-task domain and input types
-- [ ] 1.2 Add normalized-name generation, case-insensitive lookup, collision rejection, and rename tests
-- [ ] 1.3 Add a compiled ConfigStore migration and typed CRUD support for automation-task identity and execution context
-- [ ] 1.4 Define migration behavior and diagnostics for existing automation tasks without normalized names or deterministic execution context
-- [ ] 1.5 Resolve project root and timeout into immutable automation execution input and validate stale roots at run start
-- [ ] 1.6 Update automation-task persistence, validation, reference-integrity, rename, and execution-resolution tests
+- [x] 1.1 Add immutable ID, unique normalized name, display name, canonical project-root, and positive bounded timeout fields to automation-task domain and input types
+- [x] 1.2 Add normalized-name generation, case-insensitive lookup, collision rejection, and rename tests
+- [x] 1.3 Add a compiled ConfigStore migration and typed CRUD support for automation-task identity and execution context
+- [x] 1.4 Define migration behavior and diagnostics for existing automation tasks without normalized names or deterministic execution context
+- [x] 1.5 Resolve project root and timeout into immutable automation execution input and validate stale roots at run start
+- [x] 1.6 Update automation-task persistence, validation, reference-integrity, rename, and execution-resolution tests
 
 ## 2. Headless CLI Defaults
 
-- [ ] 2.1 Change workspace precedence to CLI, environment, then persisted automation-task project root
-- [ ] 2.2 Change timeout precedence to CLI, environment, then persisted automation-task timeout
-- [ ] 2.3 Remove process-current-directory workspace fallback and preserve explicit override behavior
-- [ ] 2.4 Add CLI unit and integration tests for task defaults, explicit overrides, invalid stored context, and scheduled-style invocation
+- [x] 2.1 Change workspace precedence to CLI, environment, then persisted automation-task project root
+- [x] 2.2 Change timeout precedence to CLI, environment, then persisted automation-task timeout
+- [x] 2.3 Remove process-current-directory workspace fallback and preserve explicit override behavior
+- [x] 2.4 Add CLI unit and integration tests for task defaults, explicit overrides, invalid stored context, and scheduled-style invocation
 
 ## 3. Schedule Domain And Persistence
 
-- [ ] 3.1 Define schema-versioned scheduled-task, input, status, diagnostic, host metadata, and error types
-- [ ] 3.2 Implement five-field numeric cron parsing and validation for wildcards, values, ranges, lists, and steps
-- [ ] 3.3 Add exhaustive cron boundary and unsupported-syntax tests, including day-of-month and day-of-week semantics
-- [ ] 3.4 Add typed ConfigStore schedule CRUD over existing schedule records with deterministic listing and schema diagnostics
-- [ ] 3.5 Enforce schedule-to-automation-task references and block automation-task deletion with referencing schedule IDs
-- [ ] 3.6 Add persistence tests for reference integrity, replacement timestamps, malformed payloads, unsupported schema versions, and delete conflicts
+- [x] 3.1 Define schema-versioned scheduled-task, input, status, diagnostic, host metadata, and error types
+- [x] 3.2 Implement five-field numeric cron parsing and validation for wildcards, values, ranges, lists, and steps
+- [x] 3.3 Add exhaustive cron boundary and unsupported-syntax tests, including day-of-month and day-of-week semantics
+- [x] 3.4 Add typed ConfigStore schedule CRUD over existing schedule records with deterministic listing and schema diagnostics
+- [x] 3.5 Enforce schedule-to-automation-task references and block automation-task deletion with referencing schedule IDs
+- [x] 3.6 Add persistence tests for reference integrity, replacement timestamps, malformed payloads, unsupported schema versions, and delete conflicts
 
 ## 4. Host Scheduler Contract
 
-- [ ] 4.1 Define trusted scheduler installation context and core-generated runner invocation
-- [ ] 4.2 Define async HostScheduler operations and observed host-entry types without arbitrary command inputs
-- [ ] 4.3 Add injectable command-runner and filesystem boundaries with fake implementations for tests
-- [ ] 4.4 Implement platform factory selection and unsupported-platform errors
-- [ ] 4.5 Test that generated invocations use absolute runner and ConfigStore paths and expose no caller-controlled command surface
+- [x] 4.1 Define trusted scheduler installation context and core-generated runner invocation
+- [x] 4.2 Define async HostScheduler operations and observed host-entry types without arbitrary command inputs
+- [x] 4.3 Add injectable command-runner and filesystem boundaries with fake implementations for tests
+- [x] 4.4 Implement platform factory selection and unsupported-platform errors
+- [x] 4.5 Test that generated invocations use absolute runner and ConfigStore paths and expose no caller-controlled command surface
 
 ## 5. Schedule Manager And Reconciliation
 
-- [ ] 5.1 Implement read-only inspection across desired schedules, automation-task references, headless preflight, and observed host entries
-- [ ] 5.2 Implement compositional health, drift, corruption, unavailable-platform, missing-reference, unsafe-policy, and orphan diagnostics
-- [ ] 5.3 Implement explicit idempotent reconciliation for install, replace, enable, disable, remove, and unchanged states
-- [ ] 5.4 Define and implement explicit orphan-removal policy without mutation during inspection
-- [ ] 5.5 Add fake-adapter tests for partial failures, retries, simultaneous diagnostics, runner-path drift, and optional host metadata
+- [x] 5.1 Implement read-only inspection across desired schedules, automation-task references, headless preflight, and observed host entries
+- [x] 5.2 Implement compositional health, drift, corruption, unavailable-platform, missing-reference, unsafe-policy, and orphan diagnostics
+- [x] 5.3 Implement explicit idempotent reconciliation for install, replace, enable, disable, remove, and unchanged states
+- [x] 5.4 Define and implement explicit orphan-removal policy without mutation during inspection
+- [x] 5.5 Add fake-adapter tests for partial failures, retries, simultaneous diagnostics, runner-path drift, and optional host metadata
 
 ## 6. Linux Cron Adapter
 

--- a/src/automation_task/mod.rs
+++ b/src/automation_task/mod.rs
@@ -1,33 +1,45 @@
 //! Durable automation-task identity and validation.
 //!
 //! An `AutomationTask` is a reference to a `StoredPrompt` with its own
-//! expected-outcome text. It is designed for GUI management and eventual
-//! scheduling. The task does not duplicate instructions, skills, profile,
-//! provider, model, tools, or approval policy — those live on the stored
-//! prompt and its optional profile.
+//! expected-outcome text, project root, and timeout. It is designed for GUI
+//! management and scheduling. The task does not duplicate instructions,
+//! skills, profile, provider, model, tools, or approval policy — those live
+//! on the stored prompt and its optional profile.
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
 
 /// Schema version for automation-task records.
-pub const AUTOMATION_TASK_SCHEMA_VERSION: i64 = 1;
+pub const AUTOMATION_TASK_SCHEMA_VERSION: i64 = 2;
+
+/// Maximum allowed execution timeout in seconds (24 hours).
+pub const MAX_TIMEOUT_SECONDS: u64 = 86_400;
 
 /// A durable automation-task identity.
 ///
-/// Contains a stable ID, a user-facing name, a reference to a stored prompt,
-/// required expected-outcome text, and timestamps. Provider, model, tool,
-/// approval, skills, and profile configuration are resolved indirectly
-/// through the referenced stored prompt and its optional profile.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// Contains an immutable internal ID, a unique normalized lookup name,
+/// a user-facing display name, a reference to a stored prompt, required
+/// expected-outcome text, a canonical project root, a positive execution
+/// timeout, and timestamps. Provider, model, tool, approval, skills, and
+/// profile configuration are resolved indirectly through the referenced
+/// stored prompt and its optional profile.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct AutomationTask {
-    /// Stable, case-sensitive task identifier.
+    /// Immutable, case-sensitive task identifier.
     pub id: String,
     /// User-facing display name.
-    pub name: String,
+    pub display_name: String,
+    /// Unique case-insensitive normalized name derived from `display_name`.
+    pub normalized_name: String,
     /// ID of the referenced stored prompt.
     pub stored_prompt_id: String,
     /// Required prose describing the desired outcome (not independently verified).
     pub expected_outcome: String,
+    /// Canonical project root directory used as the execution workspace.
+    pub project_root: PathBuf,
+    /// Positive bounded execution timeout in seconds.
+    pub timeout_seconds: u64,
     /// When the task was first created.
     pub created_at: DateTime<Utc>,
     /// When the task was last updated.
@@ -37,35 +49,97 @@ pub struct AutomationTask {
 /// Input for creating or replacing an automation task.
 ///
 /// On replacement, the original creation timestamp is preserved and the
-/// update timestamp advances.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// update timestamp advances. The `display_name` is normalized into
+/// `normalized_name` during validation.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct AutomationTaskInput {
-    /// Stable, case-sensitive task identifier.
+    /// Immutable, case-sensitive task identifier.
     pub id: String,
     /// User-facing display name.
-    pub name: String,
+    pub display_name: String,
     /// ID of the referenced stored prompt (must exist at write time).
     pub stored_prompt_id: String,
     /// Required prose describing the desired outcome.
     pub expected_outcome: String,
+    /// Project root directory (must be an existing directory at write time).
+    pub project_root: PathBuf,
+    /// Positive bounded execution timeout in seconds (1..=86_400).
+    pub timeout_seconds: u64,
 }
 
 /// Validate and normalize an automation-task input.
 ///
-/// Trims all fields. Returns `Ok` with normalized values, or `Err` with a
-/// human-readable message when a field is empty after trimming or when a
-/// textual identifier contains control characters.
+/// Trims all text fields, derives `normalized_name` from `display_name`,
+/// validates the timeout, and returns `Ok` with normalized values, or
+/// `Err` with a human-readable message when a field is empty after
+/// trimming, when a textual identifier contains control characters, or
+/// when the timeout is outside the supported range.
 pub fn validate_task_input(input: &AutomationTaskInput) -> Result<AutomationTaskInput, String> {
     let id = validate_text_id(&input.id, "Task ID")?;
-    let name = validate_text_content(&input.name, "Task name")?;
+    let display_name = validate_text_content(&input.display_name, "Display name")?;
+    let normalized = normalize_task_name(&display_name);
+    if normalized.is_empty() {
+        return Err("Display name must contain alphanumeric characters".to_string());
+    }
     let stored_prompt_id = validate_text_id(&input.stored_prompt_id, "Stored prompt ID")?;
     let expected_outcome = validate_text_content(&input.expected_outcome, "Expected outcome")?;
+
+    let project_root_str = input.project_root.to_string_lossy();
+    let project_root_trimmed = project_root_str.trim();
+    if project_root_trimmed.is_empty() {
+        return Err("Project root must not be empty".to_string());
+    }
+
+    if input.timeout_seconds == 0 {
+        return Err("Timeout must be greater than zero".to_string());
+    }
+    if input.timeout_seconds > MAX_TIMEOUT_SECONDS {
+        return Err(format!(
+            "Timeout must not exceed {} seconds",
+            MAX_TIMEOUT_SECONDS
+        ));
+    }
+
     Ok(AutomationTaskInput {
         id,
-        name,
+        display_name,
         stored_prompt_id,
         expected_outcome,
+        project_root: PathBuf::from(project_root_trimmed),
+        timeout_seconds: input.timeout_seconds,
     })
+}
+
+/// Normalize a user-facing task name into a stable lookup handle.
+///
+/// Lowercases the input, replaces whitespace with hyphens, drops all other
+/// non-alphanumeric characters, and collapses consecutive hyphens.
+///
+/// Examples:
+/// - `Check Email` → `check-email`
+/// - `Paul's daily brief` → `pauls-daily-brief`
+pub fn normalize_task_name(name: &str) -> String {
+    let lower = name.trim().to_lowercase();
+    let mut result = String::with_capacity(lower.len());
+    let mut prev_was_hyphen = false;
+
+    for c in lower.chars() {
+        if c.is_ascii_alphanumeric() {
+            result.push(c);
+            prev_was_hyphen = false;
+        } else if c == '-' || c.is_whitespace() {
+            if !prev_was_hyphen && !result.is_empty() {
+                result.push('-');
+                prev_was_hyphen = true;
+            }
+        }
+    }
+
+    if result.ends_with('-') {
+        result.pop();
+    }
+
+    result
 }
 
 /// Validate a textual identifier: trim, non-empty, no control characters.
@@ -97,33 +171,84 @@ mod tests {
     fn valid_input() -> AutomationTaskInput {
         AutomationTaskInput {
             id: "daily-report".to_string(),
-            name: "Daily Report".to_string(),
+            display_name: "Daily Report".to_string(),
             stored_prompt_id: "report-prompt".to_string(),
             expected_outcome: "A summary of today's activity".to_string(),
+            project_root: PathBuf::from("/tmp"),
+            timeout_seconds: 300,
         }
     }
+
+    // ---- normalize_task_name tests (Task 1.2) ----
+
+    #[test]
+    fn normalize_basic() {
+        assert_eq!(normalize_task_name("Check Email"), "check-email");
+    }
+
+    #[test]
+    fn normalize_strips_apostrophe() {
+        assert_eq!(normalize_task_name("Paul's daily brief"), "pauls-daily-brief");
+    }
+
+    #[test]
+    fn normalize_collapses_multiple_spaces() {
+        assert_eq!(normalize_task_name("My   Task"), "my-task");
+    }
+
+    #[test]
+    fn normalize_strips_leading_trailing_whitespace() {
+        assert_eq!(normalize_task_name("  Spaced Task  "), "spaced-task");
+    }
+
+    #[test]
+    fn normalize_drops_special_chars() {
+        assert_eq!(normalize_task_name("Task #1!"), "task-1");
+    }
+
+    #[test]
+    fn normalize_empty_after_processing() {
+        assert_eq!(normalize_task_name("'!!!'"), "");
+    }
+
+    #[test]
+    fn normalize_already_kebab() {
+        assert_eq!(normalize_task_name("check-email"), "check-email");
+    }
+
+    #[test]
+    fn normalize_case_insensitive() {
+        assert_eq!(normalize_task_name("DAILY-REPORT"), "daily-report");
+        assert_eq!(normalize_task_name("Daily Report"), "daily-report");
+    }
+
+    // ---- validate_task_input tests ----
 
     #[test]
     fn valid_input_passes_validation() {
         let input = valid_input();
         let result = validate_task_input(&input).unwrap();
         assert_eq!(result.id, "daily-report");
-        assert_eq!(result.name, "Daily Report");
+        assert_eq!(result.display_name, "Daily Report");
         assert_eq!(result.stored_prompt_id, "report-prompt");
         assert_eq!(result.expected_outcome, "A summary of today's activity");
+        assert_eq!(result.project_root, PathBuf::from("/tmp"));
+        assert_eq!(result.timeout_seconds, 300);
     }
 
     #[test]
     fn input_is_trimmed() {
         let input = AutomationTaskInput {
             id: "  daily-report  ".to_string(),
-            name: "  Daily Report  ".to_string(),
+            display_name: "  Daily Report  ".to_string(),
             stored_prompt_id: "  report-prompt  ".to_string(),
             expected_outcome: "  Summary  ".to_string(),
+            project_root: PathBuf::from("  /tmp  "),
+            timeout_seconds: 300,
         };
         let result = validate_task_input(&input).unwrap();
         assert_eq!(result.id, "daily-report");
-        assert_eq!(result.name, "Daily Report");
+        assert_eq!(result.display_name, "Daily Report");
         assert_eq!(result.stored_prompt_id, "report-prompt");
         assert_eq!(result.expected_outcome, "Summary");
     }
@@ -136,9 +261,16 @@ mod tests {
     }
 
     #[test]
-    fn empty_name_rejected() {
+    fn empty_display_name_rejected() {
         let mut input = valid_input();
-        input.name = "".to_string();
+        input.display_name = "".to_string();
+        assert!(validate_task_input(&input).is_err());
+    }
+
+    #[test]
+    fn display_name_only_special_chars_rejected() {
+        let mut input = valid_input();
+        input.display_name = "'!!!'".to_string();
         assert!(validate_task_input(&input).is_err());
     }
 
@@ -154,6 +286,34 @@ mod tests {
         let mut input = valid_input();
         input.expected_outcome = "".to_string();
         assert!(validate_task_input(&input).is_err());
+    }
+
+    #[test]
+    fn empty_project_root_rejected() {
+        let mut input = valid_input();
+        input.project_root = PathBuf::from("");
+        assert!(validate_task_input(&input).is_err());
+    }
+
+    #[test]
+    fn zero_timeout_rejected() {
+        let mut input = valid_input();
+        input.timeout_seconds = 0;
+        assert!(validate_task_input(&input).is_err());
+    }
+
+    #[test]
+    fn excessive_timeout_rejected() {
+        let mut input = valid_input();
+        input.timeout_seconds = MAX_TIMEOUT_SECONDS + 1;
+        assert!(validate_task_input(&input).is_err());
+    }
+
+    #[test]
+    fn max_timeout_accepted() {
+        let mut input = valid_input();
+        input.timeout_seconds = MAX_TIMEOUT_SECONDS;
+        assert!(validate_task_input(&input).is_ok());
     }
 
     #[test]
@@ -198,9 +358,12 @@ mod tests {
         let now = Utc::now();
         let task = AutomationTask {
             id: "t1".to_string(),
-            name: "Test".to_string(),
+            display_name: "Test".to_string(),
+            normalized_name: "test".to_string(),
             stored_prompt_id: "p1".to_string(),
             expected_outcome: "Done".to_string(),
+            project_root: PathBuf::from("/tmp"),
+            timeout_seconds: 60,
             created_at: now,
             updated_at: now,
         };

--- a/src/automation_task/mod.rs
+++ b/src/automation_task/mod.rs
@@ -127,11 +127,9 @@ pub fn normalize_task_name(name: &str) -> String {
         if c.is_ascii_alphanumeric() {
             result.push(c);
             prev_was_hyphen = false;
-        } else if c == '-' || c.is_whitespace() {
-            if !prev_was_hyphen && !result.is_empty() {
-                result.push('-');
-                prev_was_hyphen = true;
-            }
+        } else if (c == '-' || c.is_whitespace()) && !prev_was_hyphen && !result.is_empty() {
+            result.push('-');
+            prev_was_hyphen = true;
         }
     }
 
@@ -188,7 +186,10 @@ mod tests {
 
     #[test]
     fn normalize_strips_apostrophe() {
-        assert_eq!(normalize_task_name("Paul's daily brief"), "pauls-daily-brief");
+        assert_eq!(
+            normalize_task_name("Paul's daily brief"),
+            "pauls-daily-brief"
+        );
     }
 
     #[test]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -273,22 +273,37 @@ pub fn parse_duration(s: &str) -> Result<Duration, String> {
 // Resolution functions (CLI > env > defaults)
 // ============================================================================
 
-/// Resolve workspace from CLI, environment, or process cwd.
+/// Resolve workspace from CLI, environment, or task fallback.
 ///
 /// Canonicalizes the path and requires it to be an existing directory.
-pub fn resolve_workspace(cli: Option<&str>, env: Option<&str>) -> Result<PathBuf, String> {
-    let raw = cli.or(env).unwrap_or(".");
+pub fn resolve_workspace(
+    cli: Option<&str>,
+    env: Option<&str>,
+    fallback: Option<&std::path::Path>,
+) -> Result<PathBuf, String> {
+    let path = match cli.or(env) {
+        Some(raw) => PathBuf::from(raw),
+        None => match fallback {
+            Some(p) => p.to_path_buf(),
+            None => {
+                return Err(
+                    "workspace is required: use --workspace, AGENTIRON_WORKSPACE, \
+                     or set a project root on the automation task"
+                        .to_string(),
+                )
+            }
+        },
+    };
 
-    let path = PathBuf::from(raw);
     if !path.exists() {
-        return Err(format!("workspace does not exist: {}", raw));
+        return Err(format!("workspace does not exist: {}", path.display()));
     }
     if !path.is_dir() {
-        return Err(format!("workspace is not a directory: {}", raw));
+        return Err(format!("workspace is not a directory: {}", path.display()));
     }
 
     path.canonicalize()
-        .map_err(|e| format!("failed to canonicalize workspace '{}': {}", raw, e))
+        .map_err(|e| format!("failed to canonicalize workspace '{}': {}", path.display(), e))
 }
 
 /// Resolve the ConfigStore database path from CLI, environment, or default.
@@ -302,12 +317,21 @@ pub fn resolve_config_path(cli: Option<&str>, env: Option<&str>) -> Result<PathB
     default_config_path().map_err(|e| format!("failed to determine default config path: {}", e))
 }
 
-/// Resolve timeout duration from CLI or environment (required).
-pub fn resolve_timeout(cli: Option<&str>, env: Option<&str>) -> Result<Duration, String> {
-    let raw = cli.or(env).ok_or_else(|| {
-        "timeout is required: use --timeout or AGENTIRON_TIMEOUT (e.g. 30s, 5m, 1h)".to_string()
-    })?;
-    parse_duration(raw)
+/// Resolve timeout duration from CLI, environment, or task fallback.
+pub fn resolve_timeout(
+    cli: Option<&str>,
+    env: Option<&str>,
+    fallback: Option<Duration>,
+) -> Result<Duration, String> {
+    if let Some(raw) = cli.or(env) {
+        return parse_duration(raw);
+    }
+
+    fallback.ok_or_else(|| {
+        "timeout is required: use --timeout, AGENTIRON_TIMEOUT, \
+         or set a timeout on the automation task"
+            .to_string()
+    })
 }
 
 /// Resolve output format from CLI or environment (default: text).
@@ -545,10 +569,59 @@ pub async fn execute_run_with_streams(
         }};
     }
 
-    // 3. Resolve workspace.
+    // 3. Resolve config path and open ConfigStore (moved before
+    //    workspace/timeout so we can load task defaults).
+    let config_path =
+        match resolve_config_path(parsed.config.as_deref(), env_get(env, "AGENTIRON_CONFIG")) {
+            Ok(p) => p,
+            Err(e) => {
+                emit_failure!(
+                    AutomationRunErrorCategory::Config,
+                    e,
+                    EXIT_CONFIG,
+                    PathBuf::from(parsed.workspace.as_deref().unwrap_or("."))
+                );
+            }
+        };
+
+    if !quiet {
+        let _ = writeln!(stderr, "config: {}", config_path.display());
+    }
+
+    let store = match ConfigStore::open_at(&config_path).await {
+        Ok(s) => s,
+        Err(e) => {
+            emit_failure!(
+                AutomationRunErrorCategory::Config,
+                format!("failed to open config store: {}", e),
+                EXIT_CONFIG,
+                PathBuf::from(parsed.workspace.as_deref().unwrap_or("."))
+            );
+        }
+    };
+
+    // 4. Load the task to get workspace/timeout defaults.
+    let task_defaults = match store.get_automation_task(&parsed.task_id).await {
+        Ok(Some(t)) => Some(t),
+        Ok(None) => None,
+        Err(_) => None,
+    };
+
+    let workspace_fallback = task_defaults
+        .as_ref()
+        .filter(|t| !t.project_root.as_os_str().is_empty())
+        .map(|t| t.project_root.as_path());
+
+    let timeout_fallback = task_defaults
+        .as_ref()
+        .filter(|t| t.timeout_seconds > 0)
+        .map(|t| Duration::from_secs(t.timeout_seconds));
+
+    // 5. Resolve workspace (CLI > env > task project root).
     let workspace = match resolve_workspace(
         parsed.workspace.as_deref(),
         env_get(env, "AGENTIRON_WORKSPACE"),
+        workspace_fallback,
     ) {
         Ok(w) => w,
         Err(e) => {
@@ -565,55 +638,28 @@ pub async fn execute_run_with_streams(
         let _ = writeln!(stderr, "workspace: {}", workspace.display());
     }
 
-    // 4. Resolve timeout (required).
-    let timeout =
-        match resolve_timeout(parsed.timeout.as_deref(), env_get(env, "AGENTIRON_TIMEOUT")) {
-            Ok(t) => t,
-            Err(e) => {
-                emit_failure!(AutomationRunErrorCategory::Config, e, EXIT_USAGE, workspace);
-            }
-        };
+    // 6. Resolve timeout (CLI > env > task timeout).
+    let timeout = match resolve_timeout(
+        parsed.timeout.as_deref(),
+        env_get(env, "AGENTIRON_TIMEOUT"),
+        timeout_fallback,
+    ) {
+        Ok(t) => t,
+        Err(e) => {
+            emit_failure!(AutomationRunErrorCategory::Config, e, EXIT_USAGE, workspace);
+        }
+    };
 
     if !quiet {
         let _ = writeln!(stderr, "timeout: {:?}", timeout);
     }
-
-    // 5. Resolve config path and open ConfigStore.
-    let config_path =
-        match resolve_config_path(parsed.config.as_deref(), env_get(env, "AGENTIRON_CONFIG")) {
-            Ok(p) => p,
-            Err(e) => {
-                emit_failure!(
-                    AutomationRunErrorCategory::Config,
-                    e,
-                    EXIT_CONFIG,
-                    workspace
-                );
-            }
-        };
-
-    if !quiet {
-        let _ = writeln!(stderr, "config: {}", config_path.display());
-    }
-
-    let store = match ConfigStore::open_at(&config_path).await {
-        Ok(s) => s,
-        Err(e) => {
-            emit_failure!(
-                AutomationRunErrorCategory::Config,
-                format!("failed to open config store: {}", e),
-                EXIT_CONFIG,
-                workspace
-            );
-        }
-    };
 
     // 6. Bootstrap headless runtime.
     if !quiet {
         let _ = writeln!(stderr, "bootstrapping headless runtime...");
     }
 
-    let headless = match bootstrap_headless(store, &parsed.task_id, workspace.clone()).await {
+    let headless = match bootstrap_headless(store, &parsed.task_id, workspace.clone(), timeout).await {
         Ok(h) => h,
         Err(e) => {
             let code = exit_code_for_bootstrap_error(&e);

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -302,8 +302,13 @@ pub fn resolve_workspace(
         return Err(format!("workspace is not a directory: {}", path.display()));
     }
 
-    path.canonicalize()
-        .map_err(|e| format!("failed to canonicalize workspace '{}': {}", path.display(), e))
+    path.canonicalize().map_err(|e| {
+        format!(
+            "failed to canonicalize workspace '{}': {}",
+            path.display(),
+            e
+        )
+    })
 }
 
 /// Resolve the ConfigStore database path from CLI, environment, or default.
@@ -659,13 +664,14 @@ pub async fn execute_run_with_streams(
         let _ = writeln!(stderr, "bootstrapping headless runtime...");
     }
 
-    let headless = match bootstrap_headless(store, &parsed.task_id, workspace.clone(), timeout).await {
-        Ok(h) => h,
-        Err(e) => {
-            let code = exit_code_for_bootstrap_error(&e);
-            emit_failure!(bootstrap_error_category(&e), e.to_string(), code, workspace);
-        }
-    };
+    let headless =
+        match bootstrap_headless(store, &parsed.task_id, workspace.clone(), timeout).await {
+            Ok(h) => h,
+            Err(e) => {
+                let code = exit_code_for_bootstrap_error(&e);
+                emit_failure!(bootstrap_error_category(&e), e.to_string(), code, workspace);
+            }
+        };
 
     if !quiet {
         let _ = writeln!(

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -609,7 +609,14 @@ pub async fn execute_run_with_streams(
     let task_defaults = match store.get_automation_task(&parsed.task_id).await {
         Ok(Some(t)) => Some(t),
         Ok(None) => None,
-        Err(_) => None,
+        Err(e) => {
+            emit_failure!(
+                AutomationRunErrorCategory::Config,
+                format!("failed to load task '{}': {}", parsed.task_id, e),
+                EXIT_CONFIG,
+                PathBuf::from(parsed.workspace.as_deref().unwrap_or("."))
+            );
+        }
     };
 
     let workspace_fallback = task_defaults

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -257,11 +257,7 @@ fn resolve_workspace_uses_cli() {
         "/nonexistent-env".to_string(),
     )];
     let env_ref: Vec<(String, String)> = env;
-    let w = resolve_workspace(
-        Some("."),
-        env_get(&env_ref, "AGENTIRON_WORKSPACE"),
-        None,
-    );
+    let w = resolve_workspace(Some("."), env_get(&env_ref, "AGENTIRON_WORKSPACE"), None);
     assert!(w.is_ok());
     assert!(w.unwrap().is_absolute());
 }
@@ -293,8 +289,7 @@ fn resolve_workspace_missing_without_fallback() {
 
 #[test]
 fn resolve_workspace_rejects_nonexistent() {
-    let err =
-        resolve_workspace(Some("/nonexistent/path/xyz"), None, None).unwrap_err();
+    let err = resolve_workspace(Some("/nonexistent/path/xyz"), None, None).unwrap_err();
     assert!(err.contains("does not exist"));
 }
 

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -295,17 +295,9 @@ fn resolve_workspace_rejects_nonexistent() {
 
 #[test]
 fn resolve_workspace_rejects_file() {
-    let err = resolve_workspace(Some("/etc/hostname"), None, None);
-    match err {
-        Ok(path) => {
-            if path.exists() && !path.is_dir() {
-                panic!("expected error for file as workspace");
-            }
-        }
-        Err(e) => {
-            assert!(e.contains("not a directory") || e.contains("does not exist"));
-        }
-    }
+    let file = std::env::current_exe().unwrap();
+    let err = resolve_workspace(file.to_str(), None, None).unwrap_err();
+    assert!(err.contains("not a directory"));
 }
 
 // ============================================================================

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -257,9 +257,12 @@ fn resolve_workspace_uses_cli() {
         "/nonexistent-env".to_string(),
     )];
     let env_ref: Vec<(String, String)> = env;
-    let w = resolve_workspace(Some("."), env_get(&env_ref, "AGENTIRON_WORKSPACE"));
+    let w = resolve_workspace(
+        Some("."),
+        env_get(&env_ref, "AGENTIRON_WORKSPACE"),
+        None,
+    );
     assert!(w.is_ok());
-    // Should resolve to cwd, not the env value
     assert!(w.unwrap().is_absolute());
 }
 
@@ -270,31 +273,36 @@ fn resolve_workspace_uses_env() {
         .to_string_lossy()
         .to_string();
     let env = vec![("AGENTIRON_WORKSPACE".to_string(), env_val.clone())];
-    let w = resolve_workspace(None, env_get(&env, "AGENTIRON_WORKSPACE"));
+    let w = resolve_workspace(None, env_get(&env, "AGENTIRON_WORKSPACE"), None);
     assert!(w.is_ok());
     assert_eq!(w.unwrap(), PathBuf::from(env_val).canonicalize().unwrap());
 }
 
 #[test]
-fn resolve_workspace_defaults_to_cwd() {
-    let w = resolve_workspace(None, None).unwrap();
-    let cwd = std::env::current_dir().unwrap().canonicalize().unwrap();
-    assert_eq!(w, cwd);
+fn resolve_workspace_uses_fallback() {
+    let fallback = std::env::current_dir().unwrap();
+    let w = resolve_workspace(None, None, Some(&fallback)).unwrap();
+    assert_eq!(w, fallback.canonicalize().unwrap());
+}
+
+#[test]
+fn resolve_workspace_missing_without_fallback() {
+    let err = resolve_workspace(None, None, None).unwrap_err();
+    assert!(err.contains("required"));
 }
 
 #[test]
 fn resolve_workspace_rejects_nonexistent() {
-    let err = resolve_workspace(Some("/nonexistent/path/xyz"), None).unwrap_err();
+    let err =
+        resolve_workspace(Some("/nonexistent/path/xyz"), None, None).unwrap_err();
     assert!(err.contains("does not exist"));
 }
 
 #[test]
 fn resolve_workspace_rejects_file() {
-    let err = resolve_workspace(Some("/etc/hostname"), None);
+    let err = resolve_workspace(Some("/etc/hostname"), None, None);
     match err {
         Ok(path) => {
-            // On some systems /etc/hostname might not exist; if it does,
-            // it should be rejected.
             if path.exists() && !path.is_dir() {
                 panic!("expected error for file as workspace");
             }
@@ -311,25 +319,31 @@ fn resolve_workspace_rejects_file() {
 
 #[test]
 fn resolve_timeout_from_cli() {
-    let t = resolve_timeout(Some("5m"), Some("1h")).unwrap();
+    let t = resolve_timeout(Some("5m"), Some("1h"), None).unwrap();
     assert_eq!(t, Duration::from_secs(300));
 }
 
 #[test]
 fn resolve_timeout_from_env() {
-    let t = resolve_timeout(None, Some("1h")).unwrap();
+    let t = resolve_timeout(None, Some("1h"), None).unwrap();
     assert_eq!(t, Duration::from_secs(3600));
 }
 
 #[test]
+fn resolve_timeout_from_fallback() {
+    let t = resolve_timeout(None, None, Some(Duration::from_secs(120))).unwrap();
+    assert_eq!(t, Duration::from_secs(120));
+}
+
+#[test]
 fn resolve_timeout_missing() {
-    let err = resolve_timeout(None, None).unwrap_err();
+    let err = resolve_timeout(None, None, None).unwrap_err();
     assert!(err.contains("required"));
 }
 
 #[test]
 fn resolve_timeout_invalid_value() {
-    let err = resolve_timeout(Some("0s"), None).unwrap_err();
+    let err = resolve_timeout(Some("0s"), None, None).unwrap_err();
     assert!(err.contains("greater than zero"));
 }
 
@@ -428,9 +442,12 @@ fn exit_code_for_result_failed_unsafe_policy() {
     let mut result = AutomationRunResult::started(
         &crate::automation_task::AutomationTask {
             id: "t".to_string(),
-            name: "T".to_string(),
+            display_name: "T".to_string(),
+            normalized_name: "t".to_string(),
             stored_prompt_id: "p".to_string(),
             expected_outcome: "o".to_string(),
+            project_root: std::path::PathBuf::from("/tmp"),
+            timeout_seconds: 60,
             created_at: now,
             updated_at: now,
         },
@@ -449,9 +466,12 @@ fn exit_code_for_result_failed_execution() {
     let mut result = AutomationRunResult::started(
         &crate::automation_task::AutomationTask {
             id: "t".to_string(),
-            name: "T".to_string(),
+            display_name: "T".to_string(),
+            normalized_name: "t".to_string(),
             stored_prompt_id: "p".to_string(),
             expected_outcome: "o".to_string(),
+            project_root: std::path::PathBuf::from("/tmp"),
+            timeout_seconds: 60,
             created_at: now,
             updated_at: now,
         },
@@ -470,9 +490,12 @@ fn exit_code_for_result_completed() {
     let mut result = AutomationRunResult::started(
         &crate::automation_task::AutomationTask {
             id: "t".to_string(),
-            name: "T".to_string(),
+            display_name: "T".to_string(),
+            normalized_name: "t".to_string(),
             stored_prompt_id: "p".to_string(),
             expected_outcome: "o".to_string(),
+            project_root: std::path::PathBuf::from("/tmp"),
+            timeout_seconds: 60,
             created_at: now,
             updated_at: now,
         },
@@ -488,9 +511,12 @@ fn exit_code_for_result_failed_config() {
     let mut result = AutomationRunResult::started(
         &crate::automation_task::AutomationTask {
             id: "t".to_string(),
-            name: "T".to_string(),
+            display_name: "T".to_string(),
+            normalized_name: "t".to_string(),
             stored_prompt_id: "p".to_string(),
             expected_outcome: "o".to_string(),
+            project_root: std::path::PathBuf::from("/tmp"),
+            timeout_seconds: 60,
             created_at: now,
             updated_at: now,
         },

--- a/src/config/automation_task_tests.rs
+++ b/src/config/automation_task_tests.rs
@@ -3,10 +3,10 @@ use crate::config::records::PromptInput;
 use crate::config::{ConfigError, ConfigStore};
 use serde_json::json;
 use sqlx::Row;
+use std::path::PathBuf;
 
 async fn setup_store() -> ConfigStore {
     let store = ConfigStore::open_in_memory().await.unwrap();
-    // Seed a prompt so tasks can reference it.
     store
         .set_prompt(&PromptInput {
             id: "prompt-1".to_string(),
@@ -24,9 +24,11 @@ async fn setup_store() -> ConfigStore {
 fn task_input(id: &str, prompt_id: &str) -> AutomationTaskInput {
     AutomationTaskInput {
         id: id.to_string(),
-        name: format!("Task {}", id),
+        display_name: format!("Task {}", id),
         stored_prompt_id: prompt_id.to_string(),
         expected_outcome: "Done".to_string(),
+        project_root: std::env::temp_dir(),
+        timeout_seconds: 300,
     }
 }
 
@@ -34,18 +36,16 @@ fn task_input(id: &str, prompt_id: &str) -> AutomationTaskInput {
 async fn task_crud_create_get_list_delete() {
     let store = setup_store().await;
 
-    // Create
     let task = store
         .set_automation_task(&task_input("daily-report", "prompt-1"))
         .await
         .unwrap();
     assert_eq!(task.id, "daily-report");
-    assert_eq!(task.name, "Task daily-report");
+    assert_eq!(task.display_name, "Task daily-report");
     assert_eq!(task.stored_prompt_id, "prompt-1");
     assert_eq!(task.expected_outcome, "Done");
     assert_eq!(task.created_at, task.updated_at);
 
-    // Get
     let fetched = store
         .get_automation_task("daily-report")
         .await
@@ -53,7 +53,6 @@ async fn task_crud_create_get_list_delete() {
         .unwrap();
     assert_eq!(fetched, task);
 
-    // Delete
     store.delete_automation_task("daily-report").await.unwrap();
     assert!(store
         .get_automation_task("daily-report")
@@ -61,7 +60,6 @@ async fn task_crud_create_get_list_delete() {
         .unwrap()
         .is_none());
 
-    // Prompt remains
     assert!(store.get_prompt("prompt-1").await.unwrap().is_some());
 }
 
@@ -85,7 +83,6 @@ async fn task_list_is_deterministic_by_id() {
     let ids: Vec<&str> = list.iter().map(|t| t.id.as_str()).collect();
     assert_eq!(ids, vec!["alpha", "bravo", "charlie"]);
 
-    // Repeat — same order.
     let list2 = store.list_automation_tasks().await.unwrap();
     let ids2: Vec<&str> = list2.iter().map(|t| t.id.as_str()).collect();
     assert_eq!(ids, ids2);
@@ -99,21 +96,22 @@ async fn task_replacement_preserves_created_at_and_advances_updated_at() {
         .await
         .unwrap();
 
-    // Small delay so timestamps differ.
     tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
 
     let updated_input = AutomationTaskInput {
         id: "t1".to_string(),
-        name: "Updated Name".to_string(),
+        display_name: "Updated Name".to_string(),
         stored_prompt_id: "prompt-1".to_string(),
         expected_outcome: "New outcome".to_string(),
+        project_root: std::env::temp_dir(),
+        timeout_seconds: 600,
     };
     let updated = store.set_automation_task(&updated_input).await.unwrap();
 
     assert_eq!(updated.created_at, original.created_at);
     assert_ne!(updated.updated_at, original.updated_at);
     assert!(updated.updated_at > original.updated_at);
-    assert_eq!(updated.name, "Updated Name");
+    assert_eq!(updated.display_name, "Updated Name");
     assert_eq!(updated.expected_outcome, "New outcome");
 }
 
@@ -131,7 +129,6 @@ async fn task_missing_prompt_rejected() {
         other => panic!("expected UnknownStoredPrompt, got {:?}", other),
     }
 
-    // Task was not persisted.
     assert!(store.get_automation_task("t1").await.unwrap().is_none());
 }
 
@@ -141,9 +138,11 @@ async fn task_validation_rejects_empty_fields() {
 
     let bad_input = AutomationTaskInput {
         id: "  ".to_string(),
-        name: "Name".to_string(),
+        display_name: "Name".to_string(),
         stored_prompt_id: "prompt-1".to_string(),
         expected_outcome: "Done".to_string(),
+        project_root: std::env::temp_dir(),
+        timeout_seconds: 300,
     };
     let result = store.set_automation_task(&bad_input).await;
     assert!(matches!(result, Err(ConfigError::Validation(_))));
@@ -185,7 +184,6 @@ async fn prompt_deletion_blocked_when_task_references_it() {
         other => panic!("expected PromptReferencedByTasks, got {:?}", other),
     }
 
-    // Prompt and tasks remain.
     assert!(store.get_prompt("prompt-1").await.unwrap().is_some());
     assert!(store.get_automation_task("t1").await.unwrap().is_some());
     assert!(store.get_automation_task("t2").await.unwrap().is_some());
@@ -218,13 +216,15 @@ async fn task_input_is_trimmed_on_store() {
     let store = setup_store().await;
     let input = AutomationTaskInput {
         id: "  spaced-id  ".to_string(),
-        name: "  Spaced  ".to_string(),
+        display_name: "  Spaced  ".to_string(),
         stored_prompt_id: "  prompt-1  ".to_string(),
         expected_outcome: "  Outcome  ".to_string(),
+        project_root: std::env::temp_dir(),
+        timeout_seconds: 300,
     };
     let task = store.set_automation_task(&input).await.unwrap();
     assert_eq!(task.id, "spaced-id");
-    assert_eq!(task.name, "Spaced");
+    assert_eq!(task.display_name, "Spaced");
     assert_eq!(task.stored_prompt_id, "prompt-1");
     assert_eq!(task.expected_outcome, "Outcome");
 }
@@ -237,7 +237,6 @@ async fn schema_version_is_stored() {
         .await
         .unwrap();
 
-    // Verify the schema_version column directly.
     let row = sqlx::query("SELECT schema_version FROM automation_tasks WHERE id = ?")
         .bind("t1")
         .fetch_one(store.pool())
@@ -255,7 +254,6 @@ async fn get_rejects_unsupported_schema_version() {
         .await
         .unwrap();
 
-    // Tamper: set an unsupported schema version.
     sqlx::query("UPDATE automation_tasks SET schema_version = ? WHERE id = ?")
         .bind(999)
         .bind("t1")
@@ -275,7 +273,6 @@ async fn list_rejects_unsupported_schema_version() {
         .await
         .unwrap();
 
-    // Tamper: set an unsupported schema version.
     sqlx::query("UPDATE automation_tasks SET schema_version = ? WHERE id = ?")
         .bind(999)
         .bind("t1")
@@ -285,4 +282,87 @@ async fn list_rejects_unsupported_schema_version() {
 
     let result = store.list_automation_tasks().await;
     assert!(matches!(result, Err(ConfigError::Deserialization(_))));
+}
+
+#[tokio::test]
+async fn normalized_name_collision_rejected() {
+    let store = setup_store().await;
+    store
+        .set_automation_task(&task_input("task-a", "prompt-1"))
+        .await
+        .unwrap();
+
+    let colliding = AutomationTaskInput {
+        id: "task-b".to_string(),
+        display_name: "Task Task-a".to_string(),
+        stored_prompt_id: "prompt-1".to_string(),
+        expected_outcome: "Done".to_string(),
+        project_root: std::env::temp_dir(),
+        timeout_seconds: 300,
+    };
+    let result = store.set_automation_task(&colliding).await;
+    assert!(matches!(result, Err(ConfigError::TaskNameConflict { .. })));
+    assert!(store.get_automation_task("task-b").await.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn normalized_name_case_insensitive_collision() {
+    let store = setup_store().await;
+    let input_a = AutomationTaskInput {
+        id: "a".to_string(),
+        display_name: "Daily Report".to_string(),
+        stored_prompt_id: "prompt-1".to_string(),
+        expected_outcome: "Done".to_string(),
+        project_root: std::env::temp_dir(),
+        timeout_seconds: 300,
+    };
+    store.set_automation_task(&input_a).await.unwrap();
+
+    let input_b = AutomationTaskInput {
+        id: "b".to_string(),
+        display_name: "DAILY REPORT".to_string(),
+        stored_prompt_id: "prompt-1".to_string(),
+        expected_outcome: "Done".to_string(),
+        project_root: std::env::temp_dir(),
+        timeout_seconds: 300,
+    };
+    let result = store.set_automation_task(&input_b).await;
+    assert!(matches!(result, Err(ConfigError::TaskNameConflict { .. })));
+}
+
+#[tokio::test]
+async fn rename_preserves_id_and_updates_normalized_name() {
+    let store = setup_store().await;
+    store
+        .set_automation_task(&task_input("t1", "prompt-1"))
+        .await
+        .unwrap();
+
+    let renamed = AutomationTaskInput {
+        id: "t1".to_string(),
+        display_name: "New Name".to_string(),
+        stored_prompt_id: "prompt-1".to_string(),
+        expected_outcome: "Done".to_string(),
+        project_root: std::env::temp_dir(),
+        timeout_seconds: 300,
+    };
+    let task = store.set_automation_task(&renamed).await.unwrap();
+    assert_eq!(task.id, "t1");
+    assert_eq!(task.display_name, "New Name");
+    assert_eq!(task.normalized_name, "new-name");
+}
+
+#[tokio::test]
+async fn nonexistent_project_root_rejected() {
+    let store = setup_store().await;
+    let input = AutomationTaskInput {
+        id: "bad".to_string(),
+        display_name: "Bad Root".to_string(),
+        stored_prompt_id: "prompt-1".to_string(),
+        expected_outcome: "Done".to_string(),
+        project_root: PathBuf::from("/nonexistent/path/that/does/not/exist"),
+        timeout_seconds: 300,
+    };
+    let result = store.set_automation_task(&input).await;
+    assert!(matches!(result, Err(ConfigError::Validation(_))));
 }

--- a/src/config/error.rs
+++ b/src/config/error.rs
@@ -77,7 +77,9 @@ pub enum ConfigError {
     },
 
     /// Automation task normalized name collides with an existing task.
-    #[error("Task normalized name '{normalized_name}' collides with existing task '{existing_id}'")]
+    #[error(
+        "Task normalized name '{normalized_name}' collides with existing task '{existing_id}'"
+    )]
     TaskNameConflict {
         /// The normalized name that collided.
         normalized_name: String,

--- a/src/config/error.rs
+++ b/src/config/error.rs
@@ -75,6 +75,28 @@ pub enum ConfigError {
         /// IDs of tasks that reference the prompt.
         task_ids: Vec<String>,
     },
+
+    /// Automation task normalized name collides with an existing task.
+    #[error("Task normalized name '{normalized_name}' collides with existing task '{existing_id}'")]
+    TaskNameConflict {
+        /// The normalized name that collided.
+        normalized_name: String,
+        /// The ID of the existing task that already owns the name.
+        existing_id: String,
+    },
+
+    /// Schedule references an automation task that does not exist.
+    #[error("Schedule references unknown automation task: {0}")]
+    UnknownAutomationTask(String),
+
+    /// Automation task deletion blocked because schedules reference it.
+    #[error("Automation task '{task_id}' is referenced by schedules: {schedule_ids:?}")]
+    TaskReferencedBySchedules {
+        /// The task that was being deleted.
+        task_id: String,
+        /// IDs of schedules that reference the task.
+        schedule_ids: Vec<String>,
+    },
 }
 
 impl From<sqlx::Error> for ConfigError {

--- a/src/config/migrations.rs
+++ b/src/config/migrations.rs
@@ -185,11 +185,25 @@ pub const MIGRATIONS: &[(i64, &str)] = &[
             INSERT OR IGNORE INTO schema_version (id, version) VALUES (1, 7);
             "#,
     ),
+    (
+        8,
+        r#"
+            ALTER TABLE automation_tasks ADD COLUMN normalized_name TEXT NOT NULL DEFAULT '';
+            ALTER TABLE automation_tasks ADD COLUMN project_root TEXT NOT NULL DEFAULT '';
+            ALTER TABLE automation_tasks ADD COLUMN timeout_seconds INTEGER NOT NULL DEFAULT 0;
+
+            UPDATE automation_tasks
+                SET normalized_name = lower(trim(name)),
+                    schema_version = 2;
+
+            INSERT OR IGNORE INTO schema_version (id, version) VALUES (1, 8);
+            "#,
+    ),
 ];
 
 /// The current schema version.
 #[allow(dead_code)]
-pub const CURRENT_SCHEMA_VERSION: i64 = 7;
+pub const CURRENT_SCHEMA_VERSION: i64 = 8;
 
 /// Apply all pending migrations to the database.
 pub async fn apply_migrations(pool: &sqlx::SqlitePool) -> Result<(), super::error::ConfigError> {

--- a/src/config/migrations.rs
+++ b/src/config/migrations.rs
@@ -192,9 +192,11 @@ pub const MIGRATIONS: &[(i64, &str)] = &[
             ALTER TABLE automation_tasks ADD COLUMN project_root TEXT NOT NULL DEFAULT '';
             ALTER TABLE automation_tasks ADD COLUMN timeout_seconds INTEGER NOT NULL DEFAULT 0;
 
+            -- Backfill normalized_name from existing name. Legacy tasks keep
+            -- schema_version 1 so they remain distinguishable from complete v2
+            -- records with valid project_root and timeout_seconds.
             UPDATE automation_tasks
-                SET normalized_name = lower(trim(name)),
-                    schema_version = 2;
+                SET normalized_name = lower(trim(name));
 
             INSERT OR IGNORE INTO schema_version (id, version) VALUES (1, 8);
             "#,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -588,6 +588,9 @@ mod migrations;
 #[cfg(test)]
 mod automation_task_tests;
 
+#[cfg(test)]
+mod scheduled_task_tests;
+
 pub use builtin_models::{builtin_model_catalog, BuiltinModelEntry};
 pub use effective_catalog::{
     build_effective_catalog, CatalogError, EffectiveModelCatalog, EffectiveModelEntry,

--- a/src/config/scheduled_task_tests.rs
+++ b/src/config/scheduled_task_tests.rs
@@ -1,0 +1,271 @@
+use crate::automation_task::AutomationTaskInput;
+use crate::config::records::PromptInput;
+use crate::config::{ConfigError, ConfigStore};
+use crate::scheduled_task::ScheduledTaskInput;
+use serde_json::json;
+use std::path::PathBuf;
+
+async fn setup_store_with_task() -> ConfigStore {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+
+    store
+        .set_prompt(&PromptInput {
+            id: "prompt-1".to_string(),
+            schema_version: crate::stored_prompt::STORED_PROMPT_SCHEMA_VERSION,
+            payload: json!({
+                "instructions": "Do the thing",
+                "skills": [],
+            }),
+        })
+        .await
+        .unwrap();
+
+    store
+        .set_automation_task(&AutomationTaskInput {
+            id: "task-1".to_string(),
+            display_name: "Task One".to_string(),
+            stored_prompt_id: "prompt-1".to_string(),
+            expected_outcome: "Done".to_string(),
+            project_root: std::env::temp_dir(),
+            timeout_seconds: 300,
+        })
+        .await
+        .unwrap();
+
+    store
+}
+
+fn schedule_input(id: &str, task_id: &str) -> ScheduledTaskInput {
+    ScheduledTaskInput {
+        id: id.to_string(),
+        automation_task_id: task_id.to_string(),
+        cron_expression: "0 9 * * *".to_string(),
+        enabled: true,
+    }
+}
+
+#[tokio::test]
+async fn schedule_crud_create_get_list_delete() {
+    let store = setup_store_with_task().await;
+
+    let schedule = store
+        .set_scheduled_task(&schedule_input("morning", "task-1"))
+        .await
+        .unwrap();
+    assert_eq!(schedule.id, "morning");
+    assert_eq!(schedule.automation_task_id, "task-1");
+    assert_eq!(schedule.cron_expression, "0 9 * * *");
+    assert!(schedule.enabled);
+    assert_eq!(schedule.created_at, schedule.updated_at);
+
+    let fetched = store
+        .get_scheduled_task("morning")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(fetched, schedule);
+
+    store.delete_scheduled_task("morning").await.unwrap();
+    assert!(store
+        .get_scheduled_task("morning")
+        .await
+        .unwrap()
+        .is_none());
+}
+
+#[tokio::test]
+async fn schedule_list_deterministic_by_id() {
+    let store = setup_store_with_task().await;
+    store
+        .set_scheduled_task(&schedule_input("charlie", "task-1"))
+        .await
+        .unwrap();
+    store
+        .set_scheduled_task(&schedule_input("alpha", "task-1"))
+        .await
+        .unwrap();
+    store
+        .set_scheduled_task(&schedule_input("bravo", "task-1"))
+        .await
+        .unwrap();
+
+    let list = store.list_scheduled_tasks().await.unwrap();
+    let ids: Vec<&str> = list.iter().map(|s| s.id.as_str()).collect();
+    assert_eq!(ids, vec!["alpha", "bravo", "charlie"]);
+}
+
+#[tokio::test]
+async fn schedule_replacement_preserves_created_at() {
+    let store = setup_store_with_task().await;
+    let original = store
+        .set_scheduled_task(&schedule_input("s1", "task-1"))
+        .await
+        .unwrap();
+
+    tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
+
+    let updated = store
+        .set_scheduled_task(&ScheduledTaskInput {
+            id: "s1".to_string(),
+            automation_task_id: "task-1".to_string(),
+            cron_expression: "*/15 * * * *".to_string(),
+            enabled: false,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(updated.created_at, original.created_at);
+    assert!(updated.updated_at > original.updated_at);
+    assert_eq!(updated.cron_expression, "*/15 * * * *");
+    assert!(!updated.enabled);
+}
+
+#[tokio::test]
+async fn schedule_missing_task_rejected() {
+    let store = setup_store_with_task().await;
+    let result = store
+        .set_scheduled_task(&schedule_input("s1", "nonexistent-task"))
+        .await;
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        ConfigError::UnknownAutomationTask(task_id) => {
+            assert_eq!(task_id, "nonexistent-task");
+        }
+        other => panic!("expected UnknownAutomationTask, got {:?}", other),
+    }
+    assert!(store
+        .get_scheduled_task("s1")
+        .await
+        .unwrap()
+        .is_none());
+}
+
+#[tokio::test]
+async fn schedule_invalid_cron_rejected() {
+    let store = setup_store_with_task().await;
+    let result = store
+        .set_scheduled_task(&ScheduledTaskInput {
+            id: "s1".to_string(),
+            automation_task_id: "task-1".to_string(),
+            cron_expression: "not-valid".to_string(),
+            enabled: true,
+        })
+        .await;
+    assert!(matches!(result, Err(ConfigError::Validation(_))));
+}
+
+#[tokio::test]
+async fn schedule_macro_cron_rejected() {
+    let store = setup_store_with_task().await;
+    let result = store
+        .set_scheduled_task(&ScheduledTaskInput {
+            id: "s1".to_string(),
+            automation_task_id: "task-1".to_string(),
+            cron_expression: "@daily".to_string(),
+            enabled: true,
+        })
+        .await;
+    assert!(matches!(result, Err(ConfigError::Validation(_))));
+}
+
+#[tokio::test]
+async fn schedule_stepped_cron_accepted() {
+    let store = setup_store_with_task().await;
+    let result = store
+        .set_scheduled_task(&ScheduledTaskInput {
+            id: "s1".to_string(),
+            automation_task_id: "task-1".to_string(),
+            cron_expression: "*/15 9-17/2 1,15 * 1-5".to_string(),
+            enabled: true,
+        })
+        .await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn task_deletion_blocked_when_schedule_references_it() {
+    let store = setup_store_with_task().await;
+    store
+        .set_scheduled_task(&schedule_input("s1", "task-1"))
+        .await
+        .unwrap();
+    store
+        .set_scheduled_task(&schedule_input("s2", "task-1"))
+        .await
+        .unwrap();
+
+    let result = store.delete_automation_task("task-1").await;
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        ConfigError::TaskReferencedBySchedules {
+            task_id,
+            schedule_ids,
+        } => {
+            assert_eq!(task_id, "task-1");
+            assert_eq!(schedule_ids, vec!["s1", "s2"]);
+        }
+        other => panic!("expected TaskReferencedBySchedules, got {:?}", other),
+    }
+
+    assert!(store
+        .get_automation_task("task-1")
+        .await
+        .unwrap()
+        .is_some());
+}
+
+#[tokio::test]
+async fn task_deletion_allowed_when_no_schedule_references_it() {
+    let store = setup_store_with_task().await;
+    store.delete_automation_task("task-1").await.unwrap();
+    assert!(store
+        .get_automation_task("task-1")
+        .await
+        .unwrap()
+        .is_none());
+}
+
+#[tokio::test]
+async fn schedules_referencing_task_helper() {
+    let store = setup_store_with_task().await;
+    store
+        .set_scheduled_task(&schedule_input("s1", "task-1"))
+        .await
+        .unwrap();
+
+    let refs = store.schedules_referencing_task("task-1").await.unwrap();
+    assert_eq!(refs, vec!["s1"]);
+
+    let no_refs = store.schedules_referencing_task("other").await.unwrap();
+    assert!(no_refs.is_empty());
+}
+
+#[tokio::test]
+async fn schedule_delete_does_not_affect_task() {
+    let store = setup_store_with_task().await;
+    store
+        .set_scheduled_task(&schedule_input("s1", "task-1"))
+        .await
+        .unwrap();
+    store.delete_scheduled_task("s1").await.unwrap();
+    assert!(store
+        .get_automation_task("task-1")
+        .await
+        .unwrap()
+        .is_some());
+}
+
+#[tokio::test]
+async fn schedule_input_is_trimmed() {
+    let store = setup_store_with_task().await;
+    let input = ScheduledTaskInput {
+        id: "  spaced-id  ".to_string(),
+        automation_task_id: "  task-1  ".to_string(),
+        cron_expression: "  0 9 * * *  ".to_string(),
+        enabled: true,
+    };
+    let schedule = store.set_scheduled_task(&input).await.unwrap();
+    assert_eq!(schedule.id, "spaced-id");
+    assert_eq!(schedule.automation_task_id, "task-1");
+    assert_eq!(schedule.cron_expression, "0 9 * * *");
+}

--- a/src/config/scheduled_task_tests.rs
+++ b/src/config/scheduled_task_tests.rs
@@ -3,7 +3,6 @@ use crate::config::records::PromptInput;
 use crate::config::{ConfigError, ConfigStore};
 use crate::scheduled_task::ScheduledTaskInput;
 use serde_json::json;
-use std::path::PathBuf;
 
 async fn setup_store_with_task() -> ConfigStore {
     let store = ConfigStore::open_in_memory().await.unwrap();
@@ -58,19 +57,11 @@ async fn schedule_crud_create_get_list_delete() {
     assert!(schedule.enabled);
     assert_eq!(schedule.created_at, schedule.updated_at);
 
-    let fetched = store
-        .get_scheduled_task("morning")
-        .await
-        .unwrap()
-        .unwrap();
+    let fetched = store.get_scheduled_task("morning").await.unwrap().unwrap();
     assert_eq!(fetched, schedule);
 
     store.delete_scheduled_task("morning").await.unwrap();
-    assert!(store
-        .get_scheduled_task("morning")
-        .await
-        .unwrap()
-        .is_none());
+    assert!(store.get_scheduled_task("morning").await.unwrap().is_none());
 }
 
 #[tokio::test]
@@ -133,11 +124,7 @@ async fn schedule_missing_task_rejected() {
         }
         other => panic!("expected UnknownAutomationTask, got {:?}", other),
     }
-    assert!(store
-        .get_scheduled_task("s1")
-        .await
-        .unwrap()
-        .is_none());
+    assert!(store.get_scheduled_task("s1").await.unwrap().is_none());
 }
 
 #[tokio::test]
@@ -207,22 +194,14 @@ async fn task_deletion_blocked_when_schedule_references_it() {
         other => panic!("expected TaskReferencedBySchedules, got {:?}", other),
     }
 
-    assert!(store
-        .get_automation_task("task-1")
-        .await
-        .unwrap()
-        .is_some());
+    assert!(store.get_automation_task("task-1").await.unwrap().is_some());
 }
 
 #[tokio::test]
 async fn task_deletion_allowed_when_no_schedule_references_it() {
     let store = setup_store_with_task().await;
     store.delete_automation_task("task-1").await.unwrap();
-    assert!(store
-        .get_automation_task("task-1")
-        .await
-        .unwrap()
-        .is_none());
+    assert!(store.get_automation_task("task-1").await.unwrap().is_none());
 }
 
 #[tokio::test]
@@ -248,11 +227,7 @@ async fn schedule_delete_does_not_affect_task() {
         .await
         .unwrap();
     store.delete_scheduled_task("s1").await.unwrap();
-    assert!(store
-        .get_automation_task("task-1")
-        .await
-        .unwrap()
-        .is_some());
+    assert!(store.get_automation_task("task-1").await.unwrap().is_some());
 }
 
 #[tokio::test]

--- a/src/config/store.rs
+++ b/src/config/store.rs
@@ -1947,17 +1947,21 @@ impl ConfigStore {
 
     /// Store or replace an automation task.
     ///
-    /// Validates the input, requires the referenced stored prompt to exist,
-    /// and creates or replaces the task atomically. On replacement, the
-    /// original creation timestamp is preserved and the update timestamp
-    /// advances.
+    /// Validates the input, normalizes the display name, requires the
+    /// referenced stored prompt to exist, rejects normalized-name collisions
+    /// with other tasks, canonicalizes the project root, and creates or
+    /// replaces the task atomically. On replacement, the original creation
+    /// timestamp is preserved and the update timestamp advances.
     pub async fn set_automation_task(
         &self,
         input: &crate::automation_task::AutomationTaskInput,
     ) -> Result<crate::automation_task::AutomationTask, ConfigError> {
-        use crate::automation_task::{validate_task_input, AUTOMATION_TASK_SCHEMA_VERSION};
+        use crate::automation_task::{
+            normalize_task_name, validate_task_input, AUTOMATION_TASK_SCHEMA_VERSION,
+        };
 
         let normalized = validate_task_input(input).map_err(ConfigError::Validation)?;
+        let normalized_name = normalize_task_name(&normalized.display_name);
 
         let mut tx = self.pool.begin().await.map_err(ConfigError::from)?;
 
@@ -1974,6 +1978,48 @@ impl ConfigStore {
             ));
         }
 
+        // Reject normalized-name collisions with a different task ID.
+        let collision: Option<(String,)> =
+            sqlx::query_as("SELECT id FROM automation_tasks WHERE normalized_name = ? AND id != ?")
+                .bind(&normalized_name)
+                .bind(&normalized.id)
+                .fetch_optional(&mut *tx)
+                .await
+                .map_err(ConfigError::from)?;
+
+        if let Some((existing_id,)) = collision {
+            return Err(ConfigError::TaskNameConflict {
+                normalized_name,
+                existing_id,
+            });
+        }
+
+        // Canonicalize project root — must be an existing directory.
+        let canonical_root = tokio::fs::canonicalize(&normalized.project_root)
+            .await
+            .map_err(|e| {
+                ConfigError::Validation(format!(
+                    "Project root '{}' is not accessible: {}",
+                    normalized.project_root.display(),
+                    e
+                ))
+            })?;
+
+        let metadata = tokio::fs::metadata(&canonical_root).await.map_err(|e| {
+            ConfigError::Validation(format!(
+                "Project root '{}' cannot be read: {}",
+                canonical_root.display(),
+                e
+            ))
+        })?;
+
+        if !metadata.is_dir() {
+            return Err(ConfigError::Validation(format!(
+                "Project root '{}' is not a directory",
+                canonical_root.display()
+            )));
+        }
+
         let now = Utc::now().to_rfc3339();
 
         // Try to fetch the existing created_at so we can preserve it.
@@ -1988,23 +2034,31 @@ impl ConfigStore {
             .map(|(ca,)| ca)
             .unwrap_or_else(|| now.clone());
 
+        let project_root_str = canonical_root.to_string_lossy();
+
         sqlx::query(
             r#"
-            INSERT INTO automation_tasks (id, name, stored_prompt_id, expected_outcome, schema_version, created_at, updated_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO automation_tasks (id, name, normalized_name, stored_prompt_id, expected_outcome, project_root, timeout_seconds, schema_version, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(id) DO UPDATE SET
                 name = excluded.name,
+                normalized_name = excluded.normalized_name,
                 stored_prompt_id = excluded.stored_prompt_id,
                 expected_outcome = excluded.expected_outcome,
+                project_root = excluded.project_root,
+                timeout_seconds = excluded.timeout_seconds,
                 schema_version = excluded.schema_version,
                 created_at = excluded.created_at,
                 updated_at = excluded.updated_at
             "#,
         )
         .bind(&normalized.id)
-        .bind(&normalized.name)
+        .bind(&normalized.display_name)
+        .bind(&normalized_name)
         .bind(&normalized.stored_prompt_id)
         .bind(&normalized.expected_outcome)
+        .bind(&*project_root_str)
+        .bind(normalized.timeout_seconds as i64)
         .bind(AUTOMATION_TASK_SCHEMA_VERSION)
         .bind(&created_at)
         .bind(&now)
@@ -2019,9 +2073,12 @@ impl ConfigStore {
 
         Ok(crate::automation_task::AutomationTask {
             id: normalized.id,
-            name: normalized.name,
+            display_name: normalized.display_name,
+            normalized_name,
             stored_prompt_id: normalized.stored_prompt_id,
             expected_outcome: normalized.expected_outcome,
+            project_root: canonical_root,
+            timeout_seconds: normalized.timeout_seconds,
             created_at: created_at_dt,
             updated_at: updated_at_dt,
         })
@@ -2038,7 +2095,7 @@ impl ConfigStore {
         use crate::automation_task::AUTOMATION_TASK_SCHEMA_VERSION;
 
         let row = sqlx::query(
-            "SELECT id, name, stored_prompt_id, expected_outcome, schema_version, created_at, updated_at FROM automation_tasks WHERE id = ?",
+            "SELECT id, name, normalized_name, stored_prompt_id, expected_outcome, project_root, timeout_seconds, schema_version, created_at, updated_at FROM automation_tasks WHERE id = ?",
         )
         .bind(id)
         .fetch_optional(&self.pool)
@@ -2056,9 +2113,14 @@ impl ConfigStore {
                 }
                 Ok(Some(crate::automation_task::AutomationTask {
                     id: row.get("id"),
-                    name: row.get("name"),
+                    display_name: row.get("name"),
+                    normalized_name: row.get("normalized_name"),
                     stored_prompt_id: row.get("stored_prompt_id"),
                     expected_outcome: row.get("expected_outcome"),
+                    project_root: std::path::PathBuf::from(
+                        row.get::<String, _>("project_root"),
+                    ),
+                    timeout_seconds: row.get::<i64, _>("timeout_seconds") as u64,
                     created_at: parse_datetime(row.get::<String, _>("created_at"))?,
                     updated_at: parse_datetime(row.get::<String, _>("updated_at"))?,
                 }))
@@ -2077,7 +2139,7 @@ impl ConfigStore {
         use crate::automation_task::AUTOMATION_TASK_SCHEMA_VERSION;
 
         let rows = sqlx::query(
-            "SELECT id, name, stored_prompt_id, expected_outcome, schema_version, created_at, updated_at FROM automation_tasks ORDER BY id ASC",
+            "SELECT id, name, normalized_name, stored_prompt_id, expected_outcome, project_root, timeout_seconds, schema_version, created_at, updated_at FROM automation_tasks ORDER BY id ASC",
         )
         .fetch_all(&self.pool)
         .await
@@ -2096,9 +2158,14 @@ impl ConfigStore {
                 }
                 Ok(crate::automation_task::AutomationTask {
                     id: row.get("id"),
-                    name: row.get("name"),
+                    display_name: row.get("name"),
+                    normalized_name: row.get("normalized_name"),
                     stored_prompt_id: row.get("stored_prompt_id"),
                     expected_outcome: row.get("expected_outcome"),
+                    project_root: std::path::PathBuf::from(
+                        row.get::<String, _>("project_root"),
+                    ),
+                    timeout_seconds: row.get::<i64, _>("timeout_seconds") as u64,
                     created_at: parse_datetime(row.get::<String, _>("created_at"))?,
                     updated_at: parse_datetime(row.get::<String, _>("updated_at"))?,
                 })
@@ -2107,12 +2174,27 @@ impl ConfigStore {
     }
 
     /// Delete an automation task by ID. Does not affect the referenced prompt.
+    ///
+    /// Returns `ConfigError::TaskReferencedBySchedules` if one or more
+    /// schedules reference this task.
     pub async fn delete_automation_task(&self, id: &str) -> Result<(), ConfigError> {
+        let mut tx = self.pool.begin().await.map_err(ConfigError::from)?;
+
+        let referencing_schedules = fetch_referencing_schedule_ids(&mut *tx, id).await?;
+        if !referencing_schedules.is_empty() {
+            return Err(ConfigError::TaskReferencedBySchedules {
+                task_id: id.to_string(),
+                schedule_ids: referencing_schedules,
+            });
+        }
+
         sqlx::query("DELETE FROM automation_tasks WHERE id = ?")
             .bind(id)
-            .execute(&self.pool)
+            .execute(&mut *tx)
             .await
             .map_err(ConfigError::from)?;
+
+        tx.commit().await.map_err(ConfigError::from)?;
         Ok(())
     }
 
@@ -2122,6 +2204,173 @@ impl ConfigStore {
         prompt_id: &str,
     ) -> Result<Vec<String>, ConfigError> {
         fetch_referencing_task_ids(&self.pool, prompt_id).await
+    }
+
+    // ============================================================================
+    // Typed Scheduled-Task APIs
+    // ============================================================================
+
+    /// Store or replace a typed scheduled task.
+    ///
+    /// Validates the input, requires the referenced automation task to exist,
+    /// and creates or replaces the schedule atomically. On replacement, the
+    /// original creation timestamp is preserved and the update timestamp
+    /// advances.
+    pub async fn set_scheduled_task(
+        &self,
+        input: &crate::scheduled_task::ScheduledTaskInput,
+    ) -> Result<crate::scheduled_task::ScheduledTask, ConfigError> {
+        use crate::scheduled_task::{validate_schedule_input, SCHEDULED_TASK_SCHEMA_VERSION};
+
+        let normalized = validate_schedule_input(input).map_err(ConfigError::Validation)?;
+
+        let mut tx = self.pool.begin().await.map_err(ConfigError::from)?;
+
+        let task_exists: Option<(i64,)> =
+            sqlx::query_as("SELECT 1 FROM automation_tasks WHERE id = ?")
+                .bind(&normalized.automation_task_id)
+                .fetch_optional(&mut *tx)
+                .await
+                .map_err(ConfigError::from)?;
+
+        if task_exists.is_none() {
+            return Err(ConfigError::UnknownAutomationTask(
+                normalized.automation_task_id.clone(),
+            ));
+        }
+
+        let now = Utc::now().to_rfc3339();
+
+        let existing_created_at: Option<(String,)> =
+            sqlx::query_as("SELECT created_at FROM schedule WHERE id = ?")
+                .bind(&normalized.id)
+                .fetch_optional(&mut *tx)
+                .await
+                .map_err(ConfigError::from)?;
+
+        let created_at = existing_created_at
+            .map(|(ca,)| ca)
+            .unwrap_or_else(|| now.clone());
+
+        let payload = serde_json::json!({
+            "automation_task_id": normalized.automation_task_id,
+            "cron_expression": normalized.cron_expression,
+            "enabled": normalized.enabled,
+        });
+        let payload_str = serde_json::to_string(&payload)?;
+
+        sqlx::query(
+            r#"
+            INSERT INTO schedule (id, schema_version, payload, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT(id) DO UPDATE SET
+                schema_version = excluded.schema_version,
+                payload = excluded.payload,
+                updated_at = excluded.updated_at
+            "#,
+        )
+        .bind(&normalized.id)
+        .bind(SCHEDULED_TASK_SCHEMA_VERSION)
+        .bind(&payload_str)
+        .bind(&created_at)
+        .bind(&now)
+        .execute(&mut *tx)
+        .await
+        .map_err(ConfigError::from)?;
+
+        tx.commit().await.map_err(ConfigError::from)?;
+
+        let created_at_dt = parse_datetime(created_at)?;
+        let updated_at_dt = parse_datetime(now)?;
+
+        Ok(crate::scheduled_task::ScheduledTask {
+            id: normalized.id,
+            automation_task_id: normalized.automation_task_id,
+            cron_expression: normalized.cron_expression,
+            enabled: normalized.enabled,
+            created_at: created_at_dt,
+            updated_at: updated_at_dt,
+        })
+    }
+
+    /// Get a typed scheduled task by ID.
+    ///
+    /// Returns `Ok(None)` if no schedule with the given ID exists. Returns
+    /// `ConfigError::Deserialization` if the stored record has an unsupported
+    /// schema version or payload that is not a valid typed schedule.
+    pub async fn get_scheduled_task(
+        &self,
+        id: &str,
+    ) -> Result<Option<crate::scheduled_task::ScheduledTask>, ConfigError> {
+        use crate::scheduled_task::SCHEDULED_TASK_SCHEMA_VERSION;
+
+        let row = sqlx::query(
+            "SELECT id, schema_version, payload, created_at, updated_at FROM schedule WHERE id = ?",
+        )
+        .bind(id)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(ConfigError::from)?;
+
+        match row {
+            Some(row) => {
+                let schema_version: i64 = row.get("schema_version");
+                if schema_version != SCHEDULED_TASK_SCHEMA_VERSION {
+                    return Ok(None);
+                }
+                deserialize_schedule_row(&row)
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// List all typed scheduled tasks in deterministic order (by ID ascending).
+    ///
+    /// Skips records with an unsupported schema version or non-schedule
+    /// payloads rather than failing the entire list.
+    pub async fn list_scheduled_tasks(
+        &self,
+    ) -> Result<Vec<crate::scheduled_task::ScheduledTask>, ConfigError> {
+        use crate::scheduled_task::SCHEDULED_TASK_SCHEMA_VERSION;
+
+        let rows = sqlx::query(
+            "SELECT id, schema_version, payload, created_at, updated_at FROM schedule ORDER BY id ASC",
+        )
+        .fetch_all(&self.pool)
+        .await
+        .map_err(ConfigError::from)?;
+
+        let mut result = Vec::new();
+        for row in rows {
+            let schema_version: i64 = row.get("schema_version");
+            if schema_version != SCHEDULED_TASK_SCHEMA_VERSION {
+                continue;
+            }
+            if let Ok(task) = deserialize_schedule_row(&row) {
+                if let Some(task) = task {
+                    result.push(task);
+                }
+            }
+        }
+        Ok(result)
+    }
+
+    /// Delete a scheduled task by ID.
+    pub async fn delete_scheduled_task(&self, id: &str) -> Result<(), ConfigError> {
+        sqlx::query("DELETE FROM schedule WHERE id = ?")
+            .bind(id)
+            .execute(&self.pool)
+            .await
+            .map_err(ConfigError::from)?;
+        Ok(())
+    }
+
+    /// List schedule IDs that reference a given automation task.
+    pub async fn schedules_referencing_task(
+        &self,
+        task_id: &str,
+    ) -> Result<Vec<String>, ConfigError> {
+        fetch_referencing_schedule_ids(&self.pool, task_id).await
     }
 }
 
@@ -2145,6 +2394,76 @@ where
         .into_iter()
         .map(|row| row.get::<String, _>("id"))
         .collect())
+}
+
+/// Fetch schedule IDs referencing an automation task via JSON payload
+/// extraction. Generic over the executor so it works with both the connection
+/// pool and an in-flight transaction.
+async fn fetch_referencing_schedule_ids<'e, E>(
+    executor: E,
+    task_id: &str,
+) -> Result<Vec<String>, ConfigError>
+where
+    E: sqlx::Executor<'e, Database = sqlx::Sqlite>,
+{
+    use crate::scheduled_task::SCHEDULED_TASK_SCHEMA_VERSION;
+
+    let rows = sqlx::query(
+        "SELECT id FROM schedule \
+         WHERE schema_version = ? \
+         AND json_extract(payload, '$.automation_task_id') = ? \
+         ORDER BY id ASC",
+    )
+    .bind(SCHEDULED_TASK_SCHEMA_VERSION)
+    .bind(task_id)
+    .fetch_all(executor)
+    .await
+    .map_err(ConfigError::from)?;
+
+    Ok(rows
+        .into_iter()
+        .map(|row| row.get::<String, _>("id"))
+        .collect())
+}
+
+/// Deserialize a schedule table row into a typed `ScheduledTask`.
+fn deserialize_schedule_row(
+    row: &sqlx::sqlite::SqliteRow,
+) -> Result<Option<crate::scheduled_task::ScheduledTask>, ConfigError> {
+    use sqlx::Row;
+
+    let id: String = row.get("id");
+    let payload_str: String = row.get("payload");
+    let payload: serde_json::Value = match serde_json::from_str(&payload_str) {
+        Ok(v) => v,
+        Err(_) => return Ok(None),
+    };
+
+    let automation_task_id = payload
+        .get("automation_task_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let cron_expression = payload
+        .get("cron_expression")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let enabled = payload
+        .get("enabled")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    if automation_task_id.is_empty() || cron_expression.is_empty() {
+        return Ok(None);
+    }
+
+    Ok(Some(crate::scheduled_task::ScheduledTask {
+        id,
+        automation_task_id: automation_task_id.to_string(),
+        cron_expression: cron_expression.to_string(),
+        enabled,
+        created_at: parse_datetime(row.get::<String, _>("created_at"))?,
+        updated_at: parse_datetime(row.get::<String, _>("updated_at"))?,
+    }))
 }
 
 /// Resolve the platform-default config path.

--- a/src/config/store.rs
+++ b/src/config/store.rs
@@ -2111,6 +2111,13 @@ impl ConfigStore {
                         id, schema_version, AUTOMATION_TASK_SCHEMA_VERSION
                     )));
                 }
+                let timeout_i64: i64 = row.get("timeout_seconds");
+                if timeout_i64 < 0 {
+                    return Err(ConfigError::Deserialization(format!(
+                        "automation task '{}' has negative timeout {}",
+                        id, timeout_i64
+                    )));
+                }
                 Ok(Some(crate::automation_task::AutomationTask {
                     id: row.get("id"),
                     display_name: row.get("name"),
@@ -2118,7 +2125,7 @@ impl ConfigStore {
                     stored_prompt_id: row.get("stored_prompt_id"),
                     expected_outcome: row.get("expected_outcome"),
                     project_root: std::path::PathBuf::from(row.get::<String, _>("project_root")),
-                    timeout_seconds: row.get::<i64, _>("timeout_seconds") as u64,
+                    timeout_seconds: timeout_i64 as u64,
                     created_at: parse_datetime(row.get::<String, _>("created_at"))?,
                     updated_at: parse_datetime(row.get::<String, _>("updated_at"))?,
                 }))
@@ -2154,6 +2161,14 @@ impl ConfigStore {
                         AUTOMATION_TASK_SCHEMA_VERSION
                     )));
                 }
+                let timeout_i64: i64 = row.get("timeout_seconds");
+                if timeout_i64 < 0 {
+                    return Err(ConfigError::Deserialization(format!(
+                        "automation task '{}' has negative timeout {}",
+                        row.get::<String, _>("id"),
+                        timeout_i64
+                    )));
+                }
                 Ok(crate::automation_task::AutomationTask {
                     id: row.get("id"),
                     display_name: row.get("name"),
@@ -2161,7 +2176,7 @@ impl ConfigStore {
                     stored_prompt_id: row.get("stored_prompt_id"),
                     expected_outcome: row.get("expected_outcome"),
                     project_root: std::path::PathBuf::from(row.get::<String, _>("project_root")),
-                    timeout_seconds: row.get::<i64, _>("timeout_seconds") as u64,
+                    timeout_seconds: timeout_i64 as u64,
                     created_at: parse_datetime(row.get::<String, _>("created_at"))?,
                     updated_at: parse_datetime(row.get::<String, _>("updated_at"))?,
                 })

--- a/src/config/store.rs
+++ b/src/config/store.rs
@@ -2105,9 +2105,9 @@ impl ConfigStore {
         match row {
             Some(row) => {
                 let schema_version: i64 = row.get("schema_version");
-                if schema_version != AUTOMATION_TASK_SCHEMA_VERSION {
+                if !(1..=AUTOMATION_TASK_SCHEMA_VERSION).contains(&schema_version) {
                     return Err(ConfigError::Deserialization(format!(
-                        "automation task '{}' has unsupported schema version {} (expected {})",
+                        "automation task '{}' has unsupported schema version {} (supported 1..={})",
                         id, schema_version, AUTOMATION_TASK_SCHEMA_VERSION
                     )));
                 }
@@ -2117,9 +2117,7 @@ impl ConfigStore {
                     normalized_name: row.get("normalized_name"),
                     stored_prompt_id: row.get("stored_prompt_id"),
                     expected_outcome: row.get("expected_outcome"),
-                    project_root: std::path::PathBuf::from(
-                        row.get::<String, _>("project_root"),
-                    ),
+                    project_root: std::path::PathBuf::from(row.get::<String, _>("project_root")),
                     timeout_seconds: row.get::<i64, _>("timeout_seconds") as u64,
                     created_at: parse_datetime(row.get::<String, _>("created_at"))?,
                     updated_at: parse_datetime(row.get::<String, _>("updated_at"))?,
@@ -2148,9 +2146,9 @@ impl ConfigStore {
         rows.into_iter()
             .map(|row| {
                 let schema_version: i64 = row.get("schema_version");
-                if schema_version != AUTOMATION_TASK_SCHEMA_VERSION {
+                if !(1..=AUTOMATION_TASK_SCHEMA_VERSION).contains(&schema_version) {
                     return Err(ConfigError::Deserialization(format!(
-                        "automation task '{}' has unsupported schema version {} (expected {})",
+                        "automation task '{}' has unsupported schema version {} (supported 1..={})",
                         row.get::<String, _>("id"),
                         schema_version,
                         AUTOMATION_TASK_SCHEMA_VERSION
@@ -2162,9 +2160,7 @@ impl ConfigStore {
                     normalized_name: row.get("normalized_name"),
                     stored_prompt_id: row.get("stored_prompt_id"),
                     expected_outcome: row.get("expected_outcome"),
-                    project_root: std::path::PathBuf::from(
-                        row.get::<String, _>("project_root"),
-                    ),
+                    project_root: std::path::PathBuf::from(row.get::<String, _>("project_root")),
                     timeout_seconds: row.get::<i64, _>("timeout_seconds") as u64,
                     created_at: parse_datetime(row.get::<String, _>("created_at"))?,
                     updated_at: parse_datetime(row.get::<String, _>("updated_at"))?,
@@ -2346,10 +2342,8 @@ impl ConfigStore {
             if schema_version != SCHEDULED_TASK_SCHEMA_VERSION {
                 continue;
             }
-            if let Ok(task) = deserialize_schedule_row(&row) {
-                if let Some(task) = task {
-                    result.push(task);
-                }
+            if let Ok(Some(task)) = deserialize_schedule_row(&row) {
+                result.push(task);
             }
         }
         Ok(result)
@@ -2427,6 +2421,10 @@ where
 }
 
 /// Deserialize a schedule table row into a typed `ScheduledTask`.
+///
+/// Returns `Ok(None)` only if the record's schema version is not a typed
+/// schedule version (i.e. it predates typed schedules). Malformed payloads
+/// with the correct schema version surface as `Err(Deserialization(...))`.
 fn deserialize_schedule_row(
     row: &sqlx::sqlite::SqliteRow,
 ) -> Result<Option<crate::scheduled_task::ScheduledTask>, ConfigError> {
@@ -2434,27 +2432,28 @@ fn deserialize_schedule_row(
 
     let id: String = row.get("id");
     let payload_str: String = row.get("payload");
-    let payload: serde_json::Value = match serde_json::from_str(&payload_str) {
-        Ok(v) => v,
-        Err(_) => return Ok(None),
-    };
+    let payload: serde_json::Value = serde_json::from_str(&payload_str).map_err(|e| {
+        ConfigError::Deserialization(format!("schedule '{}' has malformed JSON: {}", id, e))
+    })?;
 
     let automation_task_id = payload
         .get("automation_task_id")
         .and_then(|v| v.as_str())
-        .unwrap_or("");
+        .ok_or_else(|| {
+            ConfigError::Deserialization(format!("schedule '{}' missing automation_task_id", id))
+        })?;
+
     let cron_expression = payload
         .get("cron_expression")
         .and_then(|v| v.as_str())
-        .unwrap_or("");
+        .ok_or_else(|| {
+            ConfigError::Deserialization(format!("schedule '{}' missing cron_expression", id))
+        })?;
+
     let enabled = payload
         .get("enabled")
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
-
-    if automation_task_id.is_empty() || cron_expression.is_empty() {
-        return Ok(None);
-    }
 
     Ok(Some(crate::scheduled_task::ScheduledTask {
         id,

--- a/src/config/store.rs
+++ b/src/config/store.rs
@@ -1963,6 +1963,34 @@ impl ConfigStore {
         let normalized = validate_task_input(input).map_err(ConfigError::Validation)?;
         let normalized_name = normalize_task_name(&normalized.display_name);
 
+        // Canonicalize project root — must be an existing directory.
+        // Performed before opening the write transaction so slow filesystem
+        // I/O does not extend the transaction's lifetime.
+        let canonical_root = tokio::fs::canonicalize(&normalized.project_root)
+            .await
+            .map_err(|e| {
+                ConfigError::Validation(format!(
+                    "Project root '{}' is not accessible: {}",
+                    normalized.project_root.display(),
+                    e
+                ))
+            })?;
+
+        let metadata = tokio::fs::metadata(&canonical_root).await.map_err(|e| {
+            ConfigError::Validation(format!(
+                "Project root '{}' cannot be read: {}",
+                canonical_root.display(),
+                e
+            ))
+        })?;
+
+        if !metadata.is_dir() {
+            return Err(ConfigError::Validation(format!(
+                "Project root '{}' is not a directory",
+                canonical_root.display()
+            )));
+        }
+
         let mut tx = self.pool.begin().await.map_err(ConfigError::from)?;
 
         // Require the referenced prompt to exist.
@@ -1992,32 +2020,6 @@ impl ConfigStore {
                 normalized_name,
                 existing_id,
             });
-        }
-
-        // Canonicalize project root — must be an existing directory.
-        let canonical_root = tokio::fs::canonicalize(&normalized.project_root)
-            .await
-            .map_err(|e| {
-                ConfigError::Validation(format!(
-                    "Project root '{}' is not accessible: {}",
-                    normalized.project_root.display(),
-                    e
-                ))
-            })?;
-
-        let metadata = tokio::fs::metadata(&canonical_root).await.map_err(|e| {
-            ConfigError::Validation(format!(
-                "Project root '{}' cannot be read: {}",
-                canonical_root.display(),
-                e
-            ))
-        })?;
-
-        if !metadata.is_dir() {
-            return Err(ConfigError::Validation(format!(
-                "Project root '{}' is not a directory",
-                canonical_root.display()
-            )));
         }
 
         let now = Utc::now().to_rfc3339();

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -436,8 +436,8 @@ pub fn effective_tool_filter(input: &ResolvedExecutionInput) -> ToolFilter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::automation_task::AutomationTaskInput;
     use crate::automation_task::normalize_task_name;
+    use crate::automation_task::AutomationTaskInput;
     use crate::config::ConfigStore;
     use crate::profile::{AgentApproval, AgentProfile, SkillFilter};
     use crate::stored_prompt::StoredPrompt;
@@ -848,9 +848,14 @@ mod tests {
         let store = setup_store_with_task_and_prompt().await;
         let reg: HashMap<AgentProfileId, AgentProfile> = HashMap::new();
 
-        let result =
-            resolve_task_execution(&store, &reg, "daily-report", PathBuf::from("/w"), TEST_TIMEOUT)
-                .await;
+        let result = resolve_task_execution(
+            &store,
+            &reg,
+            "daily-report",
+            PathBuf::from("/w"),
+            TEST_TIMEOUT,
+        )
+        .await;
         assert!(matches!(result, Err(ResolutionError::ProfileNotFound(_))));
     }
 

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -18,6 +18,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::time::Duration;
 
 /// Schema version for automation-run result payloads.
 pub const AUTOMATION_RUN_SCHEMA_VERSION: i64 = 1;
@@ -51,6 +52,8 @@ pub struct ResolvedExecutionInput {
     pub effective_skills: Vec<String>,
     /// Canonical workspace directory for the run.
     pub workspace: PathBuf,
+    /// Execution timeout for the run.
+    pub timeout: Duration,
     /// When this snapshot was resolved.
     pub resolved_at: DateTime<Utc>,
 }
@@ -176,7 +179,7 @@ impl AutomationRunResult {
             schema_version: AUTOMATION_RUN_SCHEMA_VERSION,
             run_id: uuid::Uuid::new_v4().to_string(),
             task_id: task.id.clone(),
-            task_name: task.name.clone(),
+            task_name: task.display_name.clone(),
             status: AutomationRunStatus::Failed,
             output: String::new(),
             expected_outcome: task.expected_outcome.clone(),
@@ -346,6 +349,7 @@ pub async fn resolve_task_execution(
     profiles: &HashMap<AgentProfileId, AgentProfile>,
     task_id: &str,
     workspace: PathBuf,
+    timeout: Duration,
 ) -> Result<ResolvedExecutionInput, ResolutionError> {
     let task = store
         .get_automation_task(task_id)
@@ -377,6 +381,7 @@ pub async fn resolve_task_execution(
         user_goal,
         effective_skills: skills,
         workspace,
+        timeout,
         resolved_at: Utc::now(),
     })
 }
@@ -432,9 +437,29 @@ pub fn effective_tool_filter(input: &ResolvedExecutionInput) -> ToolFilter {
 mod tests {
     use super::*;
     use crate::automation_task::AutomationTaskInput;
+    use crate::automation_task::normalize_task_name;
     use crate::config::ConfigStore;
     use crate::profile::{AgentApproval, AgentProfile, SkillFilter};
     use crate::stored_prompt::StoredPrompt;
+
+    // ---- test helpers ----
+
+    fn test_task(id: &str, display_name: &str) -> AutomationTask {
+        let now = Utc::now();
+        AutomationTask {
+            id: id.to_string(),
+            display_name: display_name.to_string(),
+            normalized_name: normalize_task_name(display_name),
+            stored_prompt_id: "p1".to_string(),
+            expected_outcome: "done".to_string(),
+            project_root: PathBuf::from("/tmp"),
+            timeout_seconds: 60,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    const TEST_TIMEOUT: Duration = Duration::from_secs(300);
 
     // ---- compose_user_goal ----
 
@@ -517,14 +542,7 @@ mod tests {
     #[test]
     fn effective_skills_inherit() {
         let now = Utc::now();
-        let task = AutomationTask {
-            id: "t1".to_string(),
-            name: "T".to_string(),
-            stored_prompt_id: "p1".to_string(),
-            expected_outcome: "done".to_string(),
-            created_at: now,
-            updated_at: now,
-        };
+        let task = test_task("t1", "T");
         let prompt = StoredPrompt {
             instructions: "do thing".to_string(),
             skills: vec!["s1".to_string(), "s2".to_string()],
@@ -542,6 +560,7 @@ mod tests {
             user_goal: "do thing\n\ndone".to_string(),
             effective_skills: vec!["s1".to_string(), "s2".to_string()],
             workspace: PathBuf::from("/tmp"),
+            timeout: TEST_TIMEOUT,
             resolved_at: now,
         };
         let skills = effective_skills(&input);
@@ -561,20 +580,14 @@ mod tests {
             ..AgentProfile::with_name("default")
         };
         let input = ResolvedExecutionInput {
-            task: AutomationTask {
-                id: "t".to_string(),
-                name: "T".to_string(),
-                stored_prompt_id: "p".to_string(),
-                expected_outcome: "o".to_string(),
-                created_at: now,
-                updated_at: now,
-            },
+            task: test_task("t", "T"),
             prompt,
             profile_id: AgentProfileId::from("default"),
             profile,
             user_goal: "do\n\no".to_string(),
             effective_skills: Vec::new(),
             workspace: PathBuf::from("/tmp"),
+            timeout: TEST_TIMEOUT,
             resolved_at: now,
         };
         assert!(effective_skills(&input).is_empty());
@@ -593,20 +606,14 @@ mod tests {
             ..AgentProfile::with_name("default")
         };
         let input = ResolvedExecutionInput {
-            task: AutomationTask {
-                id: "t".to_string(),
-                name: "T".to_string(),
-                stored_prompt_id: "p".to_string(),
-                expected_outcome: "o".to_string(),
-                created_at: now,
-                updated_at: now,
-            },
+            task: test_task("t", "T"),
             prompt,
             profile_id: AgentProfileId::from("default"),
             profile,
             user_goal: "do\n\no".to_string(),
             effective_skills: vec!["s1".to_string(), "s3".to_string()],
             workspace: PathBuf::from("/tmp"),
+            timeout: TEST_TIMEOUT,
             resolved_at: now,
         };
         let skills = effective_skills(&input);
@@ -617,34 +624,18 @@ mod tests {
 
     #[test]
     fn run_result_started_has_task_identity() {
-        let now = Utc::now();
-        let task = AutomationTask {
-            id: "daily".to_string(),
-            name: "Daily".to_string(),
-            stored_prompt_id: "p".to_string(),
-            expected_outcome: "report".to_string(),
-            created_at: now,
-            updated_at: now,
-        };
+        let task = test_task("daily", "Daily");
         let result = AutomationRunResult::started(&task, PathBuf::from("/work"));
         assert_eq!(result.task_id, "daily");
         assert_eq!(result.task_name, "Daily");
-        assert_eq!(result.expected_outcome, "report");
+        assert_eq!(result.expected_outcome, "done");
         assert_eq!(result.workspace, PathBuf::from("/work"));
         assert!(!result.run_id.is_empty());
     }
 
     #[test]
     fn run_result_complete() {
-        let now = Utc::now();
-        let task = AutomationTask {
-            id: "t".to_string(),
-            name: "T".to_string(),
-            stored_prompt_id: "p".to_string(),
-            expected_outcome: "o".to_string(),
-            created_at: now,
-            updated_at: now,
-        };
+        let task = test_task("t", "T");
         let mut result = AutomationRunResult::started(&task, PathBuf::from("/w"));
         result.complete("final output".to_string());
         assert_eq!(result.status, AutomationRunStatus::Completed);
@@ -654,15 +645,7 @@ mod tests {
 
     #[test]
     fn run_result_fail_sets_error() {
-        let now = Utc::now();
-        let task = AutomationTask {
-            id: "t".to_string(),
-            name: "T".to_string(),
-            stored_prompt_id: "p".to_string(),
-            expected_outcome: "o".to_string(),
-            created_at: now,
-            updated_at: now,
-        };
+        let task = test_task("t", "T");
         let mut result = AutomationRunResult::started(&task, PathBuf::from("/w"));
         result.fail(
             AutomationRunErrorCategory::Execution,
@@ -677,15 +660,7 @@ mod tests {
 
     #[test]
     fn run_result_cancel_and_timeout() {
-        let now = Utc::now();
-        let task = AutomationTask {
-            id: "t".to_string(),
-            name: "T".to_string(),
-            stored_prompt_id: "p".to_string(),
-            expected_outcome: "o".to_string(),
-            created_at: now,
-            updated_at: now,
-        };
+        let task = test_task("t", "T");
 
         let mut r1 = AutomationRunResult::started(&task, PathBuf::from("/w"));
         r1.cancel("SIGINT".to_string());
@@ -706,15 +681,7 @@ mod tests {
 
     #[test]
     fn run_result_serializes_to_json() {
-        let now = Utc::now();
-        let task = AutomationTask {
-            id: "t".to_string(),
-            name: "T".to_string(),
-            stored_prompt_id: "p".to_string(),
-            expected_outcome: "o".to_string(),
-            created_at: now,
-            updated_at: now,
-        };
+        let task = test_task("t", "T");
         let mut result = AutomationRunResult::started(&task, PathBuf::from("/w"));
         result.complete("done".to_string());
         result.set_resolved_metadata(
@@ -746,7 +713,6 @@ mod tests {
             "task not found".to_string(),
         );
         let json = serde_json::to_string(&result).unwrap();
-        // provider, model, and error must be present (not omitted) even when null
         assert!(
             json.contains("\"provider\":null"),
             "provider should be null, got: {}",
@@ -761,15 +727,7 @@ mod tests {
 
     #[test]
     fn json_includes_null_error_for_completed_run() {
-        let now = Utc::now();
-        let task = AutomationTask {
-            id: "t".to_string(),
-            name: "T".to_string(),
-            stored_prompt_id: "p".to_string(),
-            expected_outcome: "o".to_string(),
-            created_at: now,
-            updated_at: now,
-        };
+        let task = test_task("t", "T");
         let mut result = AutomationRunResult::started(&task, PathBuf::from("/w"));
         result.complete("done".to_string());
         let json = serde_json::to_string(&result).unwrap();
@@ -784,8 +742,8 @@ mod tests {
 
     async fn setup_store_with_task_and_prompt() -> ConfigStore {
         let store = ConfigStore::open_in_memory().await.unwrap();
+        let temp = tempfile::tempdir().unwrap();
 
-        // Register a prompt.
         let prompt = StoredPrompt {
             instructions: "Generate a daily report".to_string(),
             skills: Vec::new(),
@@ -801,13 +759,14 @@ mod tests {
             .await
             .unwrap();
 
-        // Register a task referencing the prompt.
         store
             .set_automation_task(&AutomationTaskInput {
                 id: "daily-report".to_string(),
-                name: "Daily Report".to_string(),
+                display_name: "Daily Report".to_string(),
                 stored_prompt_id: "report-prompt".to_string(),
                 expected_outcome: "A summary of today's activity".to_string(),
+                project_root: temp.path().to_path_buf(),
+                timeout_seconds: 300,
             })
             .await
             .unwrap();
@@ -829,10 +788,15 @@ mod tests {
         let store = setup_store_with_task_and_prompt().await;
         let reg = default_registry();
 
-        let input =
-            resolve_task_execution(&store, &reg, "daily-report", PathBuf::from("/workspace"))
-                .await
-                .unwrap();
+        let input = resolve_task_execution(
+            &store,
+            &reg,
+            "daily-report",
+            PathBuf::from("/workspace"),
+            TEST_TIMEOUT,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(input.task.id, "daily-report");
         assert_eq!(input.task.expected_outcome, "A summary of today's activity");
@@ -843,6 +807,7 @@ mod tests {
             "Generate a daily report\n\nA summary of today's activity"
         );
         assert_eq!(input.workspace, PathBuf::from("/workspace"));
+        assert_eq!(input.timeout, TEST_TIMEOUT);
     }
 
     #[tokio::test]
@@ -850,7 +815,9 @@ mod tests {
         let store = setup_store_with_task_and_prompt().await;
         let reg = default_registry();
 
-        let result = resolve_task_execution(&store, &reg, "missing", PathBuf::from("/w")).await;
+        let result =
+            resolve_task_execution(&store, &reg, "missing", PathBuf::from("/w"), TEST_TIMEOUT)
+                .await;
         assert!(matches!(result, Err(ResolutionError::TaskNotFound(_))));
     }
 
@@ -858,15 +825,14 @@ mod tests {
     async fn resolve_task_execution_prompt_not_found() {
         let store = ConfigStore::open_in_memory().await.unwrap();
 
-        // Creating a task referencing a nonexistent prompt is rejected at
-        // write time, so the resolver's PromptNotFound can only occur from
-        // manual DB tampering. Verify the write-time guard works.
         let result = store
             .set_automation_task(&AutomationTaskInput {
                 id: "orphan-task".to_string(),
-                name: "Orphan".to_string(),
+                display_name: "Orphan".to_string(),
                 stored_prompt_id: "nonexistent".to_string(),
                 expected_outcome: "nothing".to_string(),
+                project_root: std::env::temp_dir(),
+                timeout_seconds: 300,
             })
             .await;
 
@@ -883,7 +849,8 @@ mod tests {
         let reg: HashMap<AgentProfileId, AgentProfile> = HashMap::new();
 
         let result =
-            resolve_task_execution(&store, &reg, "daily-report", PathBuf::from("/w")).await;
+            resolve_task_execution(&store, &reg, "daily-report", PathBuf::from("/w"), TEST_TIMEOUT)
+                .await;
         assert!(matches!(result, Err(ResolutionError::ProfileNotFound(_))));
     }
 
@@ -892,40 +859,51 @@ mod tests {
         let store = setup_store_with_task_and_prompt().await;
         let reg = default_registry();
 
-        // Resolve.
-        let input1 = resolve_task_execution(&store, &reg, "daily-report", PathBuf::from("/w"))
-            .await
-            .unwrap();
+        let input1 = resolve_task_execution(
+            &store,
+            &reg,
+            "daily-report",
+            PathBuf::from("/w"),
+            TEST_TIMEOUT,
+        )
+        .await
+        .unwrap();
 
-        // Update the task's expected outcome.
+        let temp = tempfile::tempdir().unwrap();
         store
             .set_automation_task(&AutomationTaskInput {
                 id: "daily-report".to_string(),
-                name: "Daily Report".to_string(),
+                display_name: "Daily Report".to_string(),
                 stored_prompt_id: "report-prompt".to_string(),
                 expected_outcome: "Updated outcome".to_string(),
+                project_root: temp.path().to_path_buf(),
+                timeout_seconds: 300,
             })
             .await
             .unwrap();
 
-        // Original snapshot is unchanged.
         assert_eq!(
             input1.task.expected_outcome,
             "A summary of today's activity"
         );
 
-        // New resolution sees the update.
-        let input2 = resolve_task_execution(&store, &reg, "daily-report", PathBuf::from("/w"))
-            .await
-            .unwrap();
+        let input2 = resolve_task_execution(
+            &store,
+            &reg,
+            "daily-report",
+            PathBuf::from("/w"),
+            TEST_TIMEOUT,
+        )
+        .await
+        .unwrap();
         assert_eq!(input2.task.expected_outcome, "Updated outcome");
     }
 
     #[tokio::test]
     async fn resolve_task_execution_with_explicit_profile() {
         let store = ConfigStore::open_in_memory().await.unwrap();
+        let temp = tempfile::tempdir().unwrap();
 
-        // Register a prompt with an explicit profile.
         let prompt = StoredPrompt {
             instructions: "Do work".to_string(),
             skills: Vec::new(),
@@ -944,9 +922,11 @@ mod tests {
         store
             .set_automation_task(&AutomationTaskInput {
                 id: "work-task".to_string(),
-                name: "Work".to_string(),
+                display_name: "Work".to_string(),
                 stored_prompt_id: "work-prompt".to_string(),
                 expected_outcome: "Work done".to_string(),
+                project_root: temp.path().to_path_buf(),
+                timeout_seconds: 300,
             })
             .await
             .unwrap();
@@ -961,9 +941,10 @@ mod tests {
             },
         );
 
-        let input = resolve_task_execution(&store, &reg, "work-task", PathBuf::from("/w"))
-            .await
-            .unwrap();
+        let input =
+            resolve_task_execution(&store, &reg, "work-task", PathBuf::from("/w"), TEST_TIMEOUT)
+                .await
+                .unwrap();
 
         assert_eq!(input.profile_id, AgentProfileId::from("automation"));
         assert_eq!(input.profile.approval, AgentApproval::AutoApprove);

--- a/src/headless/mod.rs
+++ b/src/headless/mod.rs
@@ -946,9 +946,14 @@ mod tests {
         let store = setup_complete_store().await;
         let workspace = std::env::temp_dir();
 
-        let runtime = bootstrap_headless(store, "daily-report", workspace.clone(), std::time::Duration::from_secs(300))
-            .await
-            .expect("bootstrap should succeed");
+        let runtime = bootstrap_headless(
+            store,
+            "daily-report",
+            workspace.clone(),
+            std::time::Duration::from_secs(300),
+        )
+        .await
+        .expect("bootstrap should succeed");
 
         assert_eq!(runtime.provider_slug, "openai");
         assert_eq!(runtime.model, "gpt-4o");
@@ -970,7 +975,13 @@ mod tests {
     async fn bootstrap_missing_default_provider() {
         let store = ConfigStore::open_in_memory().await.unwrap();
 
-        let result = bootstrap_headless(store, "any-task", std::env::temp_dir(), std::time::Duration::from_secs(300)).await;
+        let result = bootstrap_headless(
+            store,
+            "any-task",
+            std::env::temp_dir(),
+            std::time::Duration::from_secs(300),
+        )
+        .await;
         assert!(matches!(
             result,
             Err(HeadlessBootstrapError::MissingDefaultProvider)
@@ -988,7 +999,13 @@ mod tests {
             .await
             .unwrap();
 
-        let result = bootstrap_headless(store, "any-task", std::env::temp_dir(), std::time::Duration::from_secs(300)).await;
+        let result = bootstrap_headless(
+            store,
+            "any-task",
+            std::env::temp_dir(),
+            std::time::Duration::from_secs(300),
+        )
+        .await;
         assert!(matches!(
             result,
             Err(HeadlessBootstrapError::CredentialFailure { .. })
@@ -1017,7 +1034,13 @@ mod tests {
             .await
             .unwrap();
 
-        let result = bootstrap_headless(store, "daily-report", std::env::temp_dir(), std::time::Duration::from_secs(300)).await;
+        let result = bootstrap_headless(
+            store,
+            "daily-report",
+            std::env::temp_dir(),
+            std::time::Duration::from_secs(300),
+        )
+        .await;
         assert!(matches!(
             result,
             Err(HeadlessBootstrapError::UnsafePolicy(_))
@@ -1072,7 +1095,13 @@ mod tests {
             .await
             .unwrap();
 
-        let result = bootstrap_headless(store, "t1", std::env::temp_dir(), std::time::Duration::from_secs(300)).await;
+        let result = bootstrap_headless(
+            store,
+            "t1",
+            std::env::temp_dir(),
+            std::time::Duration::from_secs(300),
+        )
+        .await;
         assert!(matches!(
             result,
             Err(HeadlessBootstrapError::UnsafePolicy(_))
@@ -1082,7 +1111,13 @@ mod tests {
     #[tokio::test]
     async fn bootstrap_task_not_found() {
         let store = setup_complete_store().await;
-        let result = bootstrap_headless(store, "nonexistent", std::env::temp_dir(), std::time::Duration::from_secs(300)).await;
+        let result = bootstrap_headless(
+            store,
+            "nonexistent",
+            std::env::temp_dir(),
+            std::time::Duration::from_secs(300),
+        )
+        .await;
         assert!(matches!(
             result,
             Err(HeadlessBootstrapError::Resolution(
@@ -1117,9 +1152,14 @@ mod tests {
             .unwrap();
 
         // Bootstrap succeeds — tool check is deferred to run_automation.
-        let runtime = bootstrap_headless(store, "daily-report", std::env::temp_dir(), std::time::Duration::from_secs(300))
-            .await
-            .expect("bootstrap should succeed (tool check deferred)");
+        let runtime = bootstrap_headless(
+            store,
+            "daily-report",
+            std::env::temp_dir(),
+            std::time::Duration::from_secs(300),
+        )
+        .await
+        .expect("bootstrap should succeed (tool check deferred)");
 
         let result = run_automation(
             runtime,
@@ -1156,9 +1196,14 @@ mod tests {
             .await
             .unwrap();
 
-        let runtime = bootstrap_headless(store, "daily-report", std::env::temp_dir(), std::time::Duration::from_secs(300))
-            .await
-            .expect("bootstrap should succeed with MCP");
+        let runtime = bootstrap_headless(
+            store,
+            "daily-report",
+            std::env::temp_dir(),
+            std::time::Duration::from_secs(300),
+        )
+        .await
+        .expect("bootstrap should succeed with MCP");
 
         // MCP server is registered in the runtime.
         let mcp_registry = runtime.agent.mcp_registry();
@@ -1181,9 +1226,14 @@ mod tests {
             .await
             .unwrap();
 
-        let runtime = bootstrap_headless(store, "daily-report", std::env::temp_dir(), std::time::Duration::from_secs(300))
-            .await
-            .expect("bootstrap should succeed");
+        let runtime = bootstrap_headless(
+            store,
+            "daily-report",
+            std::env::temp_dir(),
+            std::time::Duration::from_secs(300),
+        )
+        .await
+        .expect("bootstrap should succeed");
 
         // Verify skill catalog was refreshed with workspace roots (not empty
         // would be fine too, just verify it didn't crash).
@@ -1215,9 +1265,14 @@ mod tests {
             .await
             .unwrap();
 
-        let runtime = bootstrap_headless(store, "daily-report", std::env::temp_dir(), std::time::Duration::from_secs(300))
-            .await
-            .expect("bootstrap should succeed");
+        let runtime = bootstrap_headless(
+            store,
+            "daily-report",
+            std::env::temp_dir(),
+            std::time::Duration::from_secs(300),
+        )
+        .await
+        .expect("bootstrap should succeed");
 
         // Provider/model must come from the Managed profile, not the saved default.
         assert_eq!(runtime.provider_slug, "openai");
@@ -1227,9 +1282,14 @@ mod tests {
     #[tokio::test]
     async fn bootstrap_plugin_exclusion_no_plugin_tools() {
         let store = setup_complete_store().await;
-        let runtime = bootstrap_headless(store, "daily-report", std::env::temp_dir(), std::time::Duration::from_secs(300))
-            .await
-            .expect("bootstrap should succeed");
+        let runtime = bootstrap_headless(
+            store,
+            "daily-report",
+            std::env::temp_dir(),
+            std::time::Duration::from_secs(300),
+        )
+        .await
+        .expect("bootstrap should succeed");
 
         // Verify no plugin namespaced tools are in the base tool registry.
         // Plugins are never registered during headless bootstrap.
@@ -1416,9 +1476,15 @@ mod tests {
             .into_iter()
             .map(|e| (e.id, e.profile))
             .collect();
-        let resolved = resolve_task_execution(&store, &profiles, "test-task", workspace, std::time::Duration::from_secs(300))
-            .await
-            .unwrap();
+        let resolved = resolve_task_execution(
+            &store,
+            &profiles,
+            "test-task",
+            workspace,
+            std::time::Duration::from_secs(300),
+        )
+        .await
+        .unwrap();
 
         let tool_names: Vec<String> = agent
             .runtime()

--- a/src/headless/mod.rs
+++ b/src/headless/mod.rs
@@ -149,6 +149,7 @@ pub async fn bootstrap_headless(
     store: ConfigStore,
     task_id: &str,
     workspace: PathBuf,
+    timeout: std::time::Duration,
 ) -> Result<HeadlessRuntime, HeadlessBootstrapError> {
     // 1. Load persisted settings.
     let settings = store.load_runtime_settings().await?;
@@ -207,7 +208,7 @@ pub async fn bootstrap_headless(
         .collect();
 
     // 10. Resolve the automation task.
-    let resolved = resolve_task_execution(&store, &profiles, task_id, workspace).await?;
+    let resolved = resolve_task_execution(&store, &profiles, task_id, workspace, timeout).await?;
 
     // 11. Preflight: approval check only. Tool availability is checked in
     //     run_automation after session creation so MCP tools are included.
@@ -660,9 +661,12 @@ mod tests {
         let now = chrono::Utc::now();
         let task = crate::automation_task::AutomationTask {
             id: "test".to_string(),
-            name: "Test".to_string(),
+            display_name: "Test".to_string(),
+            normalized_name: "test".to_string(),
             stored_prompt_id: "p".to_string(),
             expected_outcome: "done".to_string(),
+            project_root: PathBuf::from("/tmp"),
+            timeout_seconds: 60,
             created_at: now,
             updated_at: now,
         };
@@ -687,6 +691,7 @@ mod tests {
             user_goal: "do\n\ndone".to_string(),
             effective_skills: Vec::new(),
             workspace: PathBuf::from("/tmp"),
+            timeout: std::time::Duration::from_secs(60),
             resolved_at: now,
         }
     }
@@ -924,9 +929,11 @@ mod tests {
         store
             .set_automation_task(&AutomationTaskInput {
                 id: "daily-report".to_string(),
-                name: "Daily Report".to_string(),
+                display_name: "Daily Report".to_string(),
                 stored_prompt_id: "report-prompt".to_string(),
                 expected_outcome: "A summary of today's activity".to_string(),
+                project_root: std::env::temp_dir(),
+                timeout_seconds: 300,
             })
             .await
             .unwrap();
@@ -939,7 +946,7 @@ mod tests {
         let store = setup_complete_store().await;
         let workspace = std::env::temp_dir();
 
-        let runtime = bootstrap_headless(store, "daily-report", workspace.clone())
+        let runtime = bootstrap_headless(store, "daily-report", workspace.clone(), std::time::Duration::from_secs(300))
             .await
             .expect("bootstrap should succeed");
 
@@ -963,7 +970,7 @@ mod tests {
     async fn bootstrap_missing_default_provider() {
         let store = ConfigStore::open_in_memory().await.unwrap();
 
-        let result = bootstrap_headless(store, "any-task", std::env::temp_dir()).await;
+        let result = bootstrap_headless(store, "any-task", std::env::temp_dir(), std::time::Duration::from_secs(300)).await;
         assert!(matches!(
             result,
             Err(HeadlessBootstrapError::MissingDefaultProvider)
@@ -981,7 +988,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = bootstrap_headless(store, "any-task", std::env::temp_dir()).await;
+        let result = bootstrap_headless(store, "any-task", std::env::temp_dir(), std::time::Duration::from_secs(300)).await;
         assert!(matches!(
             result,
             Err(HeadlessBootstrapError::CredentialFailure { .. })
@@ -1010,7 +1017,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = bootstrap_headless(store, "daily-report", std::env::temp_dir()).await;
+        let result = bootstrap_headless(store, "daily-report", std::env::temp_dir(), std::time::Duration::from_secs(300)).await;
         assert!(matches!(
             result,
             Err(HeadlessBootstrapError::UnsafePolicy(_))
@@ -1056,14 +1063,16 @@ mod tests {
         store
             .set_automation_task(&AutomationTaskInput {
                 id: "t1".to_string(),
-                name: "T1".to_string(),
+                display_name: "T1".to_string(),
                 stored_prompt_id: "p1".to_string(),
                 expected_outcome: "done".to_string(),
+                project_root: std::env::temp_dir(),
+                timeout_seconds: 300,
             })
             .await
             .unwrap();
 
-        let result = bootstrap_headless(store, "t1", std::env::temp_dir()).await;
+        let result = bootstrap_headless(store, "t1", std::env::temp_dir(), std::time::Duration::from_secs(300)).await;
         assert!(matches!(
             result,
             Err(HeadlessBootstrapError::UnsafePolicy(_))
@@ -1073,7 +1082,7 @@ mod tests {
     #[tokio::test]
     async fn bootstrap_task_not_found() {
         let store = setup_complete_store().await;
-        let result = bootstrap_headless(store, "nonexistent", std::env::temp_dir()).await;
+        let result = bootstrap_headless(store, "nonexistent", std::env::temp_dir(), std::time::Duration::from_secs(300)).await;
         assert!(matches!(
             result,
             Err(HeadlessBootstrapError::Resolution(
@@ -1108,7 +1117,7 @@ mod tests {
             .unwrap();
 
         // Bootstrap succeeds — tool check is deferred to run_automation.
-        let runtime = bootstrap_headless(store, "daily-report", std::env::temp_dir())
+        let runtime = bootstrap_headless(store, "daily-report", std::env::temp_dir(), std::time::Duration::from_secs(300))
             .await
             .expect("bootstrap should succeed (tool check deferred)");
 
@@ -1147,7 +1156,7 @@ mod tests {
             .await
             .unwrap();
 
-        let runtime = bootstrap_headless(store, "daily-report", std::env::temp_dir())
+        let runtime = bootstrap_headless(store, "daily-report", std::env::temp_dir(), std::time::Duration::from_secs(300))
             .await
             .expect("bootstrap should succeed with MCP");
 
@@ -1172,7 +1181,7 @@ mod tests {
             .await
             .unwrap();
 
-        let runtime = bootstrap_headless(store, "daily-report", std::env::temp_dir())
+        let runtime = bootstrap_headless(store, "daily-report", std::env::temp_dir(), std::time::Duration::from_secs(300))
             .await
             .expect("bootstrap should succeed");
 
@@ -1206,7 +1215,7 @@ mod tests {
             .await
             .unwrap();
 
-        let runtime = bootstrap_headless(store, "daily-report", std::env::temp_dir())
+        let runtime = bootstrap_headless(store, "daily-report", std::env::temp_dir(), std::time::Duration::from_secs(300))
             .await
             .expect("bootstrap should succeed");
 
@@ -1218,7 +1227,7 @@ mod tests {
     #[tokio::test]
     async fn bootstrap_plugin_exclusion_no_plugin_tools() {
         let store = setup_complete_store().await;
-        let runtime = bootstrap_headless(store, "daily-report", std::env::temp_dir())
+        let runtime = bootstrap_headless(store, "daily-report", std::env::temp_dir(), std::time::Duration::from_secs(300))
             .await
             .expect("bootstrap should succeed");
 
@@ -1369,9 +1378,11 @@ mod tests {
         store
             .set_automation_task(&AutomationTaskInput {
                 id: "test-task".to_string(),
-                name: "Test Task".to_string(),
+                display_name: "Test Task".to_string(),
                 stored_prompt_id: "test-prompt".to_string(),
                 expected_outcome: "A summary of activity".to_string(),
+                project_root: workspace.clone(),
+                timeout_seconds: 300,
             })
             .await
             .unwrap();
@@ -1405,7 +1416,7 @@ mod tests {
             .into_iter()
             .map(|e| (e.id, e.profile))
             .collect();
-        let resolved = resolve_task_execution(&store, &profiles, "test-task", workspace)
+        let resolved = resolve_task_execution(&store, &profiles, "test-task", workspace, std::time::Duration::from_secs(300))
             .await
             .unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,7 +162,6 @@
 //! [`Tool`] implementations must not block the orchestration runtime.
 
 pub mod automation_task;
-pub mod scheduled_task;
 pub mod builtin;
 pub mod capability;
 pub mod cli;
@@ -189,6 +188,7 @@ pub mod provider_credential;
 pub mod provider_profile;
 pub mod request_builder;
 pub mod runtime;
+pub mod scheduled_task;
 pub mod schema;
 pub mod skill;
 pub mod stored_prompt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,6 +162,7 @@
 //! [`Tool`] implementations must not block the orchestration runtime.
 
 pub mod automation_task;
+pub mod scheduled_task;
 pub mod builtin;
 pub mod capability;
 pub mod cli;

--- a/src/scheduled_task/cron.rs
+++ b/src/scheduled_task/cron.rs
@@ -1,0 +1,443 @@
+//! Numeric five-field cron expression parsing and validation.
+//!
+//! Supports the common cron subset:
+//! - Five fields: minute, hour, day-of-month, month, day-of-week
+//! - Wildcard (`*`)
+//! - Single numeric values
+//! - Numeric ranges (`1-5`)
+//! - Numeric lists (`1,3,5`)
+//! - Steps (`*/15`, `1-10/2`)
+//!
+//! Rejected: seconds, macros (`@daily`), named months/weekdays, non-cron kinds.
+
+use std::fmt;
+
+// ============================================================================
+// Field bounds
+// ============================================================================
+
+struct FieldBounds {
+    min: u32,
+    max: u32,
+    label: &'static str,
+}
+
+const MINUTE: FieldBounds = FieldBounds {
+    min: 0,
+    max: 59,
+    label: "minute",
+};
+const HOUR: FieldBounds = FieldBounds {
+    min: 0,
+    max: 23,
+    label: "hour",
+};
+const DAY_OF_MONTH: FieldBounds = FieldBounds {
+    min: 1,
+    max: 31,
+    label: "day-of-month",
+};
+const MONTH: FieldBounds = FieldBounds {
+    min: 1,
+    max: 12,
+    label: "month",
+};
+const DAY_OF_WEEK: FieldBounds = FieldBounds {
+    min: 0,
+    max: 6,
+    label: "day-of-week",
+};
+
+// ============================================================================
+// Cron expression
+// ============================================================================
+
+/// A parsed and validated five-field cron expression.
+///
+/// Stores the set of matching values for each field. Wildcard fields match
+/// every value in their valid range.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CronExpression {
+    minute: Vec<u32>,
+    hour: Vec<u32>,
+    day_of_month: Vec<u32>,
+    month: Vec<u32>,
+    day_of_week: Vec<u32>,
+    /// Original normalized text form.
+    text: String,
+}
+
+impl CronExpression {
+    /// Parse and validate a five-field cron expression.
+    ///
+    /// Returns `Err` with a human-readable message for unsupported syntax,
+    /// out-of-bounds values, zero steps, or malformed input.
+    pub fn parse(input: &str) -> Result<Self, String> {
+        let trimmed = input.trim();
+        if trimmed.is_empty() {
+            return Err("cron expression must not be empty".to_string());
+        }
+
+        // Reject macros, named entries, and extra fields.
+        if trimmed.starts_with('@') {
+            return Err(format!(
+                "cron macros like '{}' are not supported; use five-field numeric syntax",
+                trimmed
+            ));
+        }
+
+        let fields: Vec<&str> = trimmed.split_whitespace().collect();
+        if fields.len() != 5 {
+            return Err(format!(
+                "cron expression must have exactly 5 fields, got {}: '{}'",
+                fields.len(),
+                trimmed
+            ));
+        }
+
+        let minute = parse_field(fields[0], &MINUTE)?;
+        let hour = parse_field(fields[1], &HOUR)?;
+        let day_of_month = parse_field(fields[2], &DAY_OF_MONTH)?;
+        let month = parse_field(fields[3], &MONTH)?;
+        let day_of_week = parse_field(fields[4], &DAY_OF_WEEK)?;
+
+        // Reject named months/weekdays by checking for letters.
+        for (idx, field) in fields.iter().enumerate() {
+            if field.chars().any(|c| c.is_ascii_alphabetic()) {
+                let labels = ["minute", "hour", "day-of-month", "month", "day-of-week"];
+                return Err(format!(
+                    "cron {} field '{}' contains unsupported named values; use numeric syntax",
+                    labels[idx], field
+                ));
+            }
+        }
+
+        let text = trimmed.to_string();
+
+        Ok(Self {
+            minute,
+            hour,
+            day_of_month,
+            month,
+            day_of_week,
+            text,
+        })
+    }
+
+    /// The original normalized text form.
+    pub fn as_str(&self) -> &str {
+        &self.text
+    }
+
+    /// Matching minute values (sorted).
+    pub fn minutes(&self) -> &[u32] {
+        &self.minute
+    }
+
+    /// Matching hour values (sorted).
+    pub fn hours(&self) -> &[u32] {
+        &self.hour
+    }
+
+    /// Matching day-of-month values (sorted).
+    pub fn days_of_month(&self) -> &[u32] {
+        &self.day_of_month
+    }
+
+    /// Matching month values (sorted).
+    pub fn months(&self) -> &[u32] {
+        &self.month
+    }
+
+    /// Matching day-of-week values (sorted).
+    pub fn days_of_week(&self) -> &[u32] {
+        &self.day_of_week
+    }
+}
+
+impl fmt::Display for CronExpression {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.text)
+    }
+}
+
+// ============================================================================
+// Field parsing
+// ============================================================================
+
+/// Parse a single cron field into a sorted list of matching values.
+fn parse_field(input: &str, bounds: &FieldBounds) -> Result<Vec<u32>, String> {
+    let mut values = Vec::new();
+
+    for item in input.split(',') {
+        let parsed = parse_item(item.trim(), bounds)?;
+        values.extend(parsed);
+    }
+
+    values.sort_unstable();
+    values.dedup();
+
+    Ok(values)
+}
+
+/// Parse a single comma-separated item (e.g., `*`, `5`, `1-5`, `*/15`, `1-10/2`).
+fn parse_item(input: &str, bounds: &FieldBounds) -> Result<Vec<u32>, String> {
+    if input.is_empty() {
+        return Err(format!("cron {} field contains an empty list item", bounds.label));
+    }
+
+    let (base, step) = match input.find('/') {
+        Some(pos) => {
+            let step_str = &input[pos + 1..];
+            let step: u32 = step_str
+                .parse()
+                .map_err(|_| format!("cron {} step '{}' is not a number", bounds.label, step_str))?;
+            if step == 0 {
+                return Err(format!("cron {} step must be greater than zero", bounds.label));
+            }
+            (&input[..pos], Some(step))
+        }
+        None => (input, None),
+    };
+
+    let range_values = parse_base(base, bounds)?;
+
+    match step {
+        Some(s) => {
+            let first = range_values.first().copied().unwrap_or(0);
+            Ok(range_values
+                .into_iter()
+                .filter(|v| (*v - first) % s == 0)
+                .collect())
+        }
+        None => Ok(range_values),
+    }
+}
+
+/// Parse the base of an item (before any `/step`): `*`, `N`, or `N-M`.
+fn parse_base(base: &str, bounds: &FieldBounds) -> Result<Vec<u32>, String> {
+    if base == "*" {
+        return Ok((bounds.min..=bounds.max).collect());
+    }
+
+    if let Some(dash_pos) = base.find('-') {
+        let lo_str = &base[..dash_pos];
+        let hi_str = &base[dash_pos + 1..];
+        let lo: u32 = lo_str
+            .parse()
+            .map_err(|_| format!("cron {} range lower bound '{}' is not a number", bounds.label, lo_str))?;
+        let hi: u32 = hi_str
+            .parse()
+            .map_err(|_| format!("cron {} range upper bound '{}' is not a number", bounds.label, hi_str))?;
+
+        if lo < bounds.min || lo > bounds.max {
+            return Err(format!(
+                "cron {} value {} is out of bounds ({}-{})",
+                bounds.label, lo, bounds.min, bounds.max
+            ));
+        }
+        if hi < bounds.min || hi > bounds.max {
+            return Err(format!(
+                "cron {} value {} is out of bounds ({}-{})",
+                bounds.label, hi, bounds.min, bounds.max
+            ));
+        }
+        if hi < lo {
+            return Err(format!(
+                "cron {} range {}-{} is descending",
+                bounds.label, lo, hi
+            ));
+        }
+
+        return Ok((lo..=hi).collect());
+    }
+
+    // Single value
+    let val: u32 = base
+        .parse()
+        .map_err(|_| format!("cron {} value '{}' is not a number", bounds.label, base))?;
+
+    if val < bounds.min || val > bounds.max {
+        return Err(format!(
+            "cron {} value {} is out of bounds ({}-{})",
+            bounds.label, val, bounds.min, bounds.max
+        ));
+    }
+
+    Ok(vec![val])
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---- Basic parsing ----
+
+    #[test]
+    fn wildcard_all_fields() {
+        let cron = CronExpression::parse("* * * * *").unwrap();
+        assert_eq!(cron.minutes().len(), 60);
+        assert_eq!(cron.hours().len(), 24);
+        assert_eq!(cron.days_of_month().len(), 31);
+        assert_eq!(cron.months().len(), 12);
+        assert_eq!(cron.days_of_week().len(), 7);
+    }
+
+    #[test]
+    fn single_values() {
+        let cron = CronExpression::parse("5 9 1 3 0").unwrap();
+        assert_eq!(cron.minutes(), &[5]);
+        assert_eq!(cron.hours(), &[9]);
+        assert_eq!(cron.days_of_month(), &[1]);
+        assert_eq!(cron.months(), &[3]);
+        assert_eq!(cron.days_of_week(), &[0]);
+    }
+
+    #[test]
+    fn ranges() {
+        let cron = CronExpression::parse("1-5 0-23 1-10 1-6 0-4").unwrap();
+        assert_eq!(cron.minutes(), &[1, 2, 3, 4, 5]);
+        assert_eq!(cron.hours(), &(0..=23).collect::<Vec<_>>());
+        assert_eq!(cron.days_of_month(), &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        assert_eq!(cron.months(), &[1, 2, 3, 4, 5, 6]);
+        assert_eq!(cron.days_of_week(), &[0, 1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn lists() {
+        let cron = CronExpression::parse("1,3,5 0,12 1,15 1,6,12 1,3,5").unwrap();
+        assert_eq!(cron.minutes(), &[1, 3, 5]);
+        assert_eq!(cron.hours(), &[0, 12]);
+        assert_eq!(cron.days_of_month(), &[1, 15]);
+        assert_eq!(cron.months(), &[1, 6, 12]);
+        assert_eq!(cron.days_of_week(), &[1, 3, 5]);
+    }
+
+    #[test]
+    fn wildcard_step() {
+        let cron = CronExpression::parse("*/15 * * * *").unwrap();
+        assert_eq!(cron.minutes(), &[0, 15, 30, 45]);
+    }
+
+    #[test]
+    fn range_step() {
+        let cron = CronExpression::parse("1-10/2 * * * *").unwrap();
+        assert_eq!(cron.minutes(), &[1, 3, 5, 7, 9]);
+    }
+
+    #[test]
+    fn complex_expression() {
+        let cron = CronExpression::parse("*/15 9-17/2 * 1,6,12 1-5").unwrap();
+        assert_eq!(cron.minutes(), &[0, 15, 30, 45]);
+        assert_eq!(cron.hours(), &[9, 11, 13, 15, 17]);
+        assert_eq!(cron.months(), &[1, 6, 12]);
+        assert_eq!(cron.days_of_week(), &[1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn list_deduplicates() {
+        let cron = CronExpression::parse("5,5,1-3,2 * * * *").unwrap();
+        assert_eq!(cron.minutes(), &[1, 2, 3, 5]);
+    }
+
+    // ---- Edge cases ----
+
+    #[test]
+    fn max_values() {
+        let cron = CronExpression::parse("59 23 31 12 6").unwrap();
+        assert_eq!(cron.minutes(), &[59]);
+        assert_eq!(cron.hours(), &[23]);
+        assert_eq!(cron.days_of_month(), &[31]);
+        assert_eq!(cron.months(), &[12]);
+        assert_eq!(cron.days_of_week(), &[6]);
+    }
+
+    #[test]
+    fn step_one_full_range() {
+        let cron = CronExpression::parse("*/1 * * * *").unwrap();
+        assert_eq!(cron.minutes().len(), 60);
+    }
+
+    #[test]
+    fn whitespace_trimmed() {
+        let cron = CronExpression::parse("  */15   *   *   *   *  ").unwrap();
+        assert_eq!(cron.as_str(), "*/15   *   *   *   *");
+        assert_eq!(cron.minutes(), &[0, 15, 30, 45]);
+    }
+
+    // ---- Rejections ----
+
+    #[test]
+    fn empty_rejected() {
+        assert!(CronExpression::parse("").is_err());
+        assert!(CronExpression::parse("   ").is_err());
+    }
+
+    #[test]
+    fn macro_rejected() {
+        assert!(CronExpression::parse("@daily").is_err());
+        assert!(CronExpression::parse("@hourly").is_err());
+        assert!(CronExpression::parse("@reboot").is_err());
+    }
+
+    #[test]
+    fn named_values_rejected() {
+        assert!(CronExpression::parse("0 0 * JAN MON").is_err());
+        assert!(CronExpression::parse("0 0 * * MON-FRI").is_err());
+    }
+
+    #[test]
+    fn too_few_fields_rejected() {
+        assert!(CronExpression::parse("* * * *").is_err());
+        assert!(CronExpression::parse("* *").is_err());
+    }
+
+    #[test]
+    fn too_many_fields_rejected() {
+        assert!(CronExpression::parse("* * * * * *").is_err());
+        assert!(CronExpression::parse("0 0 * * * 30").is_err());
+    }
+
+    #[test]
+    fn out_of_bounds_rejected() {
+        assert!(CronExpression::parse("60 * * * *").is_err());
+        assert!(CronExpression::parse("* 24 * * *").is_err());
+        assert!(CronExpression::parse("* * 0 * *").is_err());
+        assert!(CronExpression::parse("* * 32 * *").is_err());
+        assert!(CronExpression::parse("* * * 13 *").is_err());
+        assert!(CronExpression::parse("* * * * 7").is_err());
+    }
+
+    #[test]
+    fn zero_step_rejected() {
+        assert!(CronExpression::parse("*/0 * * * *").is_err());
+        assert!(CronExpression::parse("1-10/0 * * * *").is_err());
+    }
+
+    #[test]
+    fn descending_range_rejected() {
+        assert!(CronExpression::parse("5-1 * * * *").is_err());
+    }
+
+    #[test]
+    fn empty_list_item_rejected() {
+        assert!(CronExpression::parse("1,,3 * * * *").is_err());
+        assert!(CronExpression::parse(",1 * * * *").is_err());
+    }
+
+    #[test]
+    fn non_numeric_rejected() {
+        assert!(CronExpression::parse("abc * * * *").is_err());
+        assert!(CronExpression::parse("* * * * xyz").is_err());
+    }
+
+    #[test]
+    fn display_preserves_normalized_form() {
+        let cron = CronExpression::parse("*/15 9 * * 1-5").unwrap();
+        assert_eq!(cron.to_string(), "*/15 9 * * 1-5");
+    }
+}

--- a/src/scheduled_task/cron.rs
+++ b/src/scheduled_task/cron.rs
@@ -183,17 +183,23 @@ fn parse_field(input: &str, bounds: &FieldBounds) -> Result<Vec<u32>, String> {
 /// Parse a single comma-separated item (e.g., `*`, `5`, `1-5`, `*/15`, `1-10/2`).
 fn parse_item(input: &str, bounds: &FieldBounds) -> Result<Vec<u32>, String> {
     if input.is_empty() {
-        return Err(format!("cron {} field contains an empty list item", bounds.label));
+        return Err(format!(
+            "cron {} field contains an empty list item",
+            bounds.label
+        ));
     }
 
     let (base, step) = match input.find('/') {
         Some(pos) => {
             let step_str = &input[pos + 1..];
-            let step: u32 = step_str
-                .parse()
-                .map_err(|_| format!("cron {} step '{}' is not a number", bounds.label, step_str))?;
+            let step: u32 = step_str.parse().map_err(|_| {
+                format!("cron {} step '{}' is not a number", bounds.label, step_str)
+            })?;
             if step == 0 {
-                return Err(format!("cron {} step must be greater than zero", bounds.label));
+                return Err(format!(
+                    "cron {} step must be greater than zero",
+                    bounds.label
+                ));
             }
             (&input[..pos], Some(step))
         }
@@ -223,12 +229,18 @@ fn parse_base(base: &str, bounds: &FieldBounds) -> Result<Vec<u32>, String> {
     if let Some(dash_pos) = base.find('-') {
         let lo_str = &base[..dash_pos];
         let hi_str = &base[dash_pos + 1..];
-        let lo: u32 = lo_str
-            .parse()
-            .map_err(|_| format!("cron {} range lower bound '{}' is not a number", bounds.label, lo_str))?;
-        let hi: u32 = hi_str
-            .parse()
-            .map_err(|_| format!("cron {} range upper bound '{}' is not a number", bounds.label, hi_str))?;
+        let lo: u32 = lo_str.parse().map_err(|_| {
+            format!(
+                "cron {} range lower bound '{}' is not a number",
+                bounds.label, lo_str
+            )
+        })?;
+        let hi: u32 = hi_str.parse().map_err(|_| {
+            format!(
+                "cron {} range upper bound '{}' is not a number",
+                bounds.label, hi_str
+            )
+        })?;
 
         if lo < bounds.min || lo > bounds.max {
             return Err(format!(

--- a/src/scheduled_task/host.rs
+++ b/src/scheduled_task/host.rs
@@ -9,11 +9,39 @@
 //! variables — the installed command is always core-derived.
 
 use async_trait::async_trait;
-use chrono::{DateTime, Utc};
 use std::path::PathBuf;
 
 use super::cron::CronExpression;
-use super::{HostRunMetadata, ScheduleHealth};
+use super::HostRunMetadata;
+
+/// Render structured program arguments as a shell-safe command string.
+///
+/// Each argument is single-quoted if it contains characters that are
+/// special to the shell. This is used for cron entries (which run via
+/// `/bin/sh -c`) and for comparing expected vs observed commands.
+pub fn render_command(program: &std::path::Path, args: &[String]) -> String {
+    let mut parts = vec![shell_quote(&program.display().to_string())];
+    for arg in args {
+        parts.push(shell_quote(arg));
+    }
+    parts.join(" ")
+}
+
+/// Quote a string for safe shell usage. If the string contains only
+/// "safe" characters (alphanumeric, dash, underscore, slash, dot, colon),
+/// it is returned unquoted. Otherwise it is single-quoted with embedded
+/// single-quotes escaped.
+fn shell_quote(s: &str) -> String {
+    if s.is_empty() {
+        return "''".to_string();
+    }
+    if s.chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '/' | '.' | ':' | '='))
+    {
+        return s.to_string();
+    }
+    format!("'{}'", s.replace('\'', "'\"'\"'"))
+}
 
 // ============================================================================
 // Installation context
@@ -32,17 +60,21 @@ pub struct SchedulerInstallContext {
 }
 
 impl SchedulerInstallContext {
-    /// Generate the fixed command line for a scheduled task.
+    /// Generate the structured program invocation for a scheduled task.
     ///
-    /// The command invokes `agent-iron run <task-id> --config <path>` with
-    /// absolute paths and no reliance on `PATH`, process working directory,
-    /// or environment variables.
-    pub fn generate_command(&self, automation_task_id: &str) -> String {
-        format!(
-            "{} run {} --config {}",
-            self.runner_executable.display(),
-            automation_task_id,
-            self.config_store_path.display()
+    /// Returns the runner executable path and argument list for
+    /// `agent-iron run <task-id> --config <path>` with absolute paths and
+    /// no reliance on `PATH`, process working directory, or environment
+    /// variables.
+    pub fn generate_invocation(&self, automation_task_id: &str) -> (PathBuf, Vec<String>) {
+        (
+            self.runner_executable.clone(),
+            vec![
+                "run".to_string(),
+                automation_task_id.to_string(),
+                "--config".to_string(),
+                self.config_store_path.display().to_string(),
+            ],
         )
     }
 }
@@ -66,8 +98,10 @@ pub struct HostInstallRequest {
     pub cron: CronExpression,
     /// Whether the entry should be enabled or disabled.
     pub enabled: bool,
-    /// Core-generated command line (from `SchedulerInstallContext`).
-    pub command: String,
+    /// Core-generated runner executable path.
+    pub program: PathBuf,
+    /// Core-generated runner arguments.
+    pub args: Vec<String>,
 }
 
 /// An observed host scheduler entry belonging to AgentIron.
@@ -146,7 +180,10 @@ pub trait HostScheduler: Send + Sync {
     /// Inspect a single owned host entry by schedule ID.
     ///
     /// Returns `Ok(None)` if no owned entry exists for the given ID.
-    async fn inspect(&self, schedule_id: &str) -> Result<Option<ObservedHostEntry>, HostSchedulerError>;
+    async fn inspect(
+        &self,
+        schedule_id: &str,
+    ) -> Result<Option<ObservedHostEntry>, HostSchedulerError>;
 }
 
 // ============================================================================
@@ -185,11 +222,7 @@ pub struct ProductionCommandRunner;
 
 #[async_trait]
 impl CommandRunner for ProductionCommandRunner {
-    async fn run(
-        &self,
-        program: &str,
-        args: &[&str],
-    ) -> Result<CommandOutput, std::io::Error> {
+    async fn run(&self, program: &str, args: &[&str]) -> Result<CommandOutput, std::io::Error> {
         let output = tokio::process::Command::new(program)
             .args(args)
             .output()
@@ -234,11 +267,7 @@ impl CommandRunner for ProductionCommandRunner {
 #[async_trait]
 pub trait CommandRunner: Send + Sync {
     /// Run a program with arguments and return the output.
-    async fn run(
-        &self,
-        program: &str,
-        args: &[&str],
-    ) -> Result<CommandOutput, std::io::Error>;
+    async fn run(&self, program: &str, args: &[&str]) -> Result<CommandOutput, std::io::Error>;
 
     /// Run a program with stdin input and return the output.
     async fn run_with_stdin(
@@ -300,6 +329,7 @@ impl HostScheduler for FakeHostScheduler {
 
     async fn install(&self, request: &HostInstallRequest) -> Result<(), HostSchedulerError> {
         self.check_error()?;
+        let command = render_command(&request.program, &request.args);
         let mut entries = self.entries.write();
         entries.insert(
             request.schedule_id.clone(),
@@ -308,7 +338,7 @@ impl HostScheduler for FakeHostScheduler {
                 enabled: request.enabled,
                 corrupt: false,
                 raw_schedule: Some(request.cron.as_str().to_string()),
-                observed_command: Some(request.command.clone()),
+                observed_command: Some(command),
                 metadata: None,
             },
         );
@@ -355,21 +385,35 @@ mod tests {
         }
     }
 
-    #[test]
-    fn generate_command_uses_absolute_paths() {
+    fn make_request(id: &str, cron: &str, enabled: bool) -> HostInstallRequest {
         let ctx = test_context();
-        let cmd = ctx.generate_command("daily-report");
-        assert!(cmd.contains("/usr/local/bin/agent-iron"));
-        assert!(cmd.contains("run daily-report"));
-        assert!(cmd.contains("--config /home/user/.config/agentiron/config.db"));
+        let (program, args) = ctx.generate_invocation("task-1");
+        HostInstallRequest {
+            schedule_id: id.to_string(),
+            automation_task_id: "task-1".to_string(),
+            cron: CronExpression::parse(cron).unwrap(),
+            enabled,
+            program,
+            args,
+        }
     }
 
     #[test]
-    fn generate_command_no_path_reliance() {
+    fn generate_invocation_uses_absolute_paths() {
         let ctx = test_context();
-        let cmd = ctx.generate_command("task-1");
-        assert!(!cmd.starts_with("agent-iron"));
-        assert!(cmd.starts_with("/"));
+        let (program, args) = ctx.generate_invocation("daily-report");
+        assert!(program.starts_with("/usr/local/bin/agent-iron"));
+        assert!(args.contains(&"run".to_string()));
+        assert!(args.contains(&"daily-report".to_string()));
+        assert!(args.contains(&"--config".to_string()));
+    }
+
+    #[test]
+    fn generate_invocation_no_path_reliance() {
+        let ctx = test_context();
+        let (program, _) = ctx.generate_invocation("task-1");
+        assert!(!program.starts_with("agent-iron"));
+        assert!(program.is_absolute());
     }
 
     #[test]
@@ -388,39 +432,22 @@ mod tests {
     #[tokio::test]
     async fn fake_install_and_inspect() {
         let scheduler = FakeHostScheduler::new();
-        let ctx = test_context();
-        let cron = CronExpression::parse("0 9 * * *").unwrap();
-        let request = HostInstallRequest {
-            schedule_id: "s1".to_string(),
-            automation_task_id: "daily-report".to_string(),
-            cron,
-            enabled: true,
-            command: ctx.generate_command("daily-report"),
-        };
-
+        let request = make_request("s1", "0 9 * * *", true);
         scheduler.install(&request).await.unwrap();
 
         let entry = scheduler.inspect("s1").await.unwrap().unwrap();
         assert_eq!(entry.schedule_id, "s1");
         assert!(entry.enabled);
-        assert!(!entry.corrupt);
         assert_eq!(entry.raw_schedule.as_deref(), Some("0 9 * * *"));
     }
 
     #[tokio::test]
     async fn fake_remove() {
         let scheduler = FakeHostScheduler::new();
-        let ctx = test_context();
-        let cron = CronExpression::parse("0 9 * * *").unwrap();
-        let request = HostInstallRequest {
-            schedule_id: "s1".to_string(),
-            automation_task_id: "t1".to_string(),
-            cron,
-            enabled: true,
-            command: ctx.generate_command("t1"),
-        };
-
-        scheduler.install(&request).await.unwrap();
+        scheduler
+            .install(&make_request("s1", "0 9 * * *", true))
+            .await
+            .unwrap();
         scheduler.remove("s1").await.unwrap();
         assert!(scheduler.inspect("s1").await.unwrap().is_none());
     }
@@ -428,22 +455,12 @@ mod tests {
     #[tokio::test]
     async fn fake_list_owned_sorted() {
         let scheduler = FakeHostScheduler::new();
-        let ctx = test_context();
-        let cron = CronExpression::parse("0 9 * * *").unwrap();
-
         for id in &["charlie", "alpha", "bravo"] {
             scheduler
-                .install(&HostInstallRequest {
-                    schedule_id: id.to_string(),
-                    automation_task_id: "t1".to_string(),
-                    cron: cron.clone(),
-                    enabled: true,
-                    command: ctx.generate_command("t1"),
-                })
+                .install(&make_request(id, "0 9 * * *", true))
                 .await
                 .unwrap();
         }
-
         let list = scheduler.list_owned().await.unwrap();
         let ids: Vec<&str> = list.iter().map(|e| e.schedule_id.as_str()).collect();
         assert_eq!(ids, vec!["alpha", "bravo", "charlie"]);
@@ -452,63 +469,53 @@ mod tests {
     #[tokio::test]
     async fn fake_replace_on_reinstall() {
         let scheduler = FakeHostScheduler::new();
-        let ctx = test_context();
-        let cron = CronExpression::parse("0 9 * * *").unwrap();
-
         scheduler
-            .install(&HostInstallRequest {
-                schedule_id: "s1".to_string(),
-                automation_task_id: "t1".to_string(),
-                cron: cron.clone(),
-                enabled: true,
-                command: ctx.generate_command("t1"),
-            })
+            .install(&make_request("s1", "0 9 * * *", true))
             .await
             .unwrap();
-
-        // Reinstall with disabled.
         scheduler
-            .install(&HostInstallRequest {
-                schedule_id: "s1".to_string(),
-                automation_task_id: "t1".to_string(),
-                cron: cron.clone(),
-                enabled: false,
-                command: ctx.generate_command("t1"),
-            })
+            .install(&make_request("s1", "0 9 * * *", false))
             .await
             .unwrap();
-
         let entry = scheduler.inspect("s1").await.unwrap().unwrap();
         assert!(!entry.enabled);
     }
 
     #[tokio::test]
     async fn fake_install_request_has_no_arbitrary_command() {
-        let scheduler = FakeHostScheduler::new();
-        let ctx = test_context();
-        let cron = CronExpression::parse("0 9 * * *").unwrap();
-
-        let request = HostInstallRequest {
-            schedule_id: "s1".to_string(),
-            automation_task_id: "t1".to_string(),
-            cron,
-            enabled: true,
-            command: ctx.generate_command("t1"),
-        };
-
-        // The command must come from SchedulerInstallContext, not from user input.
-        assert!(request.command.contains(ctx.runner_executable.display().to_string().as_str()));
-        assert!(request.command.contains("run t1"));
+        let _scheduler = FakeHostScheduler::new();
+        let request = make_request("s1", "0 9 * * *", true);
+        assert!(request.program.is_absolute());
+        assert!(request.args.contains(&"run".to_string()));
+        assert!(request.args.contains(&"task-1".to_string()));
     }
 
     #[tokio::test]
     async fn fake_force_error() {
         let scheduler = FakeHostScheduler::new();
-        *scheduler.force_error.lock() = Some(HostSchedulerError::PlatformUnavailable(
-            "test".to_string(),
-        ));
-
+        *scheduler.force_error.lock() =
+            Some(HostSchedulerError::PlatformUnavailable("test".to_string()));
         let result = scheduler.list_owned().await;
-        assert!(matches!(result, Err(HostSchedulerError::PlatformUnavailable(_))));
+        assert!(matches!(
+            result,
+            Err(HostSchedulerError::PlatformUnavailable(_))
+        ));
+    }
+
+    #[test]
+    fn shell_quote_safe_chars() {
+        assert_eq!(shell_quote("hello"), "hello");
+        assert_eq!(shell_quote("/usr/bin/agent-iron"), "/usr/bin/agent-iron");
+        assert_eq!(shell_quote("a-b_c.d"), "a-b_c.d");
+    }
+
+    #[test]
+    fn shell_quote_unsafe_chars() {
+        assert_eq!(shell_quote(""), "''");
+        assert_eq!(shell_quote("hello world"), "'hello world'");
+        assert_eq!(
+            shell_quote("/path with spaces/run"),
+            "'/path with spaces/run'"
+        );
     }
 }

--- a/src/scheduled_task/host.rs
+++ b/src/scheduled_task/host.rs
@@ -27,6 +27,16 @@ pub fn render_command(program: &std::path::Path, args: &[String]) -> String {
     parts.join(" ")
 }
 
+/// Render a command string for cron entries, escaping the `%` metacharacter.
+///
+/// Cron processes unescaped `%` as a newline **before** invoking `/bin/sh`,
+/// so single-quote protection alone is insufficient. The `\%` escape is
+/// recognised by cron (which strips the backslash) regardless of shell
+/// quoting context, so it is safe both inside and outside single quotes.
+pub fn render_cron_command(program: &std::path::Path, args: &[String]) -> String {
+    render_command(program, args).replace('%', "\\%")
+}
+
 /// Quote a string for safe shell usage. If the string contains only
 /// "safe" characters (alphanumeric, dash, underscore, slash, dot, colon),
 /// it is returned unquoted. Otherwise it is single-quoted with embedded
@@ -203,8 +213,21 @@ pub fn create_host_scheduler(
         } else if #[cfg(target_os = "macos")] {
             use super::platform::launchd::LaunchdHostScheduler;
             use std::path::PathBuf;
-            let home = std::env::var("HOME").unwrap_or_default();
-            let dir = PathBuf::from(home).join("Library/LaunchAgents");
+            let home = std::env::var("HOME")
+                .map_err(|_| HostSchedulerError::PlatformUnavailable(
+                    "HOME environment variable is not set; cannot locate LaunchAgents directory".to_string(),
+                ))?;
+            if home.is_empty() {
+                return Err(HostSchedulerError::PlatformUnavailable(
+                    "HOME environment variable is empty; cannot locate LaunchAgents directory".to_string(),
+                ));
+            }
+            let dir = PathBuf::from(&home).join("Library/LaunchAgents");
+            if !dir.is_absolute() {
+                return Err(HostSchedulerError::PlatformUnavailable(
+                    format!("resolved LaunchAgents path is not absolute: {}", dir.display()),
+                ));
+            }
             Ok(Box::new(LaunchdHostScheduler::new(Box::new(ProductionCommandRunner), dir)))
         } else if #[cfg(target_os = "windows")] {
             use super::platform::task_scheduler::TaskSchedulerHostScheduler;
@@ -220,18 +243,34 @@ pub fn create_host_scheduler(
 /// Production command runner using `tokio::process::Command`.
 pub struct ProductionCommandRunner;
 
+/// Default timeout for host scheduler commands (30 seconds).
+const COMMAND_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
 #[async_trait]
 impl CommandRunner for ProductionCommandRunner {
     async fn run(&self, program: &str, args: &[&str]) -> Result<CommandOutput, std::io::Error> {
-        let output = tokio::process::Command::new(program)
-            .args(args)
-            .output()
-            .await?;
-        Ok(CommandOutput {
-            exit_code: output.status.code().unwrap_or(-1),
-            stdout: String::from_utf8_lossy(&output.stdout).to_string(),
-            stderr: String::from_utf8_lossy(&output.stderr).to_string(),
-        })
+        let fut = async {
+            let output = tokio::process::Command::new(program)
+                .args(args)
+                .output()
+                .await?;
+            Ok(CommandOutput {
+                exit_code: output.status.code().unwrap_or(-1),
+                stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+                stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+            })
+        };
+        match tokio::time::timeout(COMMAND_TIMEOUT, fut).await {
+            Ok(result) => result,
+            Err(_) => Err(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                format!(
+                    "command '{}' timed out after {}s",
+                    program,
+                    COMMAND_TIMEOUT.as_secs()
+                ),
+            )),
+        }
     }
 
     async fn run_with_stdin(
@@ -241,21 +280,35 @@ impl CommandRunner for ProductionCommandRunner {
         stdin: &str,
     ) -> Result<CommandOutput, std::io::Error> {
         use tokio::io::AsyncWriteExt;
-        let mut child = tokio::process::Command::new(program)
-            .args(args)
-            .stdin(std::process::Stdio::piped())
-            .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::piped())
-            .spawn()?;
-        if let Some(ref mut stdin_handle) = child.stdin {
-            stdin_handle.write_all(stdin.as_bytes()).await?;
+        let stdin_bytes = stdin.as_bytes().to_vec();
+        let fut = async {
+            let mut child = tokio::process::Command::new(program)
+                .args(args)
+                .stdin(std::process::Stdio::piped())
+                .stdout(std::process::Stdio::piped())
+                .stderr(std::process::Stdio::piped())
+                .spawn()?;
+            if let Some(ref mut stdin_handle) = child.stdin {
+                stdin_handle.write_all(&stdin_bytes).await?;
+            }
+            let output = child.wait_with_output().await?;
+            Ok(CommandOutput {
+                exit_code: output.status.code().unwrap_or(-1),
+                stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+                stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+            })
+        };
+        match tokio::time::timeout(COMMAND_TIMEOUT, fut).await {
+            Ok(result) => result,
+            Err(_) => Err(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                format!(
+                    "command '{}' timed out after {}s",
+                    program,
+                    COMMAND_TIMEOUT.as_secs()
+                ),
+            )),
         }
-        let output = child.wait_with_output().await?;
-        Ok(CommandOutput {
-            exit_code: output.status.code().unwrap_or(-1),
-            stdout: String::from_utf8_lossy(&output.stdout).to_string(),
-            stderr: String::from_utf8_lossy(&output.stderr).to_string(),
-        })
     }
 }
 

--- a/src/scheduled_task/host.rs
+++ b/src/scheduled_task/host.rs
@@ -161,22 +161,68 @@ pub fn create_host_scheduler(
 ) -> Result<Box<dyn HostScheduler>, HostSchedulerError> {
     cfg_if::cfg_if! {
         if #[cfg(target_os = "linux")] {
-            Err(HostSchedulerError::PlatformUnavailable(
-                "Linux cron adapter not yet implemented".to_string(),
-            ))
+            use super::platform::cron_adapter::CronHostScheduler;
+            Ok(Box::new(CronHostScheduler::new(Box::new(ProductionCommandRunner))))
         } else if #[cfg(target_os = "macos")] {
-            Err(HostSchedulerError::PlatformUnavailable(
-                "macOS launchd adapter not yet implemented".to_string(),
-            ))
+            use super::platform::launchd::LaunchdHostScheduler;
+            use std::path::PathBuf;
+            let home = std::env::var("HOME").unwrap_or_default();
+            let dir = PathBuf::from(home).join("Library/LaunchAgents");
+            Ok(Box::new(LaunchdHostScheduler::new(Box::new(ProductionCommandRunner), dir)))
         } else if #[cfg(target_os = "windows")] {
-            Err(HostSchedulerError::PlatformUnavailable(
-                "Windows Task Scheduler adapter not yet implemented".to_string(),
-            ))
+            use super::platform::task_scheduler::TaskSchedulerHostScheduler;
+            Ok(Box::new(TaskSchedulerHostScheduler::new(Box::new(ProductionCommandRunner))))
         } else {
             Err(HostSchedulerError::PlatformUnavailable(
                 "unsupported platform".to_string(),
             ))
         }
+    }
+}
+
+/// Production command runner using `tokio::process::Command`.
+pub struct ProductionCommandRunner;
+
+#[async_trait]
+impl CommandRunner for ProductionCommandRunner {
+    async fn run(
+        &self,
+        program: &str,
+        args: &[&str],
+    ) -> Result<CommandOutput, std::io::Error> {
+        let output = tokio::process::Command::new(program)
+            .args(args)
+            .output()
+            .await?;
+        Ok(CommandOutput {
+            exit_code: output.status.code().unwrap_or(-1),
+            stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+            stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+        })
+    }
+
+    async fn run_with_stdin(
+        &self,
+        program: &str,
+        args: &[&str],
+        stdin: &str,
+    ) -> Result<CommandOutput, std::io::Error> {
+        use tokio::io::AsyncWriteExt;
+        let mut child = tokio::process::Command::new(program)
+            .args(args)
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()?;
+        if let Some(ref mut stdin_handle) = child.stdin {
+            stdin_handle.write_all(stdin.as_bytes()).await?;
+        }
+        let output = child.wait_with_output().await?;
+        Ok(CommandOutput {
+            exit_code: output.status.code().unwrap_or(-1),
+            stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+            stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+        })
     }
 }
 
@@ -192,6 +238,14 @@ pub trait CommandRunner: Send + Sync {
         &self,
         program: &str,
         args: &[&str],
+    ) -> Result<CommandOutput, std::io::Error>;
+
+    /// Run a program with stdin input and return the output.
+    async fn run_with_stdin(
+        &self,
+        program: &str,
+        args: &[&str],
+        stdin: &str,
     ) -> Result<CommandOutput, std::io::Error>;
 }
 
@@ -319,10 +373,16 @@ mod tests {
     }
 
     #[test]
-    fn factory_returns_unavailable_on_all_platforms() {
+    fn factory_returns_scheduler_on_supported_platform() {
         let ctx = test_context();
         let result = create_host_scheduler(ctx);
-        assert!(matches!(result, Err(HostSchedulerError::PlatformUnavailable(_))));
+        cfg_if::cfg_if! {
+            if #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))] {
+                assert!(result.is_ok());
+            } else {
+                assert!(matches!(result, Err(HostSchedulerError::PlatformUnavailable(_))));
+            }
+        }
     }
 
     #[tokio::test]

--- a/src/scheduled_task/host.rs
+++ b/src/scheduled_task/host.rs
@@ -1,0 +1,454 @@
+//! Host scheduler abstraction, installation context, and platform factory.
+//!
+//! The `HostScheduler` trait defines the operations each platform adapter
+//! implements: install, remove, list, and inspect owned entries. The
+//! `SchedulerInstallContext` supplies the trusted runner executable and
+//! ConfigStore path used to generate fixed `agent-iron run` invocations.
+//!
+//! Callers never provide executables, arguments, shell text, or environment
+//! variables — the installed command is always core-derived.
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use std::path::PathBuf;
+
+use super::cron::CronExpression;
+use super::{HostRunMetadata, ScheduleHealth};
+
+// ============================================================================
+// Installation context
+// ============================================================================
+
+/// Trusted installation context for generating host scheduler entries.
+///
+/// Supplied by the embedding application (e.g. the desktop app). Core does
+/// not assume `current_exe()` is the runner.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SchedulerInstallContext {
+    /// Absolute path to the `agent-iron` binary.
+    pub runner_executable: PathBuf,
+    /// Absolute path to the ConfigStore database.
+    pub config_store_path: PathBuf,
+}
+
+impl SchedulerInstallContext {
+    /// Generate the fixed command line for a scheduled task.
+    ///
+    /// The command invokes `agent-iron run <task-id> --config <path>` with
+    /// absolute paths and no reliance on `PATH`, process working directory,
+    /// or environment variables.
+    pub fn generate_command(&self, automation_task_id: &str) -> String {
+        format!(
+            "{} run {} --config {}",
+            self.runner_executable.display(),
+            automation_task_id,
+            self.config_store_path.display()
+        )
+    }
+}
+
+// ============================================================================
+// Request and observed types
+// ============================================================================
+
+/// A core-generated request to install or replace a host scheduler entry.
+///
+/// All fields are derived by core from the desired ConfigStore state and the
+/// trusted installation context. The host adapter never receives arbitrary
+/// caller-provided command content.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HostInstallRequest {
+    /// Stable schedule ID used for ownership.
+    pub schedule_id: String,
+    /// The automation task being scheduled.
+    pub automation_task_id: String,
+    /// Parsed cron expression to compile into native triggers.
+    pub cron: CronExpression,
+    /// Whether the entry should be enabled or disabled.
+    pub enabled: bool,
+    /// Core-generated command line (from `SchedulerInstallContext`).
+    pub command: String,
+}
+
+/// An observed host scheduler entry belonging to AgentIron.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ObservedHostEntry {
+    /// Schedule ID extracted from ownership markers.
+    pub schedule_id: String,
+    /// Whether the entry is currently enabled.
+    pub enabled: bool,
+    /// Whether the entry appears corrupt or malformed.
+    pub corrupt: bool,
+    /// The observed raw schedule text, if parseable.
+    pub raw_schedule: Option<String>,
+    /// The observed command, if extractable.
+    pub observed_command: Option<String>,
+    /// Optional host-reported run metadata.
+    pub metadata: Option<HostRunMetadata>,
+}
+
+// ============================================================================
+// Errors
+// ============================================================================
+
+/// Errors from host scheduler operations.
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum HostSchedulerError {
+    /// The platform does not support the requested schedule.
+    #[error("unsupported schedule for {platform}: {reason}")]
+    UnsupportedSchedule {
+        platform: &'static str,
+        reason: String,
+    },
+
+    /// The host scheduler service is unavailable.
+    #[error("platform unavailable: {0}")]
+    PlatformUnavailable(String),
+
+    /// A command or filesystem operation failed.
+    #[error("io error: {0}")]
+    Io(String),
+
+    /// The cron expression cannot be faithfully compiled.
+    #[error("compilation failed: {0}")]
+    CompilationFailed(String),
+}
+
+// ============================================================================
+// HostScheduler trait
+// ============================================================================
+
+/// Platform-specific host scheduler operations.
+///
+/// Each adapter manages only AgentIron-owned entries identified by
+/// platform-specific ownership markers. Non-owned entries are never
+/// mutated.
+#[async_trait]
+pub trait HostScheduler: Send + Sync {
+    /// The platform name (e.g. "cron", "launchd", "task-scheduler").
+    fn platform(&self) -> &'static str;
+
+    /// Install or replace an owned host entry.
+    ///
+    /// If an owned entry for the same schedule ID already exists, it is
+    /// replaced atomically. Disabled requests install a disabled entry
+    /// rather than skipping installation.
+    async fn install(&self, request: &HostInstallRequest) -> Result<(), HostSchedulerError>;
+
+    /// Remove an owned host entry by schedule ID.
+    ///
+    /// Returns `Ok(())` if the entry did not exist.
+    async fn remove(&self, schedule_id: &str) -> Result<(), HostSchedulerError>;
+
+    /// List all AgentIron-owned host entries.
+    async fn list_owned(&self) -> Result<Vec<ObservedHostEntry>, HostSchedulerError>;
+
+    /// Inspect a single owned host entry by schedule ID.
+    ///
+    /// Returns `Ok(None)` if no owned entry exists for the given ID.
+    async fn inspect(&self, schedule_id: &str) -> Result<Option<ObservedHostEntry>, HostSchedulerError>;
+}
+
+// ============================================================================
+// Factory
+// ============================================================================
+
+/// Create the platform-appropriate host scheduler.
+///
+/// Returns `Err(PlatformUnavailable)` on unsupported targets.
+pub fn create_host_scheduler(
+    _context: SchedulerInstallContext,
+) -> Result<Box<dyn HostScheduler>, HostSchedulerError> {
+    cfg_if::cfg_if! {
+        if #[cfg(target_os = "linux")] {
+            Err(HostSchedulerError::PlatformUnavailable(
+                "Linux cron adapter not yet implemented".to_string(),
+            ))
+        } else if #[cfg(target_os = "macos")] {
+            Err(HostSchedulerError::PlatformUnavailable(
+                "macOS launchd adapter not yet implemented".to_string(),
+            ))
+        } else if #[cfg(target_os = "windows")] {
+            Err(HostSchedulerError::PlatformUnavailable(
+                "Windows Task Scheduler adapter not yet implemented".to_string(),
+            ))
+        } else {
+            Err(HostSchedulerError::PlatformUnavailable(
+                "unsupported platform".to_string(),
+            ))
+        }
+    }
+}
+
+// ============================================================================
+// Injectable boundaries for testing
+// ============================================================================
+
+/// Injectable command runner for executing host scheduler commands.
+#[async_trait]
+pub trait CommandRunner: Send + Sync {
+    /// Run a program with arguments and return the output.
+    async fn run(
+        &self,
+        program: &str,
+        args: &[&str],
+    ) -> Result<CommandOutput, std::io::Error>;
+}
+
+/// Output from a command runner invocation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommandOutput {
+    pub exit_code: i32,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+/// Injectable filesystem boundary.
+#[async_trait]
+pub trait SchedulerFilesystem: Send + Sync {
+    async fn read_to_string(&self, path: &std::path::Path) -> Result<String, std::io::Error>;
+    async fn write(&self, path: &std::path::Path, content: &str) -> Result<(), std::io::Error>;
+    async fn exists(&self, path: &std::path::Path) -> bool;
+    async fn remove_file(&self, path: &std::path::Path) -> Result<(), std::io::Error>;
+}
+
+// ============================================================================
+// Fake host scheduler for testing
+// ============================================================================
+
+/// In-memory fake host scheduler for testing schedule management without
+/// touching the real host scheduler.
+#[derive(Debug, Default)]
+pub struct FakeHostScheduler {
+    entries: parking_lot::RwLock<std::collections::HashMap<String, ObservedHostEntry>>,
+    /// If set, all operations return this error.
+    pub force_error: parking_lot::Mutex<Option<HostSchedulerError>>,
+}
+
+impl FakeHostScheduler {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn check_error(&self) -> Result<(), HostSchedulerError> {
+        if let Some(ref e) = *self.force_error.lock() {
+            return Err(e.clone());
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl HostScheduler for FakeHostScheduler {
+    fn platform(&self) -> &'static str {
+        "fake"
+    }
+
+    async fn install(&self, request: &HostInstallRequest) -> Result<(), HostSchedulerError> {
+        self.check_error()?;
+        let mut entries = self.entries.write();
+        entries.insert(
+            request.schedule_id.clone(),
+            ObservedHostEntry {
+                schedule_id: request.schedule_id.clone(),
+                enabled: request.enabled,
+                corrupt: false,
+                raw_schedule: Some(request.cron.as_str().to_string()),
+                observed_command: Some(request.command.clone()),
+                metadata: None,
+            },
+        );
+        Ok(())
+    }
+
+    async fn remove(&self, schedule_id: &str) -> Result<(), HostSchedulerError> {
+        self.check_error()?;
+        let mut entries = self.entries.write();
+        entries.remove(schedule_id);
+        Ok(())
+    }
+
+    async fn list_owned(&self) -> Result<Vec<ObservedHostEntry>, HostSchedulerError> {
+        self.check_error()?;
+        let entries = self.entries.read();
+        let mut list: Vec<_> = entries.values().cloned().collect();
+        list.sort_by(|a, b| a.schedule_id.cmp(&b.schedule_id));
+        Ok(list)
+    }
+
+    async fn inspect(
+        &self,
+        schedule_id: &str,
+    ) -> Result<Option<ObservedHostEntry>, HostSchedulerError> {
+        self.check_error()?;
+        let entries = self.entries.read();
+        Ok(entries.get(schedule_id).cloned())
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_context() -> SchedulerInstallContext {
+        SchedulerInstallContext {
+            runner_executable: PathBuf::from("/usr/local/bin/agent-iron"),
+            config_store_path: PathBuf::from("/home/user/.config/agentiron/config.db"),
+        }
+    }
+
+    #[test]
+    fn generate_command_uses_absolute_paths() {
+        let ctx = test_context();
+        let cmd = ctx.generate_command("daily-report");
+        assert!(cmd.contains("/usr/local/bin/agent-iron"));
+        assert!(cmd.contains("run daily-report"));
+        assert!(cmd.contains("--config /home/user/.config/agentiron/config.db"));
+    }
+
+    #[test]
+    fn generate_command_no_path_reliance() {
+        let ctx = test_context();
+        let cmd = ctx.generate_command("task-1");
+        assert!(!cmd.starts_with("agent-iron"));
+        assert!(cmd.starts_with("/"));
+    }
+
+    #[test]
+    fn factory_returns_unavailable_on_all_platforms() {
+        let ctx = test_context();
+        let result = create_host_scheduler(ctx);
+        assert!(matches!(result, Err(HostSchedulerError::PlatformUnavailable(_))));
+    }
+
+    #[tokio::test]
+    async fn fake_install_and_inspect() {
+        let scheduler = FakeHostScheduler::new();
+        let ctx = test_context();
+        let cron = CronExpression::parse("0 9 * * *").unwrap();
+        let request = HostInstallRequest {
+            schedule_id: "s1".to_string(),
+            automation_task_id: "daily-report".to_string(),
+            cron,
+            enabled: true,
+            command: ctx.generate_command("daily-report"),
+        };
+
+        scheduler.install(&request).await.unwrap();
+
+        let entry = scheduler.inspect("s1").await.unwrap().unwrap();
+        assert_eq!(entry.schedule_id, "s1");
+        assert!(entry.enabled);
+        assert!(!entry.corrupt);
+        assert_eq!(entry.raw_schedule.as_deref(), Some("0 9 * * *"));
+    }
+
+    #[tokio::test]
+    async fn fake_remove() {
+        let scheduler = FakeHostScheduler::new();
+        let ctx = test_context();
+        let cron = CronExpression::parse("0 9 * * *").unwrap();
+        let request = HostInstallRequest {
+            schedule_id: "s1".to_string(),
+            automation_task_id: "t1".to_string(),
+            cron,
+            enabled: true,
+            command: ctx.generate_command("t1"),
+        };
+
+        scheduler.install(&request).await.unwrap();
+        scheduler.remove("s1").await.unwrap();
+        assert!(scheduler.inspect("s1").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn fake_list_owned_sorted() {
+        let scheduler = FakeHostScheduler::new();
+        let ctx = test_context();
+        let cron = CronExpression::parse("0 9 * * *").unwrap();
+
+        for id in &["charlie", "alpha", "bravo"] {
+            scheduler
+                .install(&HostInstallRequest {
+                    schedule_id: id.to_string(),
+                    automation_task_id: "t1".to_string(),
+                    cron: cron.clone(),
+                    enabled: true,
+                    command: ctx.generate_command("t1"),
+                })
+                .await
+                .unwrap();
+        }
+
+        let list = scheduler.list_owned().await.unwrap();
+        let ids: Vec<&str> = list.iter().map(|e| e.schedule_id.as_str()).collect();
+        assert_eq!(ids, vec!["alpha", "bravo", "charlie"]);
+    }
+
+    #[tokio::test]
+    async fn fake_replace_on_reinstall() {
+        let scheduler = FakeHostScheduler::new();
+        let ctx = test_context();
+        let cron = CronExpression::parse("0 9 * * *").unwrap();
+
+        scheduler
+            .install(&HostInstallRequest {
+                schedule_id: "s1".to_string(),
+                automation_task_id: "t1".to_string(),
+                cron: cron.clone(),
+                enabled: true,
+                command: ctx.generate_command("t1"),
+            })
+            .await
+            .unwrap();
+
+        // Reinstall with disabled.
+        scheduler
+            .install(&HostInstallRequest {
+                schedule_id: "s1".to_string(),
+                automation_task_id: "t1".to_string(),
+                cron: cron.clone(),
+                enabled: false,
+                command: ctx.generate_command("t1"),
+            })
+            .await
+            .unwrap();
+
+        let entry = scheduler.inspect("s1").await.unwrap().unwrap();
+        assert!(!entry.enabled);
+    }
+
+    #[tokio::test]
+    async fn fake_install_request_has_no_arbitrary_command() {
+        let scheduler = FakeHostScheduler::new();
+        let ctx = test_context();
+        let cron = CronExpression::parse("0 9 * * *").unwrap();
+
+        let request = HostInstallRequest {
+            schedule_id: "s1".to_string(),
+            automation_task_id: "t1".to_string(),
+            cron,
+            enabled: true,
+            command: ctx.generate_command("t1"),
+        };
+
+        // The command must come from SchedulerInstallContext, not from user input.
+        assert!(request.command.contains(ctx.runner_executable.display().to_string().as_str()));
+        assert!(request.command.contains("run t1"));
+    }
+
+    #[tokio::test]
+    async fn fake_force_error() {
+        let scheduler = FakeHostScheduler::new();
+        *scheduler.force_error.lock() = Some(HostSchedulerError::PlatformUnavailable(
+            "test".to_string(),
+        ));
+
+        let result = scheduler.list_owned().await;
+        assert!(matches!(result, Err(HostSchedulerError::PlatformUnavailable(_))));
+    }
+}

--- a/src/scheduled_task/manager.rs
+++ b/src/scheduled_task/manager.rs
@@ -1,0 +1,684 @@
+//! Schedule manager: desired-state inspection and host reconciliation.
+//!
+//! `ScheduleManager` is the application-facing API that reads desired
+//! ConfigStore schedules, validates automation-task references, asks the
+//! host scheduler for observed state, and returns compositional status
+//! reports. Inspection is read-only; reconciliation mutates host entries.
+
+use std::path::PathBuf;
+
+use crate::config::ConfigStore;
+use crate::scheduled_task::cron::CronExpression;
+use crate::scheduled_task::host::{
+    HostInstallRequest, HostScheduler, HostSchedulerError, ObservedHostEntry,
+    SchedulerInstallContext,
+};
+use crate::scheduled_task::{
+    DesiredState, ExecutionState, HostRunMetadata, HostState, ReferenceState, ScheduleDiagnostic,
+    ScheduleDiagnosticKind, ScheduleHealth, ScheduleStatus, ScheduledTask,
+};
+
+/// Application-facing schedule manager.
+///
+/// Combines desired ConfigStore state with observed host state to provide
+/// read-only inspection and explicit reconciliation.
+pub struct ScheduleManager<'a> {
+    store: &'a ConfigStore,
+    host: &'a dyn HostScheduler,
+    context: SchedulerInstallContext,
+}
+
+/// Policy controlling orphan removal during reconciliation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OrphanPolicy {
+    /// Report orphans but do not remove them.
+    ReportOnly,
+    /// Remove orphaned owned entries during reconcile_all.
+    RemoveOrphans,
+}
+
+impl<'a> ScheduleManager<'a> {
+    /// Create a new schedule manager.
+    pub fn new(
+        store: &'a ConfigStore,
+        host: &'a dyn HostScheduler,
+        context: SchedulerInstallContext,
+    ) -> Self {
+        Self {
+            store,
+            host,
+            context,
+        }
+    }
+
+    /// Read-only inspection of a single schedule's status.
+    ///
+    /// Compares desired ConfigStore state with observed host state without
+    /// mutating either. Reports orphans (host entry without desired state)
+    /// and drift (mismatched schedule or enabled state).
+    pub async fn inspect(&self, schedule_id: &str) -> ScheduleStatus {
+        let desired = self.store.get_scheduled_task(schedule_id).await.ok().flatten();
+        let observed = self.host.inspect(schedule_id).await.ok().flatten();
+
+        self.synthesize_status(schedule_id, desired, observed)
+    }
+
+    /// Read-only inspection of all known schedules and owned host entries.
+    ///
+    /// Combines desired ConfigStore schedules with all owned host entries.
+    /// Orphaned host entries (no desired ConfigStore record) are included.
+    pub async fn inspect_all(&self) -> Vec<ScheduleStatus> {
+        let desired_list = self.store.list_scheduled_tasks().await.unwrap_or_default();
+        let observed_list = self.host.list_owned().await.unwrap_or_default();
+
+        let mut ids: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+        for d in &desired_list {
+            ids.insert(d.id.clone());
+        }
+        for o in &observed_list {
+            ids.insert(o.schedule_id.clone());
+        }
+
+        let mut results = Vec::new();
+        for id in ids {
+            let desired = desired_list.iter().find(|d| d.id == id).cloned();
+            let observed = observed_list.iter().find(|o| o.schedule_id == id).cloned();
+            results.push(self.synthesize_status(&id, desired, observed));
+        }
+        results
+    }
+
+    /// Mutating reconciliation of a single schedule.
+    ///
+    /// Installs, replaces, enables, disables, or removes the host entry to
+    /// match desired ConfigStore state. Returns the resulting status.
+    pub async fn reconcile(&self, schedule_id: &str) -> ScheduleStatus {
+        let desired = self.store.get_scheduled_task(schedule_id).await.ok().flatten();
+
+        match desired {
+            Some(schedule) => {
+                let request = self.build_install_request(&schedule);
+                match request {
+                    Ok(req) => {
+                        if let Err(e) = self.host.install(&req).await {
+                            return self.error_status(
+                                schedule_id,
+                                DesiredState::Present,
+                                HostState::Unknown,
+                                ScheduleDiagnosticKind::InstallationFailed,
+                                format!("host install failed: {}", e),
+                            );
+                        }
+                    }
+                    Err(diagnostic) => {
+                        return self.error_status(
+                            schedule_id,
+                            DesiredState::Present,
+                            HostState::Missing,
+                            ScheduleDiagnosticKind::UnsupportedSchedule,
+                            diagnostic,
+                        );
+                    }
+                }
+            }
+            None => {
+                if let Err(e) = self.host.remove(schedule_id).await {
+                    return self.error_status(
+                        schedule_id,
+                        DesiredState::Missing,
+                        HostState::Unknown,
+                        ScheduleDiagnosticKind::InstallationFailed,
+                        format!("host remove failed: {}", e),
+                    );
+                }
+            }
+        }
+
+        self.inspect(schedule_id).await
+    }
+
+    /// Reconcile all desired schedules and optionally remove orphans.
+    ///
+    /// Returns status for every schedule and orphan processed.
+    pub async fn reconcile_all(&self, orphan_policy: OrphanPolicy) -> Vec<ScheduleStatus> {
+        let desired_list = self.store.list_scheduled_tasks().await.unwrap_or_default();
+        let observed_list = self.host.list_owned().await.unwrap_or_default();
+
+        // Reconcile all desired schedules.
+        for schedule in &desired_list {
+            let request = self.build_install_request(schedule);
+            if let Ok(req) = request {
+                let _ = self.host.install(&req).await;
+            }
+        }
+
+        // Handle orphans.
+        let desired_ids: std::collections::HashSet<&str> =
+            desired_list.iter().map(|s| s.id.as_str()).collect();
+        for observed in &observed_list {
+            if !desired_ids.contains(observed.schedule_id.as_str()) {
+                if orphan_policy == OrphanPolicy::RemoveOrphans {
+                    let _ = self.host.remove(&observed.schedule_id).await;
+                }
+            }
+        }
+
+        self.inspect_all().await
+    }
+
+    /// Build a host install request from a desired schedule.
+    fn build_install_request(
+        &self,
+        schedule: &ScheduledTask,
+    ) -> Result<HostInstallRequest, String> {
+        let cron = CronExpression::parse(&schedule.cron_expression)
+            .map_err(|e| format!("schedule cron invalid: {}", e))?;
+
+        let command = self
+            .context
+            .generate_command(&schedule.automation_task_id);
+
+        Ok(HostInstallRequest {
+            schedule_id: schedule.id.clone(),
+            automation_task_id: schedule.automation_task_id.clone(),
+            cron,
+            enabled: schedule.enabled,
+            command,
+        })
+    }
+
+    /// Synthesize a compositional status from desired and observed state.
+    fn synthesize_status(
+        &self,
+        schedule_id: &str,
+        desired: Option<ScheduledTask>,
+        observed: Option<ObservedHostEntry>,
+    ) -> ScheduleStatus {
+        let mut diagnostics = Vec::new();
+        let mut reference_state = ReferenceState::Valid;
+        let mut execution_state = ExecutionState::Ready;
+        let mut host_state = HostState::Missing;
+
+        let desired_state = if let Some(ref schedule) = desired {
+            // Check automation-task reference.
+            let task_valid = self.check_reference(&schedule.automation_task_id);
+            match task_valid {
+                ReferenceCheckResult::Missing => {
+                    reference_state = ReferenceState::Missing;
+                    execution_state = ExecutionState::Unknown;
+                    diagnostics.push(ScheduleDiagnostic {
+                        kind: ScheduleDiagnosticKind::MissingTask,
+                        message: format!(
+                            "automation task '{}' does not exist",
+                            schedule.automation_task_id
+                        ),
+                    });
+                }
+                ReferenceCheckResult::Invalid => {
+                    reference_state = ReferenceState::Invalid;
+                    execution_state = ExecutionState::Unknown;
+                    diagnostics.push(ScheduleDiagnostic {
+                        kind: ScheduleDiagnosticKind::InvalidTask,
+                        message: format!(
+                            "automation task '{}' has an unsupported schema",
+                            schedule.automation_task_id
+                        ),
+                    });
+                }
+                ReferenceCheckResult::Valid => {}
+            }
+
+            DesiredState::Present
+        } else {
+            DesiredState::Missing
+        };
+
+        // Analyze host state.
+        if let Some(ref entry) = observed {
+            if entry.corrupt {
+                host_state = HostState::Corrupt;
+                diagnostics.push(ScheduleDiagnostic {
+                    kind: ScheduleDiagnosticKind::CorruptHostEntry,
+                    message: format!("host entry '{}' is corrupt", schedule_id),
+                });
+            } else if desired.is_none() {
+                host_state = HostState::Installed;
+                diagnostics.push(ScheduleDiagnostic {
+                    kind: ScheduleDiagnosticKind::OrphanedHostEntry,
+                    message: format!(
+                        "host entry '{}' exists but no desired schedule",
+                        schedule_id
+                    ),
+                });
+            } else if !entry.enabled && desired.as_ref().map(|d| d.enabled).unwrap_or(true) {
+                host_state = HostState::Disabled;
+                diagnostics.push(ScheduleDiagnostic {
+                    kind: ScheduleDiagnosticKind::ScheduleDrift,
+                    message: format!("host entry '{}' is disabled but desired is enabled", schedule_id),
+                });
+            } else if entry.enabled && !desired.as_ref().map(|d| d.enabled).unwrap_or(true) {
+                host_state = HostState::Drifted;
+                diagnostics.push(ScheduleDiagnostic {
+                    kind: ScheduleDiagnosticKind::ScheduleDrift,
+                    message: format!("host entry '{}' is enabled but desired is disabled", schedule_id),
+                });
+            } else if self.check_drift(&desired, entry) {
+                host_state = HostState::Drifted;
+                diagnostics.push(ScheduleDiagnostic {
+                    kind: ScheduleDiagnosticKind::ScheduleDrift,
+                    message: format!("host entry '{}' schedule or command differs from desired", schedule_id),
+                });
+            } else {
+                host_state = if entry.enabled {
+                    HostState::Installed
+                } else {
+                    HostState::Disabled
+                };
+            }
+        } else if desired.is_some() {
+            host_state = HostState::Missing;
+            diagnostics.push(ScheduleDiagnostic {
+                kind: ScheduleDiagnosticKind::NotInstalled,
+                message: format!("host entry '{}' is not installed", schedule_id),
+            });
+        }
+
+        // Check runner-path drift if we have both desired and observed.
+        if let (Some(ref schedule), Some(ref entry)) = (&desired, &observed) {
+            let expected_cmd = self
+                .context
+                .generate_command(&schedule.automation_task_id);
+            if let Some(ref observed_cmd) = entry.observed_command {
+                if *observed_cmd != expected_cmd {
+                    if host_state != HostState::Corrupt {
+                        host_state = HostState::Drifted;
+                    }
+                    diagnostics.push(ScheduleDiagnostic {
+                        kind: ScheduleDiagnosticKind::RunnerPathDrift,
+                        message: format!("host entry command differs from installation context"),
+                    });
+                }
+            }
+        }
+
+        let health = self.compute_health(&desired_state, &reference_state, &host_state);
+
+        ScheduleStatus {
+            schedule_id: schedule_id.to_string(),
+            health,
+            desired_state,
+            reference_state,
+            execution_state,
+            host_state,
+            diagnostics,
+            host_metadata: observed.and_then(|o| o.metadata),
+        }
+    }
+
+    fn compute_health(
+        &self,
+        desired: &DesiredState,
+        reference: &ReferenceState,
+        host: &HostState,
+    ) -> ScheduleHealth {
+        if *reference == ReferenceState::Missing || *reference == ReferenceState::Invalid {
+            return ScheduleHealth::Degraded;
+        }
+
+        match (*desired, *host) {
+            (DesiredState::Missing, HostState::Missing) => ScheduleHealth::Healthy,
+            (DesiredState::Missing, _) => ScheduleHealth::Degraded,
+            (DesiredState::Present, HostState::Installed)
+            | (DesiredState::Present, HostState::Disabled) => ScheduleHealth::Healthy,
+            (DesiredState::Present, _) => ScheduleHealth::Degraded,
+        }
+    }
+
+    /// Check whether the desired schedule matches the observed host entry.
+    fn check_drift(&self, desired: &Option<ScheduledTask>, observed: &ObservedHostEntry) -> bool {
+        let Some(schedule) = desired else {
+            return false;
+        };
+
+        if let Some(ref raw) = observed.raw_schedule {
+            if *raw != schedule.cron_expression {
+                return true;
+            }
+        }
+
+        false
+    }
+
+    /// Synchronously check automation-task reference validity.
+    /// Since ConfigStore methods are async but synthesize_status is sync,
+    /// we return a best-effort result. A full async version would require
+    /// restructuring. For now, this always returns Valid, and the actual
+    /// reference check is performed during reconcile.
+    fn check_reference(&self, _task_id: &str) -> ReferenceCheckResult {
+        ReferenceCheckResult::Valid
+    }
+
+    /// Build an error status for failed operations.
+    fn error_status(
+        &self,
+        schedule_id: &str,
+        desired: DesiredState,
+        host: HostState,
+        kind: ScheduleDiagnosticKind,
+        message: String,
+    ) -> ScheduleStatus {
+        ScheduleStatus {
+            schedule_id: schedule_id.to_string(),
+            health: ScheduleHealth::Degraded,
+            desired_state: desired,
+            reference_state: ReferenceState::Valid,
+            execution_state: ExecutionState::Unknown,
+            host_state: host,
+            diagnostics: vec![ScheduleDiagnostic { kind, message }],
+            host_metadata: None,
+        }
+    }
+}
+
+/// Internal reference-check result.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReferenceCheckResult {
+    Valid,
+    Missing,
+    Invalid,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::automation_task::AutomationTaskInput;
+    use crate::config::records::PromptInput;
+    use crate::scheduled_task::host::FakeHostScheduler;
+    use crate::scheduled_task::ScheduledTaskInput;
+    use serde_json::json;
+
+    async fn setup_store() -> ConfigStore {
+        let store = ConfigStore::open_in_memory().await.unwrap();
+        let temp = tempfile::tempdir().unwrap();
+
+        store
+            .set_prompt(&PromptInput {
+                id: "prompt-1".to_string(),
+                schema_version: crate::stored_prompt::STORED_PROMPT_SCHEMA_VERSION,
+                payload: json!({"instructions": "Do thing", "skills": []}),
+            })
+            .await
+            .unwrap();
+
+        store
+            .set_automation_task(&AutomationTaskInput {
+                id: "task-1".to_string(),
+                display_name: "Task One".to_string(),
+                stored_prompt_id: "prompt-1".to_string(),
+                expected_outcome: "Done".to_string(),
+                project_root: temp.path().to_path_buf(),
+                timeout_seconds: 300,
+            })
+            .await
+            .unwrap();
+
+        store
+            .set_scheduled_task(&ScheduledTaskInput {
+                id: "sched-1".to_string(),
+                automation_task_id: "task-1".to_string(),
+                cron_expression: "0 9 * * *".to_string(),
+                enabled: true,
+            })
+            .await
+            .unwrap();
+
+        store
+    }
+
+    fn test_context() -> SchedulerInstallContext {
+        SchedulerInstallContext {
+            runner_executable: PathBuf::from("/usr/local/bin/agent-iron"),
+            config_store_path: PathBuf::from("/home/user/.config/agentiron/config.db"),
+        }
+    }
+
+    #[tokio::test]
+    async fn inspect_healthy_schedule() {
+        let store = setup_store().await;
+        let host = FakeHostScheduler::new();
+        let ctx = test_context();
+        let mgr = ScheduleManager::new(&store, &host, ctx);
+
+        // No host entry yet → degraded (not installed).
+        let status = mgr.inspect("sched-1").await;
+        assert_eq!(status.health, ScheduleHealth::Degraded);
+        assert_eq!(status.desired_state, DesiredState::Present);
+        assert_eq!(status.host_state, HostState::Missing);
+    }
+
+    #[tokio::test]
+    async fn reconcile_installs_host_entry() {
+        let store = setup_store().await;
+        let host = FakeHostScheduler::new();
+        let ctx = test_context();
+        let mgr = ScheduleManager::new(&store, &host, ctx);
+
+        let status = mgr.reconcile("sched-1").await;
+        assert_eq!(status.health, ScheduleHealth::Healthy);
+        assert_eq!(status.host_state, HostState::Installed);
+
+        let entry = host.inspect("sched-1").await.unwrap().unwrap();
+        assert!(entry.enabled);
+        assert!(entry.observed_command.as_deref().unwrap().contains("run task-1"));
+    }
+
+    #[tokio::test]
+    async fn reconcile_disabled_schedule() {
+        let store = setup_store().await;
+        let host = FakeHostScheduler::new();
+        let ctx = test_context();
+        let mgr = ScheduleManager::new(&store, &host, ctx);
+
+        // Update to disabled.
+        store
+            .set_scheduled_task(&ScheduledTaskInput {
+                id: "sched-1".to_string(),
+                automation_task_id: "task-1".to_string(),
+                cron_expression: "0 9 * * *".to_string(),
+                enabled: false,
+            })
+            .await
+            .unwrap();
+
+        let status = mgr.reconcile("sched-1").await;
+        assert_eq!(status.health, ScheduleHealth::Healthy);
+        assert_eq!(status.host_state, HostState::Disabled);
+    }
+
+    #[tokio::test]
+    async fn inspect_reports_drift() {
+        let store = setup_store().await;
+        let host = FakeHostScheduler::new();
+        let ctx = test_context();
+        let mgr = ScheduleManager::new(&store, &host, ctx);
+
+        // Install with original schedule.
+        mgr.reconcile("sched-1").await;
+
+        // Change desired schedule.
+        store
+            .set_scheduled_task(&ScheduledTaskInput {
+                id: "sched-1".to_string(),
+                automation_task_id: "task-1".to_string(),
+                cron_expression: "0 10 * * *".to_string(),
+                enabled: true,
+            })
+            .await
+            .unwrap();
+
+        let status = mgr.inspect("sched-1").await;
+        assert_eq!(status.health, ScheduleHealth::Degraded);
+        assert_eq!(status.host_state, HostState::Drifted);
+        assert!(status
+            .diagnostics
+            .iter()
+            .any(|d| d.kind == ScheduleDiagnosticKind::ScheduleDrift));
+    }
+
+    #[tokio::test]
+    async fn inspect_reports_orphan() {
+        let store = setup_store().await;
+        let host = FakeHostScheduler::new();
+        let ctx = test_context();
+        let mgr = ScheduleManager::new(&store, &host, ctx.clone());
+
+        let cron = CronExpression::parse("0 6 * * *").unwrap();
+        host.install(&HostInstallRequest {
+            schedule_id: "orphan".to_string(),
+            automation_task_id: "task-1".to_string(),
+            cron,
+            enabled: true,
+            command: ctx.generate_command("task-1"),
+        })
+        .await
+        .unwrap();
+
+        let status = mgr.inspect("orphan").await;
+        assert_eq!(status.health, ScheduleHealth::Degraded);
+        assert_eq!(status.desired_state, DesiredState::Missing);
+        assert!(status
+            .diagnostics
+            .iter()
+            .any(|d| d.kind == ScheduleDiagnosticKind::OrphanedHostEntry));
+    }
+
+    #[tokio::test]
+    async fn reconcile_removes_orphan_with_policy() {
+        let store = setup_store().await;
+        let host = FakeHostScheduler::new();
+        let ctx = test_context();
+        let mgr = ScheduleManager::new(&store, &host, ctx.clone());
+
+        let cron = CronExpression::parse("0 6 * * *").unwrap();
+        host.install(&HostInstallRequest {
+            schedule_id: "orphan".to_string(),
+            automation_task_id: "task-1".to_string(),
+            cron,
+            enabled: true,
+            command: ctx.generate_command("task-1"),
+        })
+        .await
+        .unwrap();
+
+        mgr.reconcile_all(OrphanPolicy::RemoveOrphans).await;
+        assert!(host.inspect("orphan").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn reconcile_all_keeps_orphan_with_report_only() {
+        let store = setup_store().await;
+        let host = FakeHostScheduler::new();
+        let ctx = test_context();
+        let mgr = ScheduleManager::new(&store, &host, ctx.clone());
+
+        let cron = CronExpression::parse("0 6 * * *").unwrap();
+        host.install(&HostInstallRequest {
+            schedule_id: "orphan".to_string(),
+            automation_task_id: "task-1".to_string(),
+            cron,
+            enabled: true,
+            command: ctx.generate_command("task-1"),
+        })
+        .await
+        .unwrap();
+
+        mgr.reconcile_all(OrphanPolicy::ReportOnly).await;
+        assert!(host.inspect("orphan").await.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn reconcile_idempotent() {
+        let store = setup_store().await;
+        let host = FakeHostScheduler::new();
+        let ctx = test_context();
+        let mgr = ScheduleManager::new(&store, &host, ctx);
+
+        let status1 = mgr.reconcile("sched-1").await;
+        let status2 = mgr.reconcile("sched-1").await;
+
+        assert_eq!(status1.health, ScheduleHealth::Healthy);
+        assert_eq!(status2.health, ScheduleHealth::Healthy);
+    }
+
+    #[tokio::test]
+    async fn inspect_runner_path_drift() {
+        let store = setup_store().await;
+        let host = FakeHostScheduler::new();
+        let ctx = test_context();
+        let mgr = ScheduleManager::new(&store, &host, ctx);
+
+        // Install with correct context.
+        mgr.reconcile("sched-1").await;
+
+        // Now create a manager with a different context.
+        let ctx2 = SchedulerInstallContext {
+            runner_executable: PathBuf::from("/different/path/agent-iron"),
+            config_store_path: PathBuf::from("/different/config.db"),
+        };
+        let mgr2 = ScheduleManager::new(&store, &host, ctx2);
+
+        let status = mgr2.inspect("sched-1").await;
+        assert!(status
+            .diagnostics
+            .iter()
+            .any(|d| d.kind == ScheduleDiagnosticKind::RunnerPathDrift));
+    }
+
+    #[tokio::test]
+    async fn inspect_missing_schedule_returns_healthy_missing() {
+        let store = setup_store().await;
+        let host = FakeHostScheduler::new();
+        let ctx = test_context();
+        let mgr = ScheduleManager::new(&store, &host, ctx);
+
+        let status = mgr.inspect("nonexistent").await;
+        assert_eq!(status.health, ScheduleHealth::Healthy);
+        assert_eq!(status.desired_state, DesiredState::Missing);
+        assert_eq!(status.host_state, HostState::Missing);
+    }
+
+    #[tokio::test]
+    async fn reconcile_removes_deleted_schedule() {
+        let store = setup_store().await;
+        let host = FakeHostScheduler::new();
+        let ctx = test_context();
+        let mgr = ScheduleManager::new(&store, &host, ctx);
+
+        // Install.
+        mgr.reconcile("sched-1").await;
+        assert!(host.inspect("sched-1").await.unwrap().is_some());
+
+        // Delete desired state.
+        store.delete_scheduled_task("sched-1").await.unwrap();
+
+        // Reconcile should remove host entry.
+        mgr.reconcile("sched-1").await;
+        assert!(host.inspect("sched-1").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn host_error_during_reconcile_reports_degraded() {
+        let store = setup_store().await;
+        let host = FakeHostScheduler::new();
+        *host.force_error.lock() = Some(HostSchedulerError::PlatformUnavailable("test".to_string()));
+        let ctx = test_context();
+        let mgr = ScheduleManager::new(&store, &host, ctx);
+
+        let status = mgr.reconcile("sched-1").await;
+        assert_eq!(status.health, ScheduleHealth::Degraded);
+        assert!(status
+            .diagnostics
+            .iter()
+            .any(|d| d.kind == ScheduleDiagnosticKind::InstallationFailed));
+    }
+}

--- a/src/scheduled_task/manager.rs
+++ b/src/scheduled_task/manager.rs
@@ -54,23 +54,48 @@ impl<'a> ScheduleManager<'a> {
     /// mutating either. Reports orphans (host entry without desired state)
     /// and drift (mismatched schedule or enabled state).
     pub async fn inspect(&self, schedule_id: &str) -> ScheduleStatus {
-        let desired = self
-            .store
-            .get_scheduled_task(schedule_id)
-            .await
-            .ok()
-            .flatten();
-        let observed = self.host.inspect(schedule_id).await.ok().flatten();
+        let (desired, store_error) = match self.store.get_scheduled_task(schedule_id).await {
+            Ok(opt) => (opt, None),
+            Err(e) => (None, Some(format!("config store error: {}", e))),
+        };
 
-        self.synthesize_status(schedule_id, desired, observed)
+        let (observed, host_error) = match self.host.inspect(schedule_id).await {
+            Ok(opt) => (opt, None),
+            Err(e) => (None, Some(format!("host error: {}", e))),
+        };
+
+        // Check automation-task reference.
+        let reference_state = match &desired {
+            Some(schedule) => {
+                match self
+                    .store
+                    .get_automation_task(&schedule.automation_task_id)
+                    .await
+                {
+                    Ok(Some(_)) => ReferenceState::Valid,
+                    Ok(None) => ReferenceState::Missing,
+                    Err(_) => ReferenceState::Invalid,
+                }
+            }
+            None => ReferenceState::Valid,
+        };
+
+        self.synthesize_status(
+            schedule_id,
+            desired,
+            observed,
+            store_error,
+            host_error,
+            reference_state,
+        )
     }
 
     /// Read-only inspection of all known schedules and owned host entries.
-    ///
-    /// Combines desired ConfigStore schedules with all owned host entries.
-    /// Orphaned host entries (no desired ConfigStore record) are included.
     pub async fn inspect_all(&self) -> Vec<ScheduleStatus> {
-        let desired_list = self.store.list_scheduled_tasks().await.unwrap_or_default();
+        let desired_list = match self.store.list_scheduled_tasks().await {
+            Ok(list) => list,
+            Err(_) => return Vec::new(),
+        };
         let observed_list = self.host.list_owned().await.unwrap_or_default();
 
         let mut ids: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
@@ -85,7 +110,31 @@ impl<'a> ScheduleManager<'a> {
         for id in ids {
             let desired = desired_list.iter().find(|d| d.id == id).cloned();
             let observed = observed_list.iter().find(|o| o.schedule_id == id).cloned();
-            results.push(self.synthesize_status(&id, desired, observed));
+
+            // Check reference for desired schedules.
+            let reference_state = match &desired {
+                Some(schedule) => {
+                    match self
+                        .store
+                        .get_automation_task(&schedule.automation_task_id)
+                        .await
+                    {
+                        Ok(Some(_)) => ReferenceState::Valid,
+                        Ok(None) => ReferenceState::Missing,
+                        Err(_) => ReferenceState::Invalid,
+                    }
+                }
+                None => ReferenceState::Valid,
+            };
+
+            results.push(self.synthesize_status(
+                &id,
+                desired,
+                observed,
+                None,
+                None,
+                reference_state,
+            ));
         }
         results
     }
@@ -202,24 +251,41 @@ impl<'a> ScheduleManager<'a> {
     }
 
     /// Synthesize a compositional status from desired and observed state.
+    #[allow(clippy::too_many_arguments)]
     fn synthesize_status(
         &self,
         schedule_id: &str,
         desired: Option<ScheduledTask>,
         observed: Option<ObservedHostEntry>,
+        store_error: Option<String>,
+        host_error: Option<String>,
+        reference_state: ReferenceState,
     ) -> ScheduleStatus {
         let mut diagnostics = Vec::new();
-        let mut reference_state = ReferenceState::Valid;
-        let mut execution_state = ExecutionState::Ready;
+        let execution_state = ExecutionState::Unknown; // Cannot verify headless safety without profile registry.
         let mut host_state = HostState::Missing;
 
+        // Surface store errors.
+        if let Some(ref msg) = store_error {
+            diagnostics.push(ScheduleDiagnostic {
+                kind: ScheduleDiagnosticKind::PlatformUnavailable,
+                message: msg.clone(),
+            });
+        }
+
+        // Surface host errors.
+        if let Some(ref msg) = host_error {
+            diagnostics.push(ScheduleDiagnostic {
+                kind: ScheduleDiagnosticKind::PlatformUnavailable,
+                message: msg.clone(),
+            });
+            host_state = HostState::Unknown;
+        }
+
         let desired_state = if let Some(ref schedule) = desired {
-            // Check automation-task reference.
-            let task_valid = self.check_reference(&schedule.automation_task_id);
-            match task_valid {
-                ReferenceCheckResult::Missing => {
-                    reference_state = ReferenceState::Missing;
-                    execution_state = ExecutionState::Unknown;
+            // Add reference diagnostics from pre-checked state.
+            match reference_state {
+                ReferenceState::Missing => {
                     diagnostics.push(ScheduleDiagnostic {
                         kind: ScheduleDiagnosticKind::MissingTask,
                         message: format!(
@@ -228,9 +294,7 @@ impl<'a> ScheduleManager<'a> {
                         ),
                     });
                 }
-                ReferenceCheckResult::Invalid => {
-                    reference_state = ReferenceState::Invalid;
-                    execution_state = ExecutionState::Unknown;
+                ReferenceState::Invalid => {
                     diagnostics.push(ScheduleDiagnostic {
                         kind: ScheduleDiagnosticKind::InvalidTask,
                         message: format!(
@@ -239,7 +303,7 @@ impl<'a> ScheduleManager<'a> {
                         ),
                     });
                 }
-                ReferenceCheckResult::Valid => {}
+                ReferenceState::Valid => {}
             }
 
             DesiredState::Present
@@ -247,63 +311,65 @@ impl<'a> ScheduleManager<'a> {
             DesiredState::Missing
         };
 
-        // Analyze host state.
-        if let Some(ref entry) = observed {
-            if entry.corrupt {
-                host_state = HostState::Corrupt;
-                diagnostics.push(ScheduleDiagnostic {
-                    kind: ScheduleDiagnosticKind::CorruptHostEntry,
-                    message: format!("host entry '{}' is corrupt", schedule_id),
-                });
-            } else if desired.is_none() {
-                host_state = HostState::Installed;
-                diagnostics.push(ScheduleDiagnostic {
-                    kind: ScheduleDiagnosticKind::OrphanedHostEntry,
-                    message: format!(
-                        "host entry '{}' exists but no desired schedule",
-                        schedule_id
-                    ),
-                });
-            } else if !entry.enabled && desired.as_ref().map(|d| d.enabled).unwrap_or(true) {
-                host_state = HostState::Disabled;
-                diagnostics.push(ScheduleDiagnostic {
-                    kind: ScheduleDiagnosticKind::ScheduleDrift,
-                    message: format!(
-                        "host entry '{}' is disabled but desired is enabled",
-                        schedule_id
-                    ),
-                });
-            } else if entry.enabled && !desired.as_ref().map(|d| d.enabled).unwrap_or(true) {
-                host_state = HostState::Drifted;
-                diagnostics.push(ScheduleDiagnostic {
-                    kind: ScheduleDiagnosticKind::ScheduleDrift,
-                    message: format!(
-                        "host entry '{}' is enabled but desired is disabled",
-                        schedule_id
-                    ),
-                });
-            } else if self.check_drift(&desired, entry) {
-                host_state = HostState::Drifted;
-                diagnostics.push(ScheduleDiagnostic {
-                    kind: ScheduleDiagnosticKind::ScheduleDrift,
-                    message: format!(
-                        "host entry '{}' schedule or command differs from desired",
-                        schedule_id
-                    ),
-                });
-            } else {
-                host_state = if entry.enabled {
-                    HostState::Installed
+        // Analyze host state (only if no host error).
+        if host_error.is_none() {
+            if let Some(ref entry) = observed {
+                if entry.corrupt {
+                    host_state = HostState::Corrupt;
+                    diagnostics.push(ScheduleDiagnostic {
+                        kind: ScheduleDiagnosticKind::CorruptHostEntry,
+                        message: format!("host entry '{}' is corrupt", schedule_id),
+                    });
+                } else if desired.is_none() {
+                    host_state = HostState::Installed;
+                    diagnostics.push(ScheduleDiagnostic {
+                        kind: ScheduleDiagnosticKind::OrphanedHostEntry,
+                        message: format!(
+                            "host entry '{}' exists but no desired schedule",
+                            schedule_id
+                        ),
+                    });
+                } else if !entry.enabled && desired.as_ref().map(|d| d.enabled).unwrap_or(true) {
+                    host_state = HostState::Disabled;
+                    diagnostics.push(ScheduleDiagnostic {
+                        kind: ScheduleDiagnosticKind::ScheduleDrift,
+                        message: format!(
+                            "host entry '{}' is disabled but desired is enabled",
+                            schedule_id
+                        ),
+                    });
+                } else if entry.enabled && !desired.as_ref().map(|d| d.enabled).unwrap_or(true) {
+                    host_state = HostState::Drifted;
+                    diagnostics.push(ScheduleDiagnostic {
+                        kind: ScheduleDiagnosticKind::ScheduleDrift,
+                        message: format!(
+                            "host entry '{}' is enabled but desired is disabled",
+                            schedule_id
+                        ),
+                    });
+                } else if self.check_drift(&desired, entry) {
+                    host_state = HostState::Drifted;
+                    diagnostics.push(ScheduleDiagnostic {
+                        kind: ScheduleDiagnosticKind::ScheduleDrift,
+                        message: format!(
+                            "host entry '{}' schedule or command differs from desired",
+                            schedule_id
+                        ),
+                    });
                 } else {
-                    HostState::Disabled
-                };
+                    host_state = if entry.enabled {
+                        HostState::Installed
+                    } else {
+                        HostState::Disabled
+                    };
+                }
+            } else if desired.is_some() {
+                host_state = HostState::Missing;
+                diagnostics.push(ScheduleDiagnostic {
+                    kind: ScheduleDiagnosticKind::NotInstalled,
+                    message: format!("host entry '{}' is not installed", schedule_id),
+                });
             }
-        } else if desired.is_some() {
-            host_state = HostState::Missing;
-            diagnostics.push(ScheduleDiagnostic {
-                kind: ScheduleDiagnosticKind::NotInstalled,
-                message: format!("host entry '{}' is not installed", schedule_id),
-            });
         }
 
         // Check runner-path drift if we have both desired and observed.
@@ -313,10 +379,8 @@ impl<'a> ScheduleManager<'a> {
                 .generate_invocation(&schedule.automation_task_id);
             let expected_cmd = crate::scheduled_task::host::render_command(&program, &args);
             if let Some(ref observed_cmd) = entry.observed_command {
-                if *observed_cmd != expected_cmd {
-                    if host_state != HostState::Corrupt {
-                        host_state = HostState::Drifted;
-                    }
+                if *observed_cmd != expected_cmd && host_state != HostState::Corrupt {
+                    host_state = HostState::Drifted;
                     diagnostics.push(ScheduleDiagnostic {
                         kind: ScheduleDiagnosticKind::RunnerPathDrift,
                         message: "host entry command differs from installation context".to_string(),
@@ -325,7 +389,11 @@ impl<'a> ScheduleManager<'a> {
             }
         }
 
-        let health = self.compute_health(&desired_state, &reference_state, &host_state);
+        let health = if store_error.is_some() || host_error.is_some() {
+            ScheduleHealth::Unavailable
+        } else {
+            self.compute_health(&desired_state, &reference_state, &host_state)
+        };
 
         ScheduleStatus {
             schedule_id: schedule_id.to_string(),
@@ -373,15 +441,6 @@ impl<'a> ScheduleManager<'a> {
         false
     }
 
-    /// Synchronously check automation-task reference validity.
-    /// Since ConfigStore methods are async but synthesize_status is sync,
-    /// we return a best-effort result. A full async version would require
-    /// restructuring. For now, this always returns Valid, and the actual
-    /// reference check is performed during reconcile.
-    fn check_reference(&self, _task_id: &str) -> ReferenceCheckResult {
-        ReferenceCheckResult::Valid
-    }
-
     /// Build an error status for failed operations.
     fn error_status(
         &self,
@@ -402,15 +461,6 @@ impl<'a> ScheduleManager<'a> {
             host_metadata: None,
         }
     }
-}
-
-/// Internal reference-check result.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[allow(dead_code)]
-enum ReferenceCheckResult {
-    Valid,
-    Missing,
-    Invalid,
 }
 
 #[cfg(test)]

--- a/src/scheduled_task/manager.rs
+++ b/src/scheduled_task/manager.rs
@@ -91,12 +91,27 @@ impl<'a> ScheduleManager<'a> {
     }
 
     /// Read-only inspection of all known schedules and owned host entries.
+    ///
+    /// Returns a vector with a single error status if the ConfigStore read
+    /// fails, so callers are never misled into thinking there are zero
+    /// schedules. Host-list failures are surfaced as per-schedule diagnostics.
     pub async fn inspect_all(&self) -> Vec<ScheduleStatus> {
         let desired_list = match self.store.list_scheduled_tasks().await {
             Ok(list) => list,
-            Err(_) => return Vec::new(),
+            Err(e) => {
+                return vec![self.error_status(
+                    "",
+                    DesiredState::Missing,
+                    HostState::Unknown,
+                    ScheduleDiagnosticKind::PlatformUnavailable,
+                    format!("config store error: {}", e),
+                )];
+            }
         };
-        let observed_list = self.host.list_owned().await.unwrap_or_default();
+        let (observed_list, host_error) = match self.host.list_owned().await {
+            Ok(list) => (list, None),
+            Err(e) => (Vec::new(), Some(format!("host error: {}", e))),
+        };
 
         let mut ids: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
         for d in &desired_list {
@@ -132,7 +147,7 @@ impl<'a> ScheduleManager<'a> {
                 desired,
                 observed,
                 None,
-                None,
+                host_error.clone(),
                 reference_state,
             ));
         }
@@ -230,17 +245,39 @@ impl<'a> ScheduleManager<'a> {
 
     /// Reconcile all desired schedules and optionally remove orphans.
     ///
-    /// Returns status for every schedule and orphan processed.
+    /// Returns status for every schedule and orphan processed. Aborts
+    /// before any host mutation if the desired-state read fails, so a
+    /// transient ConfigStore error can never cause host-entry removal.
     pub async fn reconcile_all(&self, orphan_policy: OrphanPolicy) -> Vec<ScheduleStatus> {
-        let desired_list = self.store.list_scheduled_tasks().await.unwrap_or_default();
-        let observed_list = self.host.list_owned().await.unwrap_or_default();
-
-        // Reconcile all desired schedules.
-        for schedule in &desired_list {
-            let request = self.build_install_request(schedule);
-            if let Ok(req) = request {
-                let _ = self.host.install(&req).await;
+        let desired_list = match self.store.list_scheduled_tasks().await {
+            Ok(list) => list,
+            Err(e) => {
+                return vec![self.error_status(
+                    "",
+                    DesiredState::Missing,
+                    HostState::Unknown,
+                    ScheduleDiagnosticKind::PlatformUnavailable,
+                    format!("config store error: {}", e),
+                )];
             }
+        };
+        let observed_list = match self.host.list_owned().await {
+            Ok(list) => list,
+            Err(e) => {
+                return vec![self.error_status(
+                    "",
+                    DesiredState::Missing,
+                    HostState::Unknown,
+                    ScheduleDiagnosticKind::PlatformUnavailable,
+                    format!("host error: {}", e),
+                )];
+            }
+        };
+
+        // Reconcile all desired schedules via per-schedule reconcile so each
+        // entry goes through the inspect-before-mutate path.
+        for schedule in &desired_list {
+            let _ = self.reconcile(&schedule.id).await;
         }
 
         // Handle orphans.
@@ -291,7 +328,14 @@ impl<'a> ScheduleManager<'a> {
         reference_state: ReferenceState,
     ) -> ScheduleStatus {
         let mut diagnostics = Vec::new();
-        let execution_state = ExecutionState::Unknown; // Cannot verify headless safety without profile registry.
+        let execution_state = if desired.is_some() && store_error.is_none() {
+            match reference_state {
+                ReferenceState::Valid => ExecutionState::Ready,
+                ReferenceState::Missing | ReferenceState::Invalid => ExecutionState::Unknown,
+            }
+        } else {
+            ExecutionState::Unknown
+        };
         let mut host_state = HostState::Missing;
 
         // Surface store errors.
@@ -421,7 +465,12 @@ impl<'a> ScheduleManager<'a> {
         let health = if store_error.is_some() || host_error.is_some() {
             ScheduleHealth::Unavailable
         } else {
-            self.compute_health(&desired_state, &reference_state, &host_state)
+            self.compute_health(
+                &desired_state,
+                &reference_state,
+                &execution_state,
+                &host_state,
+            )
         };
 
         ScheduleStatus {
@@ -440,18 +489,21 @@ impl<'a> ScheduleManager<'a> {
         &self,
         desired: &DesiredState,
         reference: &ReferenceState,
+        execution: &ExecutionState,
         host: &HostState,
     ) -> ScheduleHealth {
         if *reference == ReferenceState::Missing || *reference == ReferenceState::Invalid {
             return ScheduleHealth::Degraded;
         }
 
-        match (*desired, *host) {
-            (DesiredState::Missing, HostState::Missing) => ScheduleHealth::Healthy,
-            (DesiredState::Missing, _) => ScheduleHealth::Degraded,
-            (DesiredState::Present, HostState::Installed)
-            | (DesiredState::Present, HostState::Disabled) => ScheduleHealth::Healthy,
-            (DesiredState::Present, _) => ScheduleHealth::Degraded,
+        match (*desired, *execution, *host) {
+            (DesiredState::Missing, _, HostState::Missing) => ScheduleHealth::Healthy,
+            (DesiredState::Missing, _, _) => ScheduleHealth::Degraded,
+            (DesiredState::Present, ExecutionState::Ready, HostState::Installed)
+            | (DesiredState::Present, ExecutionState::Ready, HostState::Disabled) => {
+                ScheduleHealth::Healthy
+            }
+            (DesiredState::Present, _, _) => ScheduleHealth::Degraded,
         }
     }
 

--- a/src/scheduled_task/manager.rs
+++ b/src/scheduled_task/manager.rs
@@ -5,16 +5,13 @@
 //! host scheduler for observed state, and returns compositional status
 //! reports. Inspection is read-only; reconciliation mutates host entries.
 
-use std::path::PathBuf;
-
 use crate::config::ConfigStore;
 use crate::scheduled_task::cron::CronExpression;
 use crate::scheduled_task::host::{
-    HostInstallRequest, HostScheduler, HostSchedulerError, ObservedHostEntry,
-    SchedulerInstallContext,
+    HostInstallRequest, HostScheduler, ObservedHostEntry, SchedulerInstallContext,
 };
 use crate::scheduled_task::{
-    DesiredState, ExecutionState, HostRunMetadata, HostState, ReferenceState, ScheduleDiagnostic,
+    DesiredState, ExecutionState, HostState, ReferenceState, ScheduleDiagnostic,
     ScheduleDiagnosticKind, ScheduleHealth, ScheduleStatus, ScheduledTask,
 };
 
@@ -57,7 +54,12 @@ impl<'a> ScheduleManager<'a> {
     /// mutating either. Reports orphans (host entry without desired state)
     /// and drift (mismatched schedule or enabled state).
     pub async fn inspect(&self, schedule_id: &str) -> ScheduleStatus {
-        let desired = self.store.get_scheduled_task(schedule_id).await.ok().flatten();
+        let desired = self
+            .store
+            .get_scheduled_task(schedule_id)
+            .await
+            .ok()
+            .flatten();
         let observed = self.host.inspect(schedule_id).await.ok().flatten();
 
         self.synthesize_status(schedule_id, desired, observed)
@@ -93,7 +95,18 @@ impl<'a> ScheduleManager<'a> {
     /// Installs, replaces, enables, disables, or removes the host entry to
     /// match desired ConfigStore state. Returns the resulting status.
     pub async fn reconcile(&self, schedule_id: &str) -> ScheduleStatus {
-        let desired = self.store.get_scheduled_task(schedule_id).await.ok().flatten();
+        let desired = match self.store.get_scheduled_task(schedule_id).await {
+            Ok(opt) => opt,
+            Err(e) => {
+                return self.error_status(
+                    schedule_id,
+                    DesiredState::Present,
+                    HostState::Unknown,
+                    ScheduleDiagnosticKind::InstallationFailed,
+                    format!("config store error: {}", e),
+                );
+            }
+        };
 
         match desired {
             Some(schedule) => {
@@ -156,10 +169,10 @@ impl<'a> ScheduleManager<'a> {
         let desired_ids: std::collections::HashSet<&str> =
             desired_list.iter().map(|s| s.id.as_str()).collect();
         for observed in &observed_list {
-            if !desired_ids.contains(observed.schedule_id.as_str()) {
-                if orphan_policy == OrphanPolicy::RemoveOrphans {
-                    let _ = self.host.remove(&observed.schedule_id).await;
-                }
+            if !desired_ids.contains(observed.schedule_id.as_str())
+                && orphan_policy == OrphanPolicy::RemoveOrphans
+            {
+                let _ = self.host.remove(&observed.schedule_id).await;
             }
         }
 
@@ -174,16 +187,17 @@ impl<'a> ScheduleManager<'a> {
         let cron = CronExpression::parse(&schedule.cron_expression)
             .map_err(|e| format!("schedule cron invalid: {}", e))?;
 
-        let command = self
+        let (program, args) = self
             .context
-            .generate_command(&schedule.automation_task_id);
+            .generate_invocation(&schedule.automation_task_id);
 
         Ok(HostInstallRequest {
             schedule_id: schedule.id.clone(),
             automation_task_id: schedule.automation_task_id.clone(),
             cron,
             enabled: schedule.enabled,
-            command,
+            program,
+            args,
         })
     }
 
@@ -254,19 +268,28 @@ impl<'a> ScheduleManager<'a> {
                 host_state = HostState::Disabled;
                 diagnostics.push(ScheduleDiagnostic {
                     kind: ScheduleDiagnosticKind::ScheduleDrift,
-                    message: format!("host entry '{}' is disabled but desired is enabled", schedule_id),
+                    message: format!(
+                        "host entry '{}' is disabled but desired is enabled",
+                        schedule_id
+                    ),
                 });
             } else if entry.enabled && !desired.as_ref().map(|d| d.enabled).unwrap_or(true) {
                 host_state = HostState::Drifted;
                 diagnostics.push(ScheduleDiagnostic {
                     kind: ScheduleDiagnosticKind::ScheduleDrift,
-                    message: format!("host entry '{}' is enabled but desired is disabled", schedule_id),
+                    message: format!(
+                        "host entry '{}' is enabled but desired is disabled",
+                        schedule_id
+                    ),
                 });
             } else if self.check_drift(&desired, entry) {
                 host_state = HostState::Drifted;
                 diagnostics.push(ScheduleDiagnostic {
                     kind: ScheduleDiagnosticKind::ScheduleDrift,
-                    message: format!("host entry '{}' schedule or command differs from desired", schedule_id),
+                    message: format!(
+                        "host entry '{}' schedule or command differs from desired",
+                        schedule_id
+                    ),
                 });
             } else {
                 host_state = if entry.enabled {
@@ -285,9 +308,10 @@ impl<'a> ScheduleManager<'a> {
 
         // Check runner-path drift if we have both desired and observed.
         if let (Some(ref schedule), Some(ref entry)) = (&desired, &observed) {
-            let expected_cmd = self
+            let (program, args) = self
                 .context
-                .generate_command(&schedule.automation_task_id);
+                .generate_invocation(&schedule.automation_task_id);
+            let expected_cmd = crate::scheduled_task::host::render_command(&program, &args);
             if let Some(ref observed_cmd) = entry.observed_command {
                 if *observed_cmd != expected_cmd {
                     if host_state != HostState::Corrupt {
@@ -295,7 +319,7 @@ impl<'a> ScheduleManager<'a> {
                     }
                     diagnostics.push(ScheduleDiagnostic {
                         kind: ScheduleDiagnosticKind::RunnerPathDrift,
-                        message: format!("host entry command differs from installation context"),
+                        message: "host entry command differs from installation context".to_string(),
                     });
                 }
             }
@@ -382,6 +406,7 @@ impl<'a> ScheduleManager<'a> {
 
 /// Internal reference-check result.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)]
 enum ReferenceCheckResult {
     Valid,
     Missing,
@@ -393,9 +418,10 @@ mod tests {
     use super::*;
     use crate::automation_task::AutomationTaskInput;
     use crate::config::records::PromptInput;
-    use crate::scheduled_task::host::FakeHostScheduler;
+    use crate::scheduled_task::host::{FakeHostScheduler, HostSchedulerError};
     use crate::scheduled_task::ScheduledTaskInput;
     use serde_json::json;
+    use std::path::PathBuf;
 
     async fn setup_store() -> ConfigStore {
         let store = ConfigStore::open_in_memory().await.unwrap();
@@ -469,7 +495,11 @@ mod tests {
 
         let entry = host.inspect("sched-1").await.unwrap().unwrap();
         assert!(entry.enabled);
-        assert!(entry.observed_command.as_deref().unwrap().contains("run task-1"));
+        assert!(entry
+            .observed_command
+            .as_deref()
+            .unwrap()
+            .contains("run task-1"));
     }
 
     #[tokio::test]
@@ -533,12 +563,14 @@ mod tests {
         let mgr = ScheduleManager::new(&store, &host, ctx.clone());
 
         let cron = CronExpression::parse("0 6 * * *").unwrap();
+        let (program, args) = ctx.generate_invocation("task-1");
         host.install(&HostInstallRequest {
             schedule_id: "orphan".to_string(),
             automation_task_id: "task-1".to_string(),
             cron,
             enabled: true,
-            command: ctx.generate_command("task-1"),
+            program,
+            args,
         })
         .await
         .unwrap();
@@ -560,12 +592,14 @@ mod tests {
         let mgr = ScheduleManager::new(&store, &host, ctx.clone());
 
         let cron = CronExpression::parse("0 6 * * *").unwrap();
+        let (program, args) = ctx.generate_invocation("task-1");
         host.install(&HostInstallRequest {
             schedule_id: "orphan".to_string(),
             automation_task_id: "task-1".to_string(),
             cron,
             enabled: true,
-            command: ctx.generate_command("task-1"),
+            program,
+            args,
         })
         .await
         .unwrap();
@@ -582,12 +616,14 @@ mod tests {
         let mgr = ScheduleManager::new(&store, &host, ctx.clone());
 
         let cron = CronExpression::parse("0 6 * * *").unwrap();
+        let (program, args) = ctx.generate_invocation("task-1");
         host.install(&HostInstallRequest {
             schedule_id: "orphan".to_string(),
             automation_task_id: "task-1".to_string(),
             cron,
             enabled: true,
-            command: ctx.generate_command("task-1"),
+            program,
+            args,
         })
         .await
         .unwrap();
@@ -670,7 +706,8 @@ mod tests {
     async fn host_error_during_reconcile_reports_degraded() {
         let store = setup_store().await;
         let host = FakeHostScheduler::new();
-        *host.force_error.lock() = Some(HostSchedulerError::PlatformUnavailable("test".to_string()));
+        *host.force_error.lock() =
+            Some(HostSchedulerError::PlatformUnavailable("test".to_string()));
         let ctx = test_context();
         let mgr = ScheduleManager::new(&store, &host, ctx);
 

--- a/src/scheduled_task/manager.rs
+++ b/src/scheduled_task/manager.rs
@@ -162,14 +162,43 @@ impl<'a> ScheduleManager<'a> {
                 let request = self.build_install_request(&schedule);
                 match request {
                     Ok(req) => {
-                        if let Err(e) = self.host.install(&req).await {
-                            return self.error_status(
-                                schedule_id,
-                                DesiredState::Present,
-                                HostState::Unknown,
-                                ScheduleDiagnosticKind::InstallationFailed,
-                                format!("host install failed: {}", e),
-                            );
+                        // Inspect current host state before mutating.
+                        // Skip install if the entry already matches.
+                        let needs_install = match self.host.inspect(schedule_id).await {
+                            Ok(Some(entry)) => {
+                                !entry.corrupt
+                                    && entry.enabled == req.enabled
+                                    && entry
+                                        .raw_schedule
+                                        .as_deref()
+                                        .map(|s| s == req.cron.as_str())
+                                        .unwrap_or(false)
+                                    && entry
+                                        .observed_command
+                                        .as_deref()
+                                        .map(|c| {
+                                            let expected =
+                                                crate::scheduled_task::host::render_command(
+                                                    &req.program,
+                                                    &req.args,
+                                                );
+                                            c == expected
+                                        })
+                                        .unwrap_or(false)
+                            }
+                            _ => true, // Missing, corrupt, or error → needs install
+                        };
+
+                        if needs_install {
+                            if let Err(e) = self.host.install(&req).await {
+                                return self.error_status(
+                                    schedule_id,
+                                    DesiredState::Present,
+                                    HostState::Unknown,
+                                    ScheduleDiagnosticKind::InstallationFailed,
+                                    format!("host install failed: {}", e),
+                                );
+                            }
                         }
                     }
                     Err(diagnostic) => {

--- a/src/scheduled_task/mod.rs
+++ b/src/scheduled_task/mod.rs
@@ -1,0 +1,309 @@
+//! Scheduled automation-task definitions, validation, and persistence.
+//!
+//! A `ScheduledTask` is a reference to an existing `AutomationTask` paired with
+//! a five-field cron expression and enabled state. Schedules never contain
+//! executable paths, shell commands, prompt text, or environment variables —
+//! the installed host entry is always a core-generated `agent-iron run` call.
+
+pub mod cron;
+pub mod host;
+pub mod manager;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Schema version for scheduled-task payloads stored in ConfigStore.
+pub const SCHEDULED_TASK_SCHEMA_VERSION: i64 = 1;
+
+// ============================================================================
+// Domain types
+// ============================================================================
+
+/// A schedule that invokes an automation task on a recurring cron-like basis.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ScheduledTask {
+    /// Stable schedule identifier.
+    pub id: String,
+    /// The automation task to invoke.
+    pub automation_task_id: String,
+    /// Validated five-field cron expression.
+    pub cron_expression: String,
+    /// Whether this schedule is active.
+    pub enabled: bool,
+    /// When the schedule was first created.
+    pub created_at: DateTime<Utc>,
+    /// When the schedule was last updated.
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Input for creating or replacing a scheduled task.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ScheduledTaskInput {
+    /// Stable schedule identifier.
+    pub id: String,
+    /// Must reference an existing automation task.
+    pub automation_task_id: String,
+    /// Five-field numeric cron expression.
+    pub cron_expression: String,
+    /// Whether the schedule should be active.
+    pub enabled: bool,
+}
+
+/// Validate a scheduled-task input.
+///
+/// Trims the ID and automation-task ID, parses and validates the cron
+/// expression, and returns `Ok` with normalized values or `Err` with a
+/// human-readable message.
+pub fn validate_schedule_input(
+    input: &ScheduledTaskInput,
+) -> Result<ScheduledTaskInput, String> {
+    let id = trim_non_empty(&input.id, "Schedule ID")?;
+    let automation_task_id =
+        trim_non_empty(&input.automation_task_id, "Automation task ID")?;
+    let cron_expression = input.cron_expression.trim().to_string();
+    if cron_expression.is_empty() {
+        return Err("Cron expression must not be empty".to_string());
+    }
+
+    // Validate the cron expression.
+    cron::CronExpression::parse(&cron_expression)?;
+
+    Ok(ScheduledTaskInput {
+        id,
+        automation_task_id,
+        cron_expression,
+        enabled: input.enabled,
+    })
+}
+
+fn trim_non_empty(raw: &str, label: &str) -> Result<String, String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err(format!("{} must not be empty", label));
+    }
+    if trimmed.as_bytes().iter().any(|b| b.is_ascii_control()) {
+        return Err(format!("{} must not contain control characters", label));
+    }
+    Ok(trimmed.to_string())
+}
+
+// ============================================================================
+// Status and diagnostics (used by ScheduleManager in Group 5)
+// ============================================================================
+
+/// Overall health classification for a scheduled task.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ScheduleHealth {
+    /// Desired state is valid and host entry matches.
+    Healthy,
+    /// Desired state exists but host entry is missing, drifted, or partially
+    /// installed.
+    Degraded,
+    /// The platform scheduler is not available or the task cannot be
+    /// evaluated.
+    Unavailable,
+}
+
+/// Desired-state status.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DesiredState {
+    /// Schedule exists in ConfigStore.
+    Present,
+    /// Schedule does not exist in ConfigStore.
+    Missing,
+}
+
+/// Automation-task reference status.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReferenceState {
+    /// Referenced automation task exists.
+    Valid,
+    /// Referenced automation task does not exist.
+    Missing,
+    /// Referenced automation task has an unsupported schema version.
+    Invalid,
+}
+
+/// Headless execution readiness.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecutionState {
+    /// The referenced task's profile is headless-safe.
+    Ready,
+    /// The referenced task's profile requires interactive approval.
+    UnsafePolicy,
+    /// Cannot determine readiness because the task is missing or invalid.
+    Unknown,
+}
+
+/// Observed host-entry status.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HostState {
+    /// Owned host entry exists and matches desired state.
+    Installed,
+    /// Owned host entry exists but is disabled.
+    Disabled,
+    /// No owned host entry exists.
+    Missing,
+    /// Owned host entry exists but differs from desired state.
+    Drifted,
+    /// Owned host entry exists but is malformed or corrupt.
+    Corrupt,
+    /// Host scheduler state cannot be determined.
+    Unknown,
+}
+
+/// Optional metadata reported by the host scheduler, when available.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HostRunMetadata {
+    /// Last time the task ran, if known.
+    pub last_run: Option<DateTime<Utc>>,
+    /// Next scheduled run time, if known.
+    pub next_run: Option<DateTime<Utc>>,
+    /// Last result summary, if known.
+    pub last_result: Option<String>,
+}
+
+/// A single diagnostic message about a scheduled task.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ScheduleDiagnostic {
+    /// Machine-readable diagnostic kind.
+    pub kind: ScheduleDiagnosticKind,
+    /// Human-readable message.
+    pub message: String,
+}
+
+/// Classification of schedule diagnostics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ScheduleDiagnosticKind {
+    /// Host installation failed.
+    InstallationFailed,
+    /// Host entry is missing.
+    NotInstalled,
+    /// Host entry schedule differs from desired.
+    ScheduleDrift,
+    /// Host entry is corrupt.
+    CorruptHostEntry,
+    /// Orphaned owned host entry with no desired state.
+    OrphanedHostEntry,
+    /// Referenced automation task is missing.
+    MissingTask,
+    /// Referenced automation task is invalid.
+    InvalidTask,
+    /// Profile is not headless-safe.
+    UnsafePolicy,
+    /// Platform does not support this schedule.
+    UnsupportedSchedule,
+    /// Platform scheduler is unavailable.
+    PlatformUnavailable,
+    /// Runner path differs from installation context.
+    RunnerPathDrift,
+}
+
+/// A compositional status report for a scheduled task.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ScheduleStatus {
+    /// Schedule ID (or host-entry ID for orphans).
+    pub schedule_id: String,
+    /// Overall health summary.
+    pub health: ScheduleHealth,
+    /// Desired ConfigStore state.
+    pub desired_state: DesiredState,
+    /// Automation-task reference status.
+    pub reference_state: ReferenceState,
+    /// Headless execution readiness.
+    pub execution_state: ExecutionState,
+    /// Observed host-entry status.
+    pub host_state: HostState,
+    /// Diagnostics explaining the health classification.
+    pub diagnostics: Vec<ScheduleDiagnostic>,
+    /// Optional host-reported metadata.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub host_metadata: Option<HostRunMetadata>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn valid_input() -> ScheduledTaskInput {
+        ScheduledTaskInput {
+            id: "morning-brief".to_string(),
+            automation_task_id: "daily-report".to_string(),
+            cron_expression: "0 9 * * *".to_string(),
+            enabled: true,
+        }
+    }
+
+    #[test]
+    fn valid_input_passes_validation() {
+        let result = validate_schedule_input(&valid_input()).unwrap();
+        assert_eq!(result.id, "morning-brief");
+        assert_eq!(result.automation_task_id, "daily-report");
+        assert_eq!(result.cron_expression, "0 9 * * *");
+        assert!(result.enabled);
+    }
+
+    #[test]
+    fn empty_id_rejected() {
+        let mut input = valid_input();
+        input.id = "  ".to_string();
+        assert!(validate_schedule_input(&input).is_err());
+    }
+
+    #[test]
+    fn empty_task_id_rejected() {
+        let mut input = valid_input();
+        input.automation_task_id = "".to_string();
+        assert!(validate_schedule_input(&input).is_err());
+    }
+
+    #[test]
+    fn empty_cron_rejected() {
+        let mut input = valid_input();
+        input.cron_expression = "   ".to_string();
+        assert!(validate_schedule_input(&input).is_err());
+    }
+
+    #[test]
+    fn invalid_cron_rejected() {
+        let mut input = valid_input();
+        input.cron_expression = "not-cron".to_string();
+        assert!(validate_schedule_input(&input).is_err());
+    }
+
+    #[test]
+    fn macro_cron_rejected() {
+        let mut input = valid_input();
+        input.cron_expression = "@daily".to_string();
+        assert!(validate_schedule_input(&input).is_err());
+    }
+
+    #[test]
+    fn stepped_cron_accepted() {
+        let mut input = valid_input();
+        input.cron_expression = "*/15 9-17/2 * 1,6,12 1-5".to_string();
+        assert!(validate_schedule_input(&input).is_ok());
+    }
+
+    #[test]
+    fn scheduled_task_serializes() {
+        let now = Utc::now();
+        let task = ScheduledTask {
+            id: "s1".to_string(),
+            automation_task_id: "t1".to_string(),
+            cron_expression: "0 9 * * *".to_string(),
+            enabled: true,
+            created_at: now,
+            updated_at: now,
+        };
+        let json = serde_json::to_string(&task).unwrap();
+        let restored: ScheduledTask = serde_json::from_str(&json).unwrap();
+        assert_eq!(task, restored);
+    }
+}

--- a/src/scheduled_task/mod.rs
+++ b/src/scheduled_task/mod.rs
@@ -8,6 +8,7 @@
 pub mod cron;
 pub mod host;
 pub mod manager;
+pub mod platform;
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};

--- a/src/scheduled_task/mod.rs
+++ b/src/scheduled_task/mod.rs
@@ -55,12 +55,9 @@ pub struct ScheduledTaskInput {
 /// Trims the ID and automation-task ID, parses and validates the cron
 /// expression, and returns `Ok` with normalized values or `Err` with a
 /// human-readable message.
-pub fn validate_schedule_input(
-    input: &ScheduledTaskInput,
-) -> Result<ScheduledTaskInput, String> {
+pub fn validate_schedule_input(input: &ScheduledTaskInput) -> Result<ScheduledTaskInput, String> {
     let id = trim_non_empty(&input.id, "Schedule ID")?;
-    let automation_task_id =
-        trim_non_empty(&input.automation_task_id, "Automation task ID")?;
+    let automation_task_id = trim_non_empty(&input.automation_task_id, "Automation task ID")?;
     let cron_expression = input.cron_expression.trim().to_string();
     if cron_expression.is_empty() {
         return Err("Cron expression must not be empty".to_string());

--- a/src/scheduled_task/platform/cron_adapter.rs
+++ b/src/scheduled_task/platform/cron_adapter.rs
@@ -1,0 +1,390 @@
+//! Linux crontab host scheduler adapter.
+//!
+//! Uses the `crontab` command to read and write the user's crontab. Owned
+//! entries are managed via marker-delimited blocks (see `crontab` module).
+//! Non-owned content is preserved.
+//!
+//! The cron expression maps directly to crontab's native five-field syntax,
+//! so no compilation or expansion is needed — the schedule text is used
+//! as-is.
+
+use async_trait::async_trait;
+
+use crate::scheduled_task::cron::CronExpression;
+use crate::scheduled_task::host::{
+    CommandOutput, CommandRunner, HostInstallRequest, HostScheduler, HostSchedulerError,
+    ObservedHostEntry,
+};
+use crate::scheduled_task::platform::crontab::{make_block, CronOwnedBlock, ParsedCrontab};
+
+/// Linux crontab host scheduler.
+pub struct CronHostScheduler {
+    runner: Box<dyn CommandRunner>,
+}
+
+impl CronHostScheduler {
+    /// Create a new cron adapter with the given command runner.
+    pub fn new(runner: Box<dyn CommandRunner>) -> Self {
+        Self { runner }
+    }
+
+    /// Read the current crontab text. Returns empty string if no crontab.
+    async fn read_crontab(&self) -> Result<String, HostSchedulerError> {
+        let output = self
+            .runner
+            .run("crontab", &["-l"])
+            .await
+            .map_err(|e| HostSchedulerError::Io(e.to_string()))?;
+
+        // crontab -l returns exit code 1 when no crontab exists.
+        if output.exit_code == 0 {
+            Ok(output.stdout)
+        } else {
+            Ok(String::new())
+        }
+    }
+
+    /// Write the full crontab text via stdin.
+    async fn write_crontab(&self, content: &str) -> Result<(), HostSchedulerError> {
+        let output = self
+            .runner
+            .run_with_stdin("crontab", &["-"], content)
+            .await
+            .map_err(|e| HostSchedulerError::Io(e.to_string()))?;
+
+        if output.exit_code != 0 {
+            return Err(HostSchedulerError::Io(format!(
+                "crontab install failed (exit {}): {}",
+                output.exit_code, output.stderr
+            )));
+        }
+
+        Ok(())
+    }
+
+    /// Parse the current crontab.
+    async fn parse_current(&self) -> Result<ParsedCrontab, HostSchedulerError> {
+        let raw = self.read_crontab().await?;
+        Ok(ParsedCrontab::parse(&raw))
+    }
+
+    /// Convert an owned block to an observed host entry.
+    fn block_to_observed(block: &CronOwnedBlock) -> ObservedHostEntry {
+        ObservedHostEntry {
+            schedule_id: block.schedule_id.clone(),
+            enabled: block.enabled,
+            corrupt: false,
+            raw_schedule: Some(block.cron_schedule.clone()),
+            observed_command: Some(block.command.clone()),
+            metadata: None,
+        }
+    }
+}
+
+#[async_trait]
+impl HostScheduler for CronHostScheduler {
+    fn platform(&self) -> &'static str {
+        "cron"
+    }
+
+    async fn install(&self, request: &HostInstallRequest) -> Result<(), HostSchedulerError> {
+        let mut parsed = self.parse_current().await?;
+
+        // The cron expression maps directly to crontab syntax.
+        let block = make_block(
+            &request.schedule_id,
+            request.cron.as_str(),
+            &request.command,
+            request.enabled,
+        );
+
+        parsed.upsert(block);
+
+        let rendered = parsed.render();
+        self.write_crontab(&rendered).await
+    }
+
+    async fn remove(&self, schedule_id: &str) -> Result<(), HostSchedulerError> {
+        let mut parsed = self.parse_current().await?;
+        parsed.remove(schedule_id);
+        let rendered = parsed.render();
+        self.write_crontab(&rendered).await
+    }
+
+    async fn list_owned(&self) -> Result<Vec<ObservedHostEntry>, HostSchedulerError> {
+        let parsed = self.parse_current().await?;
+        Ok(parsed
+            .owned_blocks()
+            .iter()
+            .map(|b| Self::block_to_observed(b))
+            .collect())
+    }
+
+    async fn inspect(
+        &self,
+        schedule_id: &str,
+    ) -> Result<Option<ObservedHostEntry>, HostSchedulerError> {
+        let parsed = self.parse_current().await?;
+
+        if let Some(block) = parsed.find_owned(schedule_id) {
+            return Ok(Some(Self::block_to_observed(block)));
+        }
+
+        // Check for malformed blocks.
+        if parsed.contains_id(schedule_id) {
+            return Ok(Some(ObservedHostEntry {
+                schedule_id: schedule_id.to_string(),
+                enabled: false,
+                corrupt: true,
+                raw_schedule: None,
+                observed_command: None,
+                metadata: None,
+            }));
+        }
+
+        Ok(None)
+    }
+}
+
+// ============================================================================
+// Mock command runner for testing
+// ============================================================================
+
+/// Mock command runner that simulates crontab interactions.
+#[cfg(test)]
+struct MockCrontabRunner {
+    crontab_content: parking_lot::Mutex<Option<String>>,
+}
+
+#[cfg(test)]
+impl MockCrontabRunner {
+    fn new(initial: Option<&str>) -> Self {
+        Self {
+            crontab_content: parking_lot::Mutex::new(initial.map(|s| s.to_string())),
+        }
+    }
+}
+
+#[cfg(test)]
+#[async_trait]
+impl CommandRunner for MockCrontabRunner {
+    async fn run(
+        &self,
+        program: &str,
+        args: &[&str],
+    ) -> Result<CommandOutput, std::io::Error> {
+        assert_eq!(program, "crontab");
+
+        match args {
+            ["-l"] => {
+                let content = self.crontab_content.lock();
+                match &*content {
+                    Some(text) => Ok(CommandOutput {
+                        exit_code: 0,
+                        stdout: text.clone(),
+                        stderr: String::new(),
+                    }),
+                    None => Ok(CommandOutput {
+                        exit_code: 1,
+                        stdout: String::new(),
+                        stderr: "no crontab".to_string(),
+                    }),
+                }
+            }
+            _ => Ok(CommandOutput {
+                exit_code: 1,
+                stdout: String::new(),
+                stderr: "unknown args".to_string(),
+            }),
+        }
+    }
+
+    async fn run_with_stdin(
+        &self,
+        program: &str,
+        args: &[&str],
+        stdin: &str,
+    ) -> Result<CommandOutput, std::io::Error> {
+        assert_eq!(program, "crontab");
+        assert_eq!(args, &["-"]);
+
+        *self.crontab_content.lock() = Some(stdin.to_string());
+
+        Ok(CommandOutput {
+            exit_code: 0,
+            stdout: String::new(),
+            stderr: String::new(),
+        })
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::scheduled_task::host::SchedulerInstallContext;
+
+    fn make_request(id: &str, cron: &str, enabled: bool) -> HostInstallRequest {
+        let ctx = SchedulerInstallContext {
+            runner_executable: std::path::PathBuf::from("/usr/local/bin/agent-iron"),
+            config_store_path: std::path::PathBuf::from("/home/user/.config/agentiron/config.db"),
+        };
+        HostInstallRequest {
+            schedule_id: id.to_string(),
+            automation_task_id: "task-1".to_string(),
+            cron: CronExpression::parse(cron).unwrap(),
+            enabled,
+            command: ctx.generate_command("task-1"),
+        }
+    }
+
+    #[tokio::test]
+    async fn install_into_empty_crontab() {
+        let runner = MockCrontabRunner::new(None);
+        let scheduler = CronHostScheduler::new(Box::new(runner));
+
+        let request = make_request("s1", "0 9 * * *", true);
+        scheduler.install(&request).await.unwrap();
+
+        // Read back and verify.
+        let entry = scheduler.inspect("s1").await.unwrap().unwrap();
+        assert_eq!(entry.schedule_id, "s1");
+        assert!(entry.enabled);
+        assert_eq!(entry.raw_schedule.as_deref(), Some("0 9 * * *"));
+        assert!(entry.observed_command.as_deref().unwrap().contains("run task-1"));
+    }
+
+    #[tokio::test]
+    async fn install_beside_existing_entries() {
+        let initial = "# My crontab\n0 0 * * * /usr/bin/cleanup\n";
+        let runner = MockCrontabRunner::new(Some(initial));
+        let scheduler = CronHostScheduler::new(Box::new(runner));
+
+        let request = make_request("s1", "0 9 * * *", true);
+        scheduler.install(&request).await.unwrap();
+
+        // List should only show owned entries.
+        let owned = scheduler.list_owned().await.unwrap();
+        assert_eq!(owned.len(), 1);
+        assert_eq!(owned[0].schedule_id, "s1");
+    }
+
+    #[tokio::test]
+    async fn install_disabled_task() {
+        let runner = MockCrontabRunner::new(None);
+        let scheduler = CronHostScheduler::new(Box::new(runner));
+
+        let request = make_request("s1", "0 9 * * *", false);
+        scheduler.install(&request).await.unwrap();
+
+        let entry = scheduler.inspect("s1").await.unwrap().unwrap();
+        assert!(!entry.enabled);
+    }
+
+    #[tokio::test]
+    async fn replace_existing_block() {
+        let runner = MockCrontabRunner::new(None);
+        let scheduler = CronHostScheduler::new(Box::new(runner));
+
+        // Install initial.
+        scheduler
+            .install(&make_request("s1", "0 9 * * *", true))
+            .await
+            .unwrap();
+
+        // Replace with different schedule.
+        scheduler
+            .install(&make_request("s1", "0 10 * * *", true))
+            .await
+            .unwrap();
+
+        let entry = scheduler.inspect("s1").await.unwrap().unwrap();
+        assert_eq!(entry.raw_schedule.as_deref(), Some("0 10 * * *"));
+    }
+
+    #[tokio::test]
+    async fn remove_block() {
+        let runner = MockCrontabRunner::new(None);
+        let scheduler = CronHostScheduler::new(Box::new(runner));
+
+        scheduler
+            .install(&make_request("s1", "0 9 * * *", true))
+            .await
+            .unwrap();
+        scheduler
+            .install(&make_request("s2", "0 10 * * *", true))
+            .await
+            .unwrap();
+
+        scheduler.remove("s1").await.unwrap();
+
+        assert!(scheduler.inspect("s1").await.unwrap().is_none());
+        assert!(scheduler.inspect("s2").await.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn list_multiple_owned() {
+        let runner = MockCrontabRunner::new(None);
+        let scheduler = CronHostScheduler::new(Box::new(runner));
+
+        for (id, cron) in &[("alpha", "0 9 * * *"), ("bravo", "0 10 * * *")] {
+            scheduler
+                .install(&make_request(id, cron, true))
+                .await
+                .unwrap();
+        }
+
+        let owned = scheduler.list_owned().await.unwrap();
+        assert_eq!(owned.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn inspect_nonexistent_returns_none() {
+        let runner = MockCrontabRunner::new(None);
+        let scheduler = CronHostScheduler::new(Box::new(runner));
+
+        let result = scheduler.inspect("nonexistent").await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn faithful_cron_compilation() {
+        // On Linux, the cron expression maps directly to crontab syntax.
+        // No transformation is needed.
+        let runner = MockCrontabRunner::new(None);
+        let scheduler = CronHostScheduler::new(Box::new(runner));
+
+        let complex = "*/15 9-17/2 1,15 * 1-5";
+        scheduler
+            .install(&make_request("s1", complex, true))
+            .await
+            .unwrap();
+
+        let entry = scheduler.inspect("s1").await.unwrap().unwrap();
+        assert_eq!(entry.raw_schedule.as_deref(), Some(complex));
+    }
+
+    #[tokio::test]
+    async fn enable_after_disabled() {
+        let runner = MockCrontabRunner::new(None);
+        let scheduler = CronHostScheduler::new(Box::new(runner));
+
+        // Install disabled.
+        scheduler
+            .install(&make_request("s1", "0 9 * * *", false))
+            .await
+            .unwrap();
+
+        // Replace with enabled.
+        scheduler
+            .install(&make_request("s1", "0 9 * * *", true))
+            .await
+            .unwrap();
+
+        let entry = scheduler.inspect("s1").await.unwrap().unwrap();
+        assert!(entry.enabled);
+    }
+}

--- a/src/scheduled_task/platform/cron_adapter.rs
+++ b/src/scheduled_task/platform/cron_adapter.rs
@@ -9,9 +9,10 @@
 //! as-is.
 
 use async_trait::async_trait;
+use tokio::sync::Mutex;
 
 use crate::scheduled_task::host::{
-    render_command, CommandRunner, HostInstallRequest, HostScheduler, HostSchedulerError,
+    render_cron_command, CommandRunner, HostInstallRequest, HostScheduler, HostSchedulerError,
     ObservedHostEntry,
 };
 use crate::scheduled_task::platform::crontab::{make_block, CronOwnedBlock, ParsedCrontab};
@@ -19,12 +20,16 @@ use crate::scheduled_task::platform::crontab::{make_block, CronOwnedBlock, Parse
 /// Linux crontab host scheduler.
 pub struct CronHostScheduler {
     runner: Box<dyn CommandRunner>,
+    lock: Mutex<()>,
 }
 
 impl CronHostScheduler {
     /// Create a new cron adapter with the given command runner.
     pub fn new(runner: Box<dyn CommandRunner>) -> Self {
-        Self { runner }
+        Self {
+            runner,
+            lock: Mutex::new(()),
+        }
     }
 
     /// Read the current crontab text. Returns empty string if no crontab.
@@ -97,10 +102,12 @@ impl HostScheduler for CronHostScheduler {
     }
 
     async fn install(&self, request: &HostInstallRequest) -> Result<(), HostSchedulerError> {
+        let _guard = self.lock.lock().await;
         let mut parsed = self.parse_current().await?;
 
-        // The cron expression maps directly to crontab syntax.
-        let command = render_command(&request.program, &request.args);
+        // The cron expression maps directly to crontab syntax. Escape `%`
+        // for cron's metacharacter handling.
+        let command = render_cron_command(&request.program, &request.args);
         let block = make_block(
             &request.schedule_id,
             request.cron.as_str(),
@@ -115,6 +122,7 @@ impl HostScheduler for CronHostScheduler {
     }
 
     async fn remove(&self, schedule_id: &str) -> Result<(), HostSchedulerError> {
+        let _guard = self.lock.lock().await;
         let mut parsed = self.parse_current().await?;
         parsed.remove(schedule_id);
         let rendered = parsed.render();
@@ -123,11 +131,24 @@ impl HostScheduler for CronHostScheduler {
 
     async fn list_owned(&self) -> Result<Vec<ObservedHostEntry>, HostSchedulerError> {
         let parsed = self.parse_current().await?;
-        Ok(parsed
+        let mut entries: Vec<ObservedHostEntry> = parsed
             .owned_blocks()
             .iter()
             .map(|b| Self::block_to_observed(b))
-            .collect())
+            .collect();
+        // Expose malformed owned blocks so reconciliation can discover
+        // corrupted AgentIron entries.
+        for (schedule_id, _raw) in parsed.malformed_blocks() {
+            entries.push(ObservedHostEntry {
+                schedule_id: schedule_id.clone(),
+                enabled: false,
+                corrupt: true,
+                raw_schedule: None,
+                observed_command: None,
+                metadata: None,
+            });
+        }
+        Ok(entries)
     }
 
     async fn inspect(

--- a/src/scheduled_task/platform/cron_adapter.rs
+++ b/src/scheduled_task/platform/cron_adapter.rs
@@ -10,9 +10,8 @@
 
 use async_trait::async_trait;
 
-use crate::scheduled_task::cron::CronExpression;
 use crate::scheduled_task::host::{
-    CommandOutput, CommandRunner, HostInstallRequest, HostScheduler, HostSchedulerError,
+    render_command, CommandRunner, HostInstallRequest, HostScheduler, HostSchedulerError,
     ObservedHostEntry,
 };
 use crate::scheduled_task::platform::crontab::{make_block, CronOwnedBlock, ParsedCrontab};
@@ -36,12 +35,22 @@ impl CronHostScheduler {
             .await
             .map_err(|e| HostSchedulerError::Io(e.to_string()))?;
 
-        // crontab -l returns exit code 1 when no crontab exists.
         if output.exit_code == 0 {
-            Ok(output.stdout)
-        } else {
-            Ok(String::new())
+            return Ok(output.stdout);
         }
+
+        // crontab -l exits 1 with "no crontab" on stderr when the user has no
+        // crontab. Only that case is treated as an empty crontab. Any other
+        // non-zero exit (permission denied, command not found, etc.) is a real
+        // failure and must propagate rather than silently erasing the crontab.
+        if output.exit_code == 1 && output.stderr.contains("no crontab") {
+            return Ok(String::new());
+        }
+
+        Err(HostSchedulerError::Io(format!(
+            "crontab -l failed (exit {}): {}",
+            output.exit_code, output.stderr
+        )))
     }
 
     /// Write the full crontab text via stdin.
@@ -91,10 +100,11 @@ impl HostScheduler for CronHostScheduler {
         let mut parsed = self.parse_current().await?;
 
         // The cron expression maps directly to crontab syntax.
+        let command = render_command(&request.program, &request.args);
         let block = make_block(
             &request.schedule_id,
             request.cron.as_str(),
-            &request.command,
+            &command,
             request.enabled,
         );
 
@@ -153,14 +163,47 @@ impl HostScheduler for CronHostScheduler {
 /// Mock command runner that simulates crontab interactions.
 #[cfg(test)]
 struct MockCrontabRunner {
-    crontab_content: parking_lot::Mutex<Option<String>>,
+    state: parking_lot::Mutex<MockCrontabState>,
 }
+
+/// Simulated crontab state for the mock runner.
+#[cfg(test)]
+#[derive(Clone)]
+enum MockCrontabState {
+    /// Active crontab with content.
+    Content(String),
+    /// No crontab for the user (exit 1, "no crontab").
+    Absent,
+    /// `crontab -l` fails with the given exit code and stderr. Used to
+    /// simulate permission errors and other non-"no crontab" failures.
+    ReadError { exit_code: i32, stderr: String },
+}
+
+#[cfg(test)]
+use crate::scheduled_task::cron::CronExpression;
+#[cfg(test)]
+use crate::scheduled_task::host::CommandOutput;
 
 #[cfg(test)]
 impl MockCrontabRunner {
     fn new(initial: Option<&str>) -> Self {
+        let state = match initial {
+            Some(text) => MockCrontabState::Content(text.to_string()),
+            None => MockCrontabState::Absent,
+        };
         Self {
-            crontab_content: parking_lot::Mutex::new(initial.map(|s| s.to_string())),
+            state: parking_lot::Mutex::new(state),
+        }
+    }
+
+    /// Create a runner where `crontab -l` fails with the given exit code
+    /// and stderr (e.g. a permission error with exit code 2).
+    fn with_read_error(exit_code: i32, stderr: &str) -> Self {
+        Self {
+            state: parking_lot::Mutex::new(MockCrontabState::ReadError {
+                exit_code,
+                stderr: stderr.to_string(),
+            }),
         }
     }
 }
@@ -168,26 +211,27 @@ impl MockCrontabRunner {
 #[cfg(test)]
 #[async_trait]
 impl CommandRunner for MockCrontabRunner {
-    async fn run(
-        &self,
-        program: &str,
-        args: &[&str],
-    ) -> Result<CommandOutput, std::io::Error> {
+    async fn run(&self, program: &str, args: &[&str]) -> Result<CommandOutput, std::io::Error> {
         assert_eq!(program, "crontab");
 
         match args {
             ["-l"] => {
-                let content = self.crontab_content.lock();
-                match &*content {
-                    Some(text) => Ok(CommandOutput {
+                let state = self.state.lock().clone();
+                match state {
+                    MockCrontabState::Content(text) => Ok(CommandOutput {
                         exit_code: 0,
-                        stdout: text.clone(),
+                        stdout: text,
                         stderr: String::new(),
                     }),
-                    None => Ok(CommandOutput {
+                    MockCrontabState::Absent => Ok(CommandOutput {
                         exit_code: 1,
                         stdout: String::new(),
-                        stderr: "no crontab".to_string(),
+                        stderr: "no crontab for user".to_string(),
+                    }),
+                    MockCrontabState::ReadError { exit_code, stderr } => Ok(CommandOutput {
+                        exit_code,
+                        stdout: String::new(),
+                        stderr,
                     }),
                 }
             }
@@ -208,7 +252,7 @@ impl CommandRunner for MockCrontabRunner {
         assert_eq!(program, "crontab");
         assert_eq!(args, &["-"]);
 
-        *self.crontab_content.lock() = Some(stdin.to_string());
+        *self.state.lock() = MockCrontabState::Content(stdin.to_string());
 
         Ok(CommandOutput {
             exit_code: 0,
@@ -232,12 +276,14 @@ mod tests {
             runner_executable: std::path::PathBuf::from("/usr/local/bin/agent-iron"),
             config_store_path: std::path::PathBuf::from("/home/user/.config/agentiron/config.db"),
         };
+        let (program, args) = ctx.generate_invocation("task-1");
         HostInstallRequest {
             schedule_id: id.to_string(),
             automation_task_id: "task-1".to_string(),
             cron: CronExpression::parse(cron).unwrap(),
             enabled,
-            command: ctx.generate_command("task-1"),
+            program,
+            args,
         }
     }
 
@@ -254,7 +300,11 @@ mod tests {
         assert_eq!(entry.schedule_id, "s1");
         assert!(entry.enabled);
         assert_eq!(entry.raw_schedule.as_deref(), Some("0 9 * * *"));
-        assert!(entry.observed_command.as_deref().unwrap().contains("run task-1"));
+        assert!(entry
+            .observed_command
+            .as_deref()
+            .unwrap()
+            .contains("run task-1"));
     }
 
     #[tokio::test]
@@ -386,5 +436,17 @@ mod tests {
 
         let entry = scheduler.inspect("s1").await.unwrap().unwrap();
         assert!(entry.enabled);
+    }
+
+    #[tokio::test]
+    async fn read_permission_error_propagates() {
+        // Exit code 2 (e.g. permission denied) must not be treated as an empty
+        // crontab; it must propagate as an error.
+        let runner = MockCrontabRunner::with_read_error(2, "crontab: permission denied");
+        let scheduler = CronHostScheduler::new(Box::new(runner));
+
+        let result = scheduler.list_owned().await;
+        assert!(result.is_err());
+        assert!(matches!(result, Err(HostSchedulerError::Io(_))));
     }
 }

--- a/src/scheduled_task/platform/crontab.rs
+++ b/src/scheduled_task/platform/crontab.rs
@@ -1,0 +1,587 @@
+//! Crontab content parsing, rendering, and ownership management.
+//!
+//! AgentIron owns crontab entries via marker-delimited blocks:
+//!
+//! ```text
+//! # iron-core-task:<id>:begin
+//! 0 9 * * * /path/to/agent-iron run task-1 --config /path/to/config.db
+//! # iron-core-task:<id>:end
+//! ```
+//!
+//! Disabled tasks retain the block but comment out the schedule line:
+//!
+//! ```text
+//! # iron-core-task:<id>:begin
+//! # iron-core-task:<id>:disabled
+//! # 0 9 * * * /path/to/agent-iron run task-1 --config /path/to/config.db
+//! # iron-core-task:<id>:end
+//! ```
+//!
+//! Non-owned crontab content is preserved byte-for-byte.
+
+use std::collections::HashSet;
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/// Prefix for ownership marker comments.
+pub const MARKER_PREFIX: &str = "# iron-core-task:";
+
+// ============================================================================
+// Owned block
+// ============================================================================
+
+/// A parsed owned crontab block.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CronOwnedBlock {
+    pub schedule_id: String,
+    pub enabled: bool,
+    /// The cron schedule fields (e.g. `"0 9 * * *"`).
+    pub cron_schedule: String,
+    /// The full command line.
+    pub command: String,
+}
+
+impl CronOwnedBlock {
+    /// Render the block as crontab text.
+    pub fn render(&self) -> String {
+        let begin = format!("{}{}:begin", MARKER_PREFIX, self.schedule_id);
+        let end = format!("{}{}:end", MARKER_PREFIX, self.schedule_id);
+        let cron_line = format!("{} {}", self.cron_schedule, self.command);
+
+        if self.enabled {
+            format!("{}\n{}\n{}\n", begin, cron_line, end)
+        } else {
+            format!(
+                "{}\n{}{}:disabled\n# {}\n{}\n",
+                begin,
+                MARKER_PREFIX,
+                self.schedule_id,
+                cron_line,
+                end
+            )
+        }
+    }
+}
+
+/// Build an owned block from a schedule ID, cron text, command, and enabled
+/// state.
+pub fn make_block(
+    schedule_id: &str,
+    cron_text: &str,
+    command: &str,
+    enabled: bool,
+) -> CronOwnedBlock {
+    CronOwnedBlock {
+        schedule_id: schedule_id.to_string(),
+        enabled,
+        cron_schedule: cron_text.to_string(),
+        command: command.to_string(),
+    }
+}
+
+// ============================================================================
+// Crontab content
+// ============================================================================
+
+/// A parsed crontab with owned blocks separated from non-owned content.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ParsedCrontab {
+    /// All segments in order.
+    pub segments: Vec<CrontabSegment>,
+}
+
+/// A segment of the crontab.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CrontabSegment {
+    /// A valid owned block.
+    Owned(CronOwnedBlock),
+    /// Non-owned lines, preserved as-is.
+    Other(String),
+    /// A malformed owned block (unbalanced or duplicate markers).
+    Malformed {
+        schedule_id: String,
+        raw: String,
+    },
+}
+
+impl ParsedCrontab {
+    /// Parse raw crontab text into segments.
+    pub fn parse(raw: &str) -> Self {
+        let lines: Vec<&str> = raw.lines().collect();
+        let mut segments = Vec::new();
+        let mut other_buf = String::new();
+        let mut seen_ids: HashSet<String> = HashSet::new();
+
+        let mut i = 0;
+        while i < lines.len() {
+            let line = lines[i];
+
+            if let Some(sid) = parse_begin_marker(line) {
+                // Flush pending other content.
+                if !other_buf.is_empty() {
+                    segments.push(CrontabSegment::Other(std::mem::take(&mut other_buf)));
+                }
+
+                // Find the matching end marker.
+                let end_idx = find_end_marker(&lines, i + 1, &sid);
+
+                match end_idx {
+                    Some(ei) => {
+                        let is_duplicate = !seen_ids.insert(sid.clone());
+                        let block_lines = &lines[i + 1..ei];
+                        let raw_block: String = lines[i..=ei]
+                            .iter()
+                            .copied()
+                            .collect::<Vec<_>>()
+                            .join("\n")
+                            + "\n";
+
+                        if is_duplicate {
+                            segments.push(CrontabSegment::Malformed {
+                                schedule_id: sid,
+                                raw: raw_block,
+                            });
+                        } else if let Some(block) = parse_block_body(&sid, block_lines) {
+                            segments.push(CrontabSegment::Owned(block));
+                        } else {
+                            segments.push(CrontabSegment::Malformed {
+                                schedule_id: sid,
+                                raw: raw_block,
+                            });
+                        }
+                        i = ei + 1;
+                    }
+                    None => {
+                        // No end marker — everything from here to EOF is malformed.
+                        let raw_block: String = lines[i..]
+                            .iter()
+                            .copied()
+                            .collect::<Vec<_>>()
+                            .join("\n")
+                            + "\n";
+                        segments.push(CrontabSegment::Malformed {
+                            schedule_id: sid,
+                            raw: raw_block,
+                        });
+                        i = lines.len();
+                    }
+                }
+            } else {
+                // Non-owned line.
+                other_buf.push_str(line);
+                other_buf.push('\n');
+                i += 1;
+            }
+        }
+
+        if !other_buf.is_empty() {
+            segments.push(CrontabSegment::Other(other_buf));
+        }
+
+        ParsedCrontab { segments }
+    }
+
+    /// Render the crontab back to text.
+    pub fn render(&self) -> String {
+        let mut result = String::new();
+        for seg in &self.segments {
+            match seg {
+                CrontabSegment::Owned(block) => result.push_str(&block.render()),
+                CrontabSegment::Other(text) => result.push_str(text),
+                CrontabSegment::Malformed { raw, .. } => result.push_str(raw),
+            }
+        }
+        result
+    }
+
+    /// Find an owned block by schedule ID.
+    pub fn find_owned(&self, schedule_id: &str) -> Option<&CronOwnedBlock> {
+        self.segments.iter().find_map(|s| match s {
+            CrontabSegment::Owned(b) if b.schedule_id == schedule_id => Some(b),
+            _ => None,
+        })
+    }
+
+    /// Check if any segment (owned or malformed) references the given ID.
+    pub fn contains_id(&self, schedule_id: &str) -> bool {
+        self.segments.iter().any(|s| match s {
+            CrontabSegment::Owned(b) => b.schedule_id == schedule_id,
+            CrontabSegment::Malformed { schedule_id: sid, .. } => sid == schedule_id,
+            _ => false,
+        })
+    }
+
+    /// Insert or replace an owned block, preserving non-owned content.
+    pub fn upsert(&mut self, block: CronOwnedBlock) {
+        let mut new_segments = Vec::new();
+        let mut inserted = false;
+
+        for seg in self.segments.drain(..) {
+            match &seg {
+                CrontabSegment::Owned(existing) if existing.schedule_id == block.schedule_id => {
+                    // Replace in place.
+                    new_segments.push(CrontabSegment::Owned(block.clone()));
+                    inserted = true;
+                }
+                CrontabSegment::Malformed {
+                    schedule_id: sid, ..
+                } if sid == &block.schedule_id => {
+                    // Replace malformed block too.
+                    new_segments.push(CrontabSegment::Owned(block.clone()));
+                    inserted = true;
+                }
+                _ => {
+                    new_segments.push(seg);
+                }
+            }
+        }
+
+        if !inserted {
+            new_segments.push(CrontabSegment::Owned(block));
+        }
+
+        self.segments = new_segments;
+    }
+
+    /// Remove an owned block by schedule ID. Returns true if something was
+    /// removed.
+    pub fn remove(&mut self, schedule_id: &str) -> bool {
+        let before = self.segments.len();
+        self.segments.retain(|s| match s {
+            CrontabSegment::Owned(b) => b.schedule_id != schedule_id,
+            CrontabSegment::Malformed {
+                schedule_id: sid, ..
+            } => sid != schedule_id,
+            _ => true,
+        });
+        self.segments.len() < before
+    }
+
+    /// List all valid owned blocks.
+    pub fn owned_blocks(&self) -> Vec<&CronOwnedBlock> {
+        self.segments
+            .iter()
+            .filter_map(|s| match s {
+                CrontabSegment::Owned(b) => Some(b),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// List all malformed blocks.
+    pub fn malformed_blocks(&self) -> Vec<(&String, &String)> {
+        self.segments
+            .iter()
+            .filter_map(|s| match s {
+                CrontabSegment::Malformed { schedule_id, raw } => {
+                    Some((schedule_id, raw))
+                }
+                _ => None,
+            })
+            .collect()
+    }
+}
+
+// ============================================================================
+// Marker parsing helpers
+// ============================================================================
+
+/// Extract the schedule ID from a `# iron-core-task:<id>:begin` line.
+fn parse_begin_marker(line: &str) -> Option<String> {
+    let trimmed = line.trim();
+    if !trimmed.starts_with(MARKER_PREFIX) {
+        return None;
+    }
+    let rest = &trimmed[MARKER_PREFIX.len()..];
+    if let Some(id) = rest.strip_suffix(":begin") {
+        let id = id.trim();
+        if !id.is_empty() {
+            return Some(id.to_string());
+        }
+    }
+    None
+}
+
+/// Find the line index of `# iron-core-task:<id>:end` starting from `from`.
+fn find_end_marker(lines: &[&str], from: usize, id: &str) -> Option<usize> {
+    let end_marker = format!("{}{}:end", MARKER_PREFIX, id);
+    for (idx, line) in lines.iter().enumerate().skip(from) {
+        if line.trim() == end_marker {
+            return Some(idx);
+        }
+        // Detect nested begin of the same ID (malformed).
+        if let Some(nested_id) = parse_begin_marker(line) {
+            if nested_id == id {
+                return None;
+            }
+        }
+    }
+    None
+}
+
+/// Parse the body of an owned block (lines between begin and end markers).
+fn parse_block_body(schedule_id: &str, body_lines: &[&str]) -> Option<CronOwnedBlock> {
+    if body_lines.is_empty() {
+        return None;
+    }
+
+    let mut enabled = true;
+    let mut cron_line: Option<String> = None;
+
+    for line in body_lines {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        // Check for disabled marker.
+        let disabled_marker = format!("{}{}:disabled", MARKER_PREFIX, schedule_id);
+        if trimmed == disabled_marker {
+            enabled = false;
+            continue;
+        }
+
+        // Check for commented cron line (disabled).
+        if let Some(rest) = trimmed.strip_prefix("# ") {
+            if looks_like_cron_line(rest) {
+                if cron_line.is_some() {
+                    return None; // Multiple cron lines — malformed.
+                }
+                cron_line = Some(rest.to_string());
+                continue;
+            }
+        }
+
+        // Active cron line.
+        if looks_like_cron_line(trimmed) {
+            if cron_line.is_some() {
+                return None;
+            }
+            cron_line = Some(trimmed.to_string());
+        }
+    }
+
+    let cron_line = cron_line?;
+
+    // Split into schedule fields and command.
+    let parts: Vec<&str> = cron_line.splitn(6, ' ').collect();
+    if parts.len() < 6 {
+        return None;
+    }
+    let cron_schedule = parts[..5].join(" ");
+    let command = parts[5].to_string();
+
+    Some(CronOwnedBlock {
+        schedule_id: schedule_id.to_string(),
+        enabled,
+        cron_schedule,
+        command,
+    })
+}
+
+/// Heuristic: does a line look like a cron schedule entry?
+fn looks_like_cron_line(line: &str) -> bool {
+    let parts: Vec<&str> = line.split_whitespace().collect();
+    parts.len() >= 6
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---- Block rendering ----
+
+    #[test]
+    fn render_enabled_block() {
+        let block = make_block("morning", "0 9 * * *", "/usr/bin/agent-iron run t1", true);
+        let text = block.render();
+        assert!(text.contains("# iron-core-task:morning:begin"));
+        assert!(text.contains("0 9 * * * /usr/bin/agent-iron run t1"));
+        assert!(text.contains("# iron-core-task:morning:end"));
+        assert!(!text.contains("disabled"));
+    }
+
+    #[test]
+    fn render_disabled_block() {
+        let block = make_block("morning", "0 9 * * *", "/usr/bin/agent-iron run t1", false);
+        let text = block.render();
+        assert!(text.contains("# iron-core-task:morning:begin"));
+        assert!(text.contains("# iron-core-task:morning:disabled"));
+        assert!(text.contains("# 0 9 * * * /usr/bin/agent-iron run t1"));
+        assert!(text.contains("# iron-core-task:morning:end"));
+    }
+
+    // ---- Round-trip parse/render ----
+
+    #[test]
+    fn round_trip_enabled_block() {
+        let block = make_block("s1", "0 9 * * *", "/agent-iron run t1 --config /c.db", true);
+        let rendered = block.render();
+        let parsed = ParsedCrontab::parse(&rendered);
+        let found = parsed.find_owned("s1").unwrap();
+        assert_eq!(found, &block);
+    }
+
+    #[test]
+    fn round_trip_disabled_block() {
+        let block = make_block("s1", "*/15 * * * *", "/agent-iron run t1", false);
+        let rendered = block.render();
+        let parsed = ParsedCrontab::parse(&rendered);
+        let found = parsed.find_owned("s1").unwrap();
+        assert_eq!(found, &block);
+    }
+
+    // ---- Mixed content ----
+
+    #[test]
+    fn parse_preserves_non_owned_content() {
+        let raw = "# My crontab\n\
+                   0 0 * * * /usr/bin/cleanup\n\
+                   \n\
+                   # iron-core-task:morning:begin\n\
+                   0 9 * * * /agent-iron run t1\n\
+                   # iron-core-task:morning:end\n\
+                   \n\
+                   30 5 * * 1 /usr/bin/backup\n";
+
+        let parsed = ParsedCrontab::parse(raw);
+        assert_eq!(parsed.owned_blocks().len(), 1);
+        assert_eq!(parsed.malformed_blocks().len(), 0);
+
+        // Non-owned content is preserved.
+        let rendered = parsed.render();
+        assert!(rendered.contains("0 0 * * * /usr/bin/cleanup"));
+        assert!(rendered.contains("30 5 * * 1 /usr/bin/backup"));
+        assert!(rendered.contains("# My crontab"));
+    }
+
+    #[test]
+    fn parse_multiple_owned_blocks() {
+        let raw = "# iron-core-task:a:begin\n\
+                   0 9 * * * /agent-iron run a\n\
+                   # iron-core-task:a:end\n\
+                   # iron-core-task:b:begin\n\
+                   0 10 * * * /agent-iron run b\n\
+                   # iron-core-task:b:end\n";
+
+        let parsed = ParsedCrontab::parse(raw);
+        assert_eq!(parsed.owned_blocks().len(), 2);
+    }
+
+    #[test]
+    fn parse_malformed_missing_end() {
+        let raw = "# iron-core-task:bad:begin\n\
+                   0 9 * * * /agent-iron run t1\n";
+
+        let parsed = ParsedCrontab::parse(raw);
+        assert_eq!(parsed.malformed_blocks().len(), 1);
+        assert_eq!(parsed.owned_blocks().len(), 0);
+    }
+
+    #[test]
+    fn parse_duplicate_id_marks_second_malformed() {
+        let raw = "# iron-core-task:dup:begin\n\
+                   0 9 * * * /agent-iron run t1\n\
+                   # iron-core-task:dup:end\n\
+                   # iron-core-task:dup:begin\n\
+                   0 10 * * * /agent-iron run t2\n\
+                   # iron-core-task:dup:end\n";
+
+        let parsed = ParsedCrontab::parse(raw);
+        assert_eq!(parsed.owned_blocks().len(), 1);
+        assert_eq!(parsed.malformed_blocks().len(), 1);
+    }
+
+    #[test]
+    fn parse_nested_begin_malformed() {
+        let raw = "# iron-core-task:a:begin\n\
+                   # iron-core-task:a:begin\n\
+                   0 9 * * * /agent-iron run t1\n\
+                   # iron-core-task:a:end\n";
+
+        let parsed = ParsedCrontab::parse(raw);
+        // The nested begin makes the first block malformed.
+        assert_eq!(parsed.malformed_blocks().len(), 1);
+    }
+
+    // ---- Upsert / remove ----
+
+    #[test]
+    fn upsert_replaces_in_place() {
+        let raw = "# iron-core-task:s1:begin\n\
+                   0 9 * * * /agent-iron run old\n\
+                   # iron-core-task:s1:end\n";
+
+        let mut parsed = ParsedCrontab::parse(raw);
+        let new_block = make_block("s1", "0 10 * * *", "/agent-iron run new", true);
+        parsed.upsert(new_block);
+
+        let found = parsed.find_owned("s1").unwrap();
+        assert_eq!(found.cron_schedule, "0 10 * * *");
+        assert_eq!(found.command, "/agent-iron run new");
+    }
+
+    #[test]
+    fn upsert_appends_new_block() {
+        let raw = "0 0 * * * /usr/bin/cleanup\n";
+        let mut parsed = ParsedCrontab::parse(raw);
+        let block = make_block("s1", "0 9 * * *", "/agent-iron run t1", true);
+        parsed.upsert(block);
+
+        assert_eq!(parsed.owned_blocks().len(), 1);
+        assert!(parsed.render().contains("0 0 * * * /usr/bin/cleanup"));
+    }
+
+    #[test]
+    fn remove_owned_block_preserves_others() {
+        let raw = "# iron-core-task:a:begin\n\
+                   0 9 * * * /agent-iron run a\n\
+                   # iron-core-task:a:end\n\
+                   # iron-core-task:b:begin\n\
+                   0 10 * * * /agent-iron run b\n\
+                   # iron-core-task:b:end\n";
+
+        let mut parsed = ParsedCrontab::parse(raw);
+        assert!(parsed.remove("a"));
+        assert_eq!(parsed.owned_blocks().len(), 1);
+        assert!(parsed.find_owned("a").is_none());
+        assert!(parsed.find_owned("b").is_some());
+    }
+
+    #[test]
+    fn remove_nonexistent_returns_false() {
+        let mut parsed = ParsedCrontab::parse("# unrelated\n");
+        assert!(!parsed.remove("nope"));
+    }
+
+    // ---- Edge cases ----
+
+    #[test]
+    fn empty_crontab() {
+        let parsed = ParsedCrontab::parse("");
+        assert!(parsed.owned_blocks().is_empty());
+        assert!(parsed.malformed_blocks().is_empty());
+    }
+
+    #[test]
+    fn no_owned_blocks() {
+        let raw = "0 0 * * * /usr/bin/cleanup\n30 5 * * 1 /usr/bin/backup\n";
+        let parsed = ParsedCrontab::parse(raw);
+        assert!(parsed.owned_blocks().is_empty());
+        assert_eq!(parsed.render(), raw);
+    }
+
+    #[test]
+    fn render_preserves_trailing_newlines() {
+        let raw = "0 0 * * * /cleanup\n\n";
+        let parsed = ParsedCrontab::parse(raw);
+        let rendered = parsed.render();
+        assert!(rendered.ends_with("\n\n"));
+    }
+}

--- a/src/scheduled_task/platform/crontab.rs
+++ b/src/scheduled_task/platform/crontab.rs
@@ -55,11 +55,7 @@ impl CronOwnedBlock {
         } else {
             format!(
                 "{}\n{}{}:disabled\n# {}\n{}\n",
-                begin,
-                MARKER_PREFIX,
-                self.schedule_id,
-                cron_line,
-                end
+                begin, MARKER_PREFIX, self.schedule_id, cron_line, end
             )
         }
     }
@@ -100,10 +96,7 @@ pub enum CrontabSegment {
     /// Non-owned lines, preserved as-is.
     Other(String),
     /// A malformed owned block (unbalanced or duplicate markers).
-    Malformed {
-        schedule_id: String,
-        raw: String,
-    },
+    Malformed { schedule_id: String, raw: String },
 }
 
 impl ParsedCrontab {
@@ -131,12 +124,7 @@ impl ParsedCrontab {
                     Some(ei) => {
                         let is_duplicate = !seen_ids.insert(sid.clone());
                         let block_lines = &lines[i + 1..ei];
-                        let raw_block: String = lines[i..=ei]
-                            .iter()
-                            .copied()
-                            .collect::<Vec<_>>()
-                            .join("\n")
-                            + "\n";
+                        let raw_block: String = lines[i..=ei].to_vec().join("\n") + "\n";
 
                         if is_duplicate {
                             segments.push(CrontabSegment::Malformed {
@@ -155,12 +143,7 @@ impl ParsedCrontab {
                     }
                     None => {
                         // No end marker — everything from here to EOF is malformed.
-                        let raw_block: String = lines[i..]
-                            .iter()
-                            .copied()
-                            .collect::<Vec<_>>()
-                            .join("\n")
-                            + "\n";
+                        let raw_block: String = lines[i..].to_vec().join("\n") + "\n";
                         segments.push(CrontabSegment::Malformed {
                             schedule_id: sid,
                             raw: raw_block,
@@ -208,12 +191,18 @@ impl ParsedCrontab {
     pub fn contains_id(&self, schedule_id: &str) -> bool {
         self.segments.iter().any(|s| match s {
             CrontabSegment::Owned(b) => b.schedule_id == schedule_id,
-            CrontabSegment::Malformed { schedule_id: sid, .. } => sid == schedule_id,
+            CrontabSegment::Malformed {
+                schedule_id: sid, ..
+            } => sid == schedule_id,
             _ => false,
         })
     }
 
     /// Insert or replace an owned block, preserving non-owned content.
+    ///
+    /// Only matching `Owned` segments are replaced in place. `Malformed`
+    /// segments are never replaced: their content may include unrelated
+    /// text, so a new `Owned` block is appended instead.
     pub fn upsert(&mut self, block: CronOwnedBlock) {
         let mut new_segments = Vec::new();
         let mut inserted = false;
@@ -222,13 +211,6 @@ impl ParsedCrontab {
             match &seg {
                 CrontabSegment::Owned(existing) if existing.schedule_id == block.schedule_id => {
                     // Replace in place.
-                    new_segments.push(CrontabSegment::Owned(block.clone()));
-                    inserted = true;
-                }
-                CrontabSegment::Malformed {
-                    schedule_id: sid, ..
-                } if sid == &block.schedule_id => {
-                    // Replace malformed block too.
                     new_segments.push(CrontabSegment::Owned(block.clone()));
                     inserted = true;
                 }
@@ -247,13 +229,14 @@ impl ParsedCrontab {
 
     /// Remove an owned block by schedule ID. Returns true if something was
     /// removed.
+    ///
+    /// Only `Owned` segments are removed. `Malformed` segments are preserved
+    /// because their content may include unrelated text that we cannot
+    /// safely delete.
     pub fn remove(&mut self, schedule_id: &str) -> bool {
         let before = self.segments.len();
         self.segments.retain(|s| match s {
             CrontabSegment::Owned(b) => b.schedule_id != schedule_id,
-            CrontabSegment::Malformed {
-                schedule_id: sid, ..
-            } => sid != schedule_id,
             _ => true,
         });
         self.segments.len() < before
@@ -275,9 +258,7 @@ impl ParsedCrontab {
         self.segments
             .iter()
             .filter_map(|s| match s {
-                CrontabSegment::Malformed { schedule_id, raw } => {
-                    Some((schedule_id, raw))
-                }
+                CrontabSegment::Malformed { schedule_id, raw } => Some((schedule_id, raw)),
                 _ => None,
             })
             .collect()

--- a/src/scheduled_task/platform/crontab.rs
+++ b/src/scheduled_task/platform/crontab.rs
@@ -21,6 +21,8 @@
 
 use std::collections::HashSet;
 
+use crate::scheduled_task::cron::CronExpression;
+
 // ============================================================================
 // Constants
 // ============================================================================
@@ -48,7 +50,11 @@ impl CronOwnedBlock {
     pub fn render(&self) -> String {
         let begin = format!("{}{}:begin", MARKER_PREFIX, self.schedule_id);
         let end = format!("{}{}:end", MARKER_PREFIX, self.schedule_id);
-        let cron_line = format!("{} {}", self.cron_schedule, self.command);
+        let cron_line = format!(
+            "{} {}",
+            self.cron_schedule,
+            escape_cron_percent(&self.command)
+        );
 
         if self.enabled {
             format!("{}\n{}\n{}\n", begin, cron_line, end)
@@ -101,8 +107,12 @@ pub enum CrontabSegment {
 
 impl ParsedCrontab {
     /// Parse raw crontab text into segments.
+    ///
+    /// Original line endings (LF or CRLF) and trailing-newline state are
+    /// preserved for non-owned content so rewrites only modify managed
+    /// entries.
     pub fn parse(raw: &str) -> Self {
-        let lines: Vec<&str> = raw.lines().collect();
+        let lines: Vec<&str> = raw.split_inclusive('\n').collect();
         let mut segments = Vec::new();
         let mut other_buf = String::new();
         let mut seen_ids: HashSet<String> = HashSet::new();
@@ -123,27 +133,29 @@ impl ParsedCrontab {
                 match end_idx {
                     Some(ei) => {
                         let is_duplicate = !seen_ids.insert(sid.clone());
-                        let block_lines = &lines[i + 1..ei];
-                        let raw_block: String = lines[i..=ei].to_vec().join("\n") + "\n";
+                        let raw_block: String = lines[i..=ei].concat();
 
                         if is_duplicate {
                             segments.push(CrontabSegment::Malformed {
                                 schedule_id: sid,
                                 raw: raw_block,
                             });
-                        } else if let Some(block) = parse_block_body(&sid, block_lines) {
-                            segments.push(CrontabSegment::Owned(block));
                         } else {
-                            segments.push(CrontabSegment::Malformed {
-                                schedule_id: sid,
-                                raw: raw_block,
-                            });
+                            let block_lines: Vec<&str> = lines[i + 1..ei].to_vec();
+                            if let Some(block) = parse_block_body(&sid, &block_lines) {
+                                segments.push(CrontabSegment::Owned(block));
+                            } else {
+                                segments.push(CrontabSegment::Malformed {
+                                    schedule_id: sid,
+                                    raw: raw_block,
+                                });
+                            }
                         }
                         i = ei + 1;
                     }
                     None => {
                         // No end marker — everything from here to EOF is malformed.
-                        let raw_block: String = lines[i..].to_vec().join("\n") + "\n";
+                        let raw_block: String = lines[i..].concat();
                         segments.push(CrontabSegment::Malformed {
                             schedule_id: sid,
                             raw: raw_block,
@@ -152,9 +164,8 @@ impl ParsedCrontab {
                     }
                 }
             } else {
-                // Non-owned line.
+                // Non-owned line — preserve original text including line ending.
                 other_buf.push_str(line);
-                other_buf.push('\n');
                 i += 1;
             }
         }
@@ -292,11 +303,10 @@ fn find_end_marker(lines: &[&str], from: usize, id: &str) -> Option<usize> {
         if line.trim() == end_marker {
             return Some(idx);
         }
-        // Detect nested begin of the same ID (malformed).
-        if let Some(nested_id) = parse_begin_marker(line) {
-            if nested_id == id {
-                return None;
-            }
+        // Reject any nested begin marker, regardless of ID — nested
+        // ownership blocks are malformed and must not be silently consumed.
+        if parse_begin_marker(line).is_some() {
+            return None;
         }
     }
     None
@@ -346,13 +356,14 @@ fn parse_block_body(schedule_id: &str, body_lines: &[&str]) -> Option<CronOwnedB
 
     let cron_line = cron_line?;
 
-    // Split into schedule fields and command.
-    let parts: Vec<&str> = cron_line.splitn(6, ' ').collect();
+    // Split into schedule fields and command using whitespace-aware parsing
+    // that handles tabs and repeated spaces consistently with looks_like_cron_line.
+    let parts: Vec<&str> = cron_line.split_whitespace().collect();
     if parts.len() < 6 {
         return None;
     }
     let cron_schedule = parts[..5].join(" ");
-    let command = parts[5].to_string();
+    let command = unescape_cron_percent(&parts[5..].join(" "));
 
     Some(CronOwnedBlock {
         schedule_id: schedule_id.to_string(),
@@ -362,10 +373,27 @@ fn parse_block_body(schedule_id: &str, body_lines: &[&str]) -> Option<CronOwnedB
     })
 }
 
+/// Escape `%` as `\%` for cron (cron treats unescaped `%` as newline).
+fn escape_cron_percent(s: &str) -> String {
+    s.replace('%', "\\%")
+}
+
+/// Reverse the cron `%` escaping applied by [`escape_cron_percent`].
+fn unescape_cron_percent(s: &str) -> String {
+    s.replace("\\%", "%")
+}
+
 /// Heuristic: does a line look like a cron schedule entry?
+///
+/// Validates that the first five whitespace-separated tokens form a valid
+/// five-field cron expression and that at least one command token follows.
 fn looks_like_cron_line(line: &str) -> bool {
     let parts: Vec<&str> = line.split_whitespace().collect();
-    parts.len() >= 6
+    if parts.len() < 6 {
+        return false;
+    }
+    let schedule = parts[..5].join(" ");
+    CronExpression::parse(&schedule).is_ok()
 }
 
 // ============================================================================

--- a/src/scheduled_task/platform/launchd.rs
+++ b/src/scheduled_task/platform/launchd.rs
@@ -24,6 +24,14 @@ fn escape_xml(s: &str) -> String {
         .replace('"', "&quot;")
 }
 
+/// Reverse the entity escaping applied by [`escape_xml`].
+fn unescape_xml(s: &str) -> String {
+    s.replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&amp;", "&")
+}
+
 /// Label prefix for AgentIron launchd entries.
 pub const LABEL_PREFIX: &str = "com.agentiron.task.";
 
@@ -79,6 +87,20 @@ pub fn expand_cron(cron: &CronExpression) -> Result<Vec<CalendarInterval>, Strin
 
     let mut intervals = Vec::new();
 
+    /// Push an interval, aborting early if MAX_INTERVALS would be exceeded.
+    macro_rules! push_interval {
+        ($intervals:expr, $val:expr) => {
+            if $intervals.len() >= MAX_INTERVALS {
+                return Err(format!(
+                    "cron expression expands to more than {} launchd intervals; \
+                     use a simpler expression",
+                    MAX_INTERVALS
+                ));
+            }
+            $intervals.push($val);
+        };
+    }
+
     if dom_restricted && dow_restricted {
         // Cron DOM-or-DOW: fire when either matches.
         // Set 1: specific DOM, DOW wildcard.
@@ -86,13 +108,16 @@ pub fn expand_cron(cron: &CronExpression) -> Result<Vec<CalendarInterval>, Strin
             for &h_val in &hour_vals {
                 for &dom in doms {
                     for &mo in &month_vals {
-                        intervals.push(CalendarInterval {
-                            minute: m_val,
-                            hour: h_val,
-                            day_of_month: Some(dom),
-                            month: mo,
-                            day_of_week: None,
-                        });
+                        push_interval!(
+                            intervals,
+                            CalendarInterval {
+                                minute: m_val,
+                                hour: h_val,
+                                day_of_month: Some(dom),
+                                month: mo,
+                                day_of_week: None,
+                            }
+                        );
                     }
                 }
             }
@@ -102,13 +127,16 @@ pub fn expand_cron(cron: &CronExpression) -> Result<Vec<CalendarInterval>, Strin
             for &h_val in &hour_vals {
                 for &dow in dows {
                     for &mo in &month_vals {
-                        intervals.push(CalendarInterval {
-                            minute: m_val,
-                            hour: h_val,
-                            day_of_month: None,
-                            month: mo,
-                            day_of_week: Some(if dow == 0 { 7 } else { dow }),
-                        });
+                        push_interval!(
+                            intervals,
+                            CalendarInterval {
+                                minute: m_val,
+                                hour: h_val,
+                                day_of_month: None,
+                                month: mo,
+                                day_of_week: Some(if dow == 0 { 7 } else { dow }),
+                            }
+                        );
                     }
                 }
             }
@@ -134,13 +162,16 @@ pub fn expand_cron(cron: &CronExpression) -> Result<Vec<CalendarInterval>, Strin
                 for &dom in &dom_vals {
                     for &mo in &month_vals {
                         for &dow in &dow_vals {
-                            intervals.push(CalendarInterval {
-                                minute: m_val,
-                                hour: h_val,
-                                day_of_month: dom,
-                                month: mo,
-                                day_of_week: dow,
-                            });
+                            push_interval!(
+                                intervals,
+                                CalendarInterval {
+                                    minute: m_val,
+                                    hour: h_val,
+                                    day_of_month: dom,
+                                    month: mo,
+                                    day_of_week: dow,
+                                }
+                            );
                         }
                     }
                 }
@@ -253,6 +284,8 @@ fn push_interval_keys(xml: &mut String, interval: &CalendarInterval, indent: &st
 /// Extract the `<string>` values inside a plist's `ProgramArguments` array.
 ///
 /// Returns an empty vector if the key or array cannot be located.
+/// String values are XML-decoded so escaped paths and arguments match
+/// their actual values.
 fn parse_program_arguments(text: &str) -> Vec<String> {
     let key = "<key>ProgramArguments</key>";
     let key_pos = match text.find(key) {
@@ -279,7 +312,7 @@ fn parse_program_arguments(text: &str) -> Vec<String> {
             Some(p) => p,
             None => break,
         };
-        args.push(rest[..close].to_string());
+        args.push(unescape_xml(&rest[..close]));
         cursor = &rest[close + "</string>".len()..];
     }
     args
@@ -320,12 +353,39 @@ impl LaunchdHostScheduler {
     }
 
     /// Bootout (unload) the agent if currently loaded.
-    async fn bootout_if_loaded(&self, schedule_id: &str) {
+    ///
+    /// Returns `Ok(())` if the agent was successfully unloaded or was not
+    /// loaded to begin with. Other failures are propagated.
+    async fn bootout_if_loaded(&self, schedule_id: &str) -> Result<(), HostSchedulerError> {
         let target = self.service_target(schedule_id);
-        let _ = self.runner.run("launchctl", &["bootout", &target]).await;
+        let output = self
+            .runner
+            .run("launchctl", &["bootout", &target])
+            .await
+            .map_err(|e| HostSchedulerError::Io(e.to_string()))?;
+
+        if output.exit_code == 0 {
+            return Ok(());
+        }
+
+        let stderr = output.stderr.to_lowercase();
+        if stderr.contains("not loaded")
+            || stderr.contains("could not find")
+            || stderr.contains("no such process")
+        {
+            return Ok(());
+        }
+
+        Err(HostSchedulerError::Io(format!(
+            "launchctl bootout failed (exit {}): {}",
+            output.exit_code, output.stderr
+        )))
     }
 
     /// Bootstrap (load) the agent from its plist.
+    ///
+    /// Returns `Ok(())` if the agent was successfully loaded or was already
+    /// loaded. Other failures are propagated.
     async fn bootstrap(&self, schedule_id: &str) -> Result<(), HostSchedulerError> {
         let plist_path = self.plist_path(schedule_id);
         let path_str = plist_path.to_string_lossy().to_string();
@@ -337,37 +397,90 @@ impl LaunchdHostScheduler {
             .await
             .map_err(|e| HostSchedulerError::Io(e.to_string()))?;
 
-        if output.exit_code != 0 && !output.stderr.contains("already") {
-            return Err(HostSchedulerError::Io(format!(
-                "launchctl bootstrap failed: {}",
-                output.stderr
-            )));
+        if output.exit_code == 0 {
+            return Ok(());
         }
 
-        Ok(())
+        let stderr = output.stderr.to_lowercase();
+        if stderr.contains("already loaded") || stderr.contains("already bootstrapped") {
+            return Ok(());
+        }
+
+        Err(HostSchedulerError::Io(format!(
+            "launchctl bootstrap failed: {}",
+            output.stderr
+        )))
     }
 
     /// Read and parse a schedule's plist file into an observed entry.
     ///
-    /// Returns `None` if the file cannot be read or reports a non-zero exit.
-    /// The XML text is parsed to determine enabled/disabled state, extract the
-    /// program command, and flag corruption.
-    async fn read_plist_entry(&self, schedule_id: &str) -> Option<ObservedHostEntry> {
+    /// Returns `Ok(None)` if the plist file is confirmed absent. Returns
+    /// `Ok(Some(entry))` with `corrupt: true` if the file exists but is
+    /// malformed. Returns `Err` for command execution failures or
+    /// non-"not found" errors so reconciliation does not treat
+    /// inaccessible state as absence.
+    async fn read_plist_entry(
+        &self,
+        schedule_id: &str,
+    ) -> Result<Option<ObservedHostEntry>, HostSchedulerError> {
         let plist_path = self.plist_path(schedule_id);
         let path_str = plist_path.to_string_lossy().to_string();
 
-        let output = self.runner.run("cat", &[&path_str]).await.ok()?;
+        let output = self
+            .runner
+            .run("cat", &[&path_str])
+            .await
+            .map_err(|e| HostSchedulerError::Io(e.to_string()))?;
+
         if output.exit_code != 0 {
-            return None;
+            let stderr = output.stderr.to_lowercase();
+            if stderr.contains("no such file") || stderr.contains("not found") {
+                return Ok(None);
+            }
+            return Err(HostSchedulerError::Io(format!(
+                "cat failed (exit {}): {}",
+                output.exit_code, output.stderr
+            )));
         }
 
         let text = &output.stdout;
+        let expected_label = format!("{}{}", LABEL_PREFIX, schedule_id);
 
-        // A valid launchd plist has a <plist> root and a Label key.
-        let corrupt = !text.contains("<plist") || !text.contains("<key>Label</key>");
+        // Structural validation: require well-formed plist structure.
+        let has_plist_open = text.contains("<plist");
+        let has_plist_close = text.contains("</plist>");
+        let has_dict = text.contains("<dict>") && text.contains("</dict>");
 
-        // Disabled is true when <true/> is the value following the Disabled key,
-        // i.e. it appears before the next sibling <key>.
+        if !has_plist_open || !has_plist_close || !has_dict {
+            return Ok(Some(ObservedHostEntry {
+                schedule_id: schedule_id.to_string(),
+                enabled: false,
+                corrupt: true,
+                raw_schedule: None,
+                observed_command: None,
+                metadata: None,
+            }));
+        }
+
+        // Validate Label matches expected schedule ID (XML-decoded).
+        let label_key = "<key>Label</key>";
+        let label_ok = text.find(label_key).is_some_and(|pos| {
+            let after = &text[pos + label_key.len()..];
+            after.contains(&format!("<string>{}</string>", escape_xml(&expected_label)))
+        });
+
+        if !label_ok {
+            return Ok(Some(ObservedHostEntry {
+                schedule_id: schedule_id.to_string(),
+                enabled: false,
+                corrupt: true,
+                raw_schedule: None,
+                observed_command: None,
+                metadata: None,
+            }));
+        }
+
+        // Disabled is true when <true/> is the value following the Disabled key.
         let disabled = text.find("<key>Disabled</key>").map(|pos| {
             let after = &text[pos + "<key>Disabled</key>".len()..];
             match (after.find("<true/>"), after.find("<key>")) {
@@ -377,16 +490,29 @@ impl LaunchdHostScheduler {
             }
         });
 
+        // Validate ProgramArguments exists and has at least one string value.
         let command = parse_program_arguments(text).join(" ");
+        let has_program_args = text.contains("<key>ProgramArguments</key>") && !command.is_empty();
 
-        Some(ObservedHostEntry {
+        if !has_program_args {
+            return Ok(Some(ObservedHostEntry {
+                schedule_id: schedule_id.to_string(),
+                enabled: !disabled.unwrap_or(false),
+                corrupt: true,
+                raw_schedule: None,
+                observed_command: None,
+                metadata: None,
+            }));
+        }
+
+        Ok(Some(ObservedHostEntry {
             schedule_id: schedule_id.to_string(),
             enabled: !disabled.unwrap_or(false),
-            corrupt,
+            corrupt: false,
             raw_schedule: None,
             observed_command: Some(command),
             metadata: None,
-        })
+        }))
     }
 }
 
@@ -440,13 +566,35 @@ impl HostScheduler for LaunchdHostScheduler {
         }
 
         // Reload: bootout if loaded, then bootstrap.
-        self.bootout_if_loaded(&request.schedule_id).await;
+        self.bootout_if_loaded(&request.schedule_id).await?;
         self.bootstrap(&request.schedule_id).await?;
 
         // Apply enabled/disabled state via launchctl.
-        if !request.enabled {
-            let target = self.service_target(&request.schedule_id);
-            let _ = self.runner.run("launchctl", &["disable", &target]).await;
+        let target = self.service_target(&request.schedule_id);
+        if request.enabled {
+            let output = self
+                .runner
+                .run("launchctl", &["enable", &target])
+                .await
+                .map_err(|e| HostSchedulerError::Io(e.to_string()))?;
+            if output.exit_code != 0 {
+                return Err(HostSchedulerError::Io(format!(
+                    "launchctl enable failed: {}",
+                    output.stderr
+                )));
+            }
+        } else {
+            let output = self
+                .runner
+                .run("launchctl", &["disable", &target])
+                .await
+                .map_err(|e| HostSchedulerError::Io(e.to_string()))?;
+            if output.exit_code != 0 {
+                return Err(HostSchedulerError::Io(format!(
+                    "launchctl disable failed: {}",
+                    output.stderr
+                )));
+            }
         }
 
         Ok(())
@@ -454,7 +602,7 @@ impl HostScheduler for LaunchdHostScheduler {
 
     async fn remove(&self, schedule_id: &str) -> Result<(), HostSchedulerError> {
         // Unload the agent first.
-        self.bootout_if_loaded(schedule_id).await;
+        self.bootout_if_loaded(schedule_id).await?;
 
         // Then delete the plist file.
         let plist_path = self.plist_path(schedule_id);
@@ -484,13 +632,20 @@ impl HostScheduler for LaunchdHostScheduler {
             .await
             .map_err(|e| HostSchedulerError::Io(e.to_string()))?;
 
+        if output.exit_code != 0 {
+            return Err(HostSchedulerError::Io(format!(
+                "ls failed (exit {}): {}",
+                output.exit_code, output.stderr
+            )));
+        }
+
         let mut entries = Vec::new();
         for line in output.stdout.lines() {
             if let Some(schedule_id) = line
                 .strip_prefix(&format!("{}{}", LABEL_PREFIX, ""))
                 .and_then(|s| s.strip_suffix(".plist"))
             {
-                if let Some(entry) = self.read_plist_entry(schedule_id).await {
+                if let Some(entry) = self.read_plist_entry(schedule_id).await? {
                     entries.push(entry);
                 }
             }
@@ -502,7 +657,7 @@ impl HostScheduler for LaunchdHostScheduler {
         &self,
         schedule_id: &str,
     ) -> Result<Option<ObservedHostEntry>, HostSchedulerError> {
-        Ok(self.read_plist_entry(schedule_id).await)
+        self.read_plist_entry(schedule_id).await
     }
 }
 

--- a/src/scheduled_task/platform/launchd.rs
+++ b/src/scheduled_task/platform/launchd.rs
@@ -250,6 +250,41 @@ fn push_interval_keys(xml: &mut String, interval: &CalendarInterval, indent: &st
     }
 }
 
+/// Extract the `<string>` values inside a plist's `ProgramArguments` array.
+///
+/// Returns an empty vector if the key or array cannot be located.
+fn parse_program_arguments(text: &str) -> Vec<String> {
+    let key = "<key>ProgramArguments</key>";
+    let key_pos = match text.find(key) {
+        Some(p) => p + key.len(),
+        None => return Vec::new(),
+    };
+    let after_key = &text[key_pos..];
+    let array_open = match after_key.find("<array>") {
+        Some(p) => key_pos + p + "<array>".len(),
+        None => return Vec::new(),
+    };
+    let array_close = match text[array_open..].find("</array>") {
+        Some(p) => array_open + p,
+        None => return Vec::new(),
+    };
+    let body = &text[array_open..array_close];
+
+    let mut args = Vec::new();
+    let mut cursor = body;
+    while let Some(open) = cursor.find("<string>") {
+        let value_start = open + "<string>".len();
+        let rest = &cursor[value_start..];
+        let close = match rest.find("</string>") {
+            Some(p) => p,
+            None => break,
+        };
+        args.push(rest[..close].to_string());
+        cursor = &rest[close + "</string>".len()..];
+    }
+    args
+}
+
 // ============================================================================
 // Adapter
 // ============================================================================
@@ -310,6 +345,48 @@ impl LaunchdHostScheduler {
         }
 
         Ok(())
+    }
+
+    /// Read and parse a schedule's plist file into an observed entry.
+    ///
+    /// Returns `None` if the file cannot be read or reports a non-zero exit.
+    /// The XML text is parsed to determine enabled/disabled state, extract the
+    /// program command, and flag corruption.
+    async fn read_plist_entry(&self, schedule_id: &str) -> Option<ObservedHostEntry> {
+        let plist_path = self.plist_path(schedule_id);
+        let path_str = plist_path.to_string_lossy().to_string();
+
+        let output = self.runner.run("cat", &[&path_str]).await.ok()?;
+        if output.exit_code != 0 {
+            return None;
+        }
+
+        let text = &output.stdout;
+
+        // A valid launchd plist has a <plist> root and a Label key.
+        let corrupt = !text.contains("<plist") || !text.contains("<key>Label</key>");
+
+        // Disabled is true when <true/> is the value following the Disabled key,
+        // i.e. it appears before the next sibling <key>.
+        let disabled = text.find("<key>Disabled</key>").map(|pos| {
+            let after = &text[pos + "<key>Disabled</key>".len()..];
+            match (after.find("<true/>"), after.find("<key>")) {
+                (Some(t), Some(k)) => t < k,
+                (Some(_), None) => true,
+                _ => false,
+            }
+        });
+
+        let command = parse_program_arguments(text).join(" ");
+
+        Some(ObservedHostEntry {
+            schedule_id: schedule_id.to_string(),
+            enabled: !disabled.unwrap_or(false),
+            corrupt,
+            raw_schedule: None,
+            observed_command: Some(command),
+            metadata: None,
+        })
     }
 }
 
@@ -413,14 +490,9 @@ impl HostScheduler for LaunchdHostScheduler {
                 .strip_prefix(&format!("{}{}", LABEL_PREFIX, ""))
                 .and_then(|s| s.strip_suffix(".plist"))
             {
-                entries.push(ObservedHostEntry {
-                    schedule_id: schedule_id.to_string(),
-                    enabled: true,
-                    corrupt: false,
-                    raw_schedule: None,
-                    observed_command: None,
-                    metadata: None,
-                });
+                if let Some(entry) = self.read_plist_entry(schedule_id).await {
+                    entries.push(entry);
+                }
             }
         }
         Ok(entries)
@@ -430,8 +502,7 @@ impl HostScheduler for LaunchdHostScheduler {
         &self,
         schedule_id: &str,
     ) -> Result<Option<ObservedHostEntry>, HostSchedulerError> {
-        let list = self.list_owned().await?;
-        Ok(list.into_iter().find(|e| e.schedule_id == schedule_id))
+        Ok(self.read_plist_entry(schedule_id).await)
     }
 }
 

--- a/src/scheduled_task/platform/launchd.rs
+++ b/src/scheduled_task/platform/launchd.rs
@@ -1,0 +1,458 @@
+//! macOS launchd host scheduler adapter.
+//!
+//! Manages user-level LaunchAgent plists with `com.agentiron.task.` labels.
+//! Cron expressions are expanded into launchd `StartCalendarInterval`
+//! entries. plist files live in `~/Library/LaunchAgents/`.
+//!
+//! The plist rendering and cron expansion logic is platform-independent
+//! and tested here. The actual `launchctl` command execution is Linux
+//! unavailable but the adapter is designed for correctness on macOS.
+
+use async_trait::async_trait;
+use std::path::PathBuf;
+
+use crate::scheduled_task::cron::CronExpression;
+use crate::scheduled_task::host::{
+    CommandRunner, HostInstallRequest, HostScheduler, HostSchedulerError, ObservedHostEntry,
+};
+
+/// Label prefix for AgentIron launchd entries.
+pub const LABEL_PREFIX: &str = "com.agentiron.task.";
+
+/// Maximum number of StartCalendarInterval entries before rejecting.
+/// Prevents combinatorial explosion from complex cron expressions.
+pub const MAX_INTERVALS: usize = 64;
+
+// ============================================================================
+// Cron to StartCalendarInterval expansion
+// ============================================================================
+
+/// A single launchd calendar interval.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CalendarInterval {
+    pub minute: Option<u32>,
+    pub hour: Option<u32>,
+    pub day_of_month: Option<u32>,
+    pub month: Option<u32>,
+    pub day_of_week: Option<u32>,
+}
+
+/// Expand a parsed cron expression into launchd calendar intervals.
+///
+/// Returns `Err` if the expansion would exceed `MAX_INTERVALS` entries or
+/// if the expression cannot be faithfully represented.
+pub fn expand_cron(cron: &CronExpression) -> Result<Vec<CalendarInterval>, String> {
+    let minutes = cron.minutes();
+    let hours = cron.hours();
+    let doms = cron.days_of_month();
+    let months = cron.months();
+    let dows = cron.days_of_week();
+
+    let dom_restricted = doms.len() < 31;
+    let dow_restricted = dows.len() < 7;
+    let month_restricted = months.len() < 12;
+
+    // Wildcard minute/hour fields produce None (match any).
+    let minute_vals: Vec<Option<u32>> = if minutes.len() < 60 {
+        minutes.iter().copied().map(Some).collect()
+    } else {
+        vec![None]
+    };
+    let hour_vals: Vec<Option<u32>> = if hours.len() < 24 {
+        hours.iter().copied().map(Some).collect()
+    } else {
+        vec![None]
+    };
+    let month_vals: Vec<Option<u32>> = if month_restricted {
+        months.iter().copied().map(Some).collect()
+    } else {
+        vec![None]
+    };
+
+    let mut intervals = Vec::new();
+
+    if dom_restricted && dow_restricted {
+        // Cron DOM-or-DOW: fire when either matches.
+        // Set 1: specific DOM, DOW wildcard.
+        for &m_val in &minute_vals {
+            for &h_val in &hour_vals {
+                for &dom in doms {
+                    for &mo in &month_vals {
+                        intervals.push(CalendarInterval {
+                            minute: m_val,
+                            hour: h_val,
+                            day_of_month: Some(dom),
+                            month: mo,
+                            day_of_week: None,
+                        });
+                    }
+                }
+            }
+        }
+        // Set 2: DOM wildcard, specific DOW.
+        for &m_val in &minute_vals {
+            for &h_val in &hour_vals {
+                for &dow in dows {
+                    for &mo in &month_vals {
+                        intervals.push(CalendarInterval {
+                            minute: m_val,
+                            hour: h_val,
+                            day_of_month: None,
+                            month: mo,
+                            day_of_week: Some(if dow == 0 { 7 } else { dow }),
+                        });
+                    }
+                }
+            }
+        }
+    } else {
+        // Simple case: iterate only over restricted fields.
+        let dom_vals: Vec<Option<u32>> = if dom_restricted {
+            doms.iter().copied().map(Some).collect()
+        } else {
+            vec![None]
+        };
+        let dow_vals: Vec<Option<u32>> = if dow_restricted {
+            dows.iter()
+                .copied()
+                .map(|d| Some(if d == 0 { 7 } else { d }))
+                .collect()
+        } else {
+            vec![None]
+        };
+
+        for &m_val in &minute_vals {
+            for &h_val in &hour_vals {
+                for &dom in &dom_vals {
+                    for &mo in &month_vals {
+                        for &dow in &dow_vals {
+                            intervals.push(CalendarInterval {
+                                minute: m_val,
+                                hour: h_val,
+                                day_of_month: dom,
+                                month: mo,
+                                day_of_week: dow,
+                            });
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    intervals.sort_by_key(|i| (i.minute, i.hour, i.day_of_month, i.month, i.day_of_week));
+    intervals.dedup();
+
+    if intervals.len() > MAX_INTERVALS {
+        return Err(format!(
+            "cron expression expands to {} launchd intervals (max {}); \
+             use a simpler expression",
+            intervals.len(),
+            MAX_INTERVALS
+        ));
+    }
+
+    Ok(intervals)
+}
+
+// ============================================================================
+// Plist rendering
+// ============================================================================
+
+/// Render a complete LaunchAgent plist for the given parameters.
+pub fn render_plist(
+    schedule_id: &str,
+    intervals: &[CalendarInterval],
+    program_args: &[String],
+    disabled: bool,
+) -> String {
+    let label = format!("{}{}", LABEL_PREFIX, schedule_id);
+
+    let mut xml = String::new();
+    xml.push_str("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+    xml.push_str("<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n");
+    xml.push_str("<plist version=\"1.0\">\n");
+    xml.push_str("<dict>\n");
+
+    xml.push_str(&format!("    <key>Label</key>\n    <string>{}</string>\n", label));
+
+    if disabled {
+        xml.push_str("    <key>Disabled</key>\n    <true/>\n");
+    }
+
+    xml.push_str("    <key>ProgramArguments</key>\n    <array>\n");
+    for arg in program_args {
+        xml.push_str(&format!("        <string>{}</string>\n", arg));
+    }
+    xml.push_str("    </array>\n");
+
+    xml.push_str("    <key>StartCalendarInterval</key>\n");
+    if intervals.len() == 1 {
+        xml.push_str("    <dict>\n");
+        push_interval_keys(&mut xml, &intervals[0], "        ");
+        xml.push_str("    </dict>\n");
+    } else {
+        xml.push_str("    <array>\n");
+        for interval in intervals {
+            xml.push_str("        <dict>\n");
+            push_interval_keys(&mut xml, interval, "            ");
+            xml.push_str("        </dict>\n");
+        }
+        xml.push_str("    </array>\n");
+    }
+
+    xml.push_str("</dict>\n");
+    xml.push_str("</plist>\n");
+    xml
+}
+
+fn push_interval_keys(xml: &mut String, interval: &CalendarInterval, indent: &str) {
+    if let Some(m) = interval.minute {
+        xml.push_str(&format!("{}<key>Minute</key>\n{}<integer>{}</integer>\n", indent, indent, m));
+    }
+    if let Some(h) = interval.hour {
+        xml.push_str(&format!("{}<key>Hour</key>\n{}<integer>{}</integer>\n", indent, indent, h));
+    }
+    if let Some(d) = interval.day_of_month {
+        xml.push_str(&format!("{}<key>Day</key>\n{}<integer>{}</integer>\n", indent, indent, d));
+    }
+    if let Some(mo) = interval.month {
+        xml.push_str(&format!("{}<key>Month</key>\n{}<integer>{}</integer>\n", indent, indent, mo));
+    }
+    if let Some(dow) = interval.day_of_week {
+        xml.push_str(&format!(
+            "{}<key>Weekday</key>\n{}<integer>{}</integer>\n",
+            indent, indent, dow
+        ));
+    }
+}
+
+// ============================================================================
+// Adapter
+// ============================================================================
+
+/// macOS launchd host scheduler.
+pub struct LaunchdHostScheduler {
+    runner: Box<dyn CommandRunner>,
+    launchagents_dir: PathBuf,
+}
+
+impl LaunchdHostScheduler {
+    pub fn new(runner: Box<dyn CommandRunner>, launchagents_dir: PathBuf) -> Self {
+        Self {
+            runner,
+            launchagents_dir,
+        }
+    }
+
+    fn plist_path(&self, schedule_id: &str) -> PathBuf {
+        self.launchagents_dir
+            .join(format!("{}{}.plist", LABEL_PREFIX, schedule_id))
+    }
+}
+
+#[async_trait]
+impl HostScheduler for LaunchdHostScheduler {
+    fn platform(&self) -> &'static str {
+        "launchd"
+    }
+
+    async fn install(&self, request: &HostInstallRequest) -> Result<(), HostSchedulerError> {
+        let intervals = expand_cron(&request.cron).map_err(|reason| {
+            HostSchedulerError::UnsupportedSchedule {
+                platform: "launchd",
+                reason,
+            }
+        })?;
+
+        // Split command into program arguments.
+        let program_args: Vec<String> = request.command.split_whitespace().map(String::from).collect();
+
+        let plist_content = render_plist(
+            &request.schedule_id,
+            &intervals,
+            &program_args,
+            !request.enabled,
+        );
+
+        // Write plist via launchctl bootstrap or direct file write.
+        let plist_path = self.plist_path(&request.schedule_id);
+        let path_str = plist_path.to_string_lossy().to_string();
+
+        let output = self
+            .runner
+            .run_with_stdin("tee", &[&path_str], &plist_content)
+            .await
+            .map_err(|e| HostSchedulerError::Io(e.to_string()))?;
+
+        if output.exit_code != 0 {
+            return Err(HostSchedulerError::Io(format!(
+                "failed to write plist: {}",
+                output.stderr
+            )));
+        }
+
+        Ok(())
+    }
+
+    async fn remove(&self, schedule_id: &str) -> Result<(), HostSchedulerError> {
+        let plist_path = self.plist_path(schedule_id);
+        let path_str = plist_path.to_string_lossy().to_string();
+
+        let _ = self
+            .runner
+            .run("rm", &["-f", &path_str])
+            .await;
+
+        Ok(())
+    }
+
+    async fn list_owned(&self) -> Result<Vec<ObservedHostEntry>, HostSchedulerError> {
+        let dir_str = self.launchagents_dir.to_string_lossy().to_string();
+        let output = self
+            .runner
+            .run("ls", &["-1", &dir_str])
+            .await
+            .map_err(|e| HostSchedulerError::Io(e.to_string()))?;
+
+        let mut entries = Vec::new();
+        for line in output.stdout.lines() {
+            if let Some(schedule_id) = line
+                .strip_prefix(&format!("{}{}", LABEL_PREFIX, ""))
+                .and_then(|s| s.strip_suffix(".plist"))
+            {
+                entries.push(ObservedHostEntry {
+                    schedule_id: schedule_id.to_string(),
+                    enabled: true,
+                    corrupt: false,
+                    raw_schedule: None,
+                    observed_command: None,
+                    metadata: None,
+                });
+            }
+        }
+        Ok(entries)
+    }
+
+    async fn inspect(
+        &self,
+        schedule_id: &str,
+    ) -> Result<Option<ObservedHostEntry>, HostSchedulerError> {
+        let list = self.list_owned().await?;
+        Ok(list
+            .into_iter()
+            .find(|e| e.schedule_id == schedule_id))
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn expand_simple_daily() {
+        let cron = CronExpression::parse("0 9 * * *").unwrap();
+        let intervals = expand_cron(&cron).unwrap();
+        assert_eq!(intervals.len(), 1);
+        assert_eq!(intervals[0].minute, Some(0));
+        assert_eq!(intervals[0].hour, Some(9));
+    }
+
+    #[test]
+    fn expand_every_15_minutes() {
+        let cron = CronExpression::parse("*/15 * * * *").unwrap();
+        let intervals = expand_cron(&cron).unwrap();
+        assert_eq!(intervals.len(), 4);
+        assert_eq!(intervals[0].minute, Some(0));
+        assert_eq!(intervals[1].minute, Some(15));
+    }
+
+    #[test]
+    fn expand_weekdays() {
+        let cron = CronExpression::parse("0 9 * * 1-5").unwrap();
+        let intervals = expand_cron(&cron).unwrap();
+        assert!(intervals.len() >= 5);
+    }
+
+    #[test]
+    fn expand_dom_and_dow_creates_union() {
+        let cron = CronExpression::parse("0 9 1 * 1").unwrap();
+        let intervals = expand_cron(&cron).unwrap();
+        // DOM=1 OR DOW=1 → at least 2 intervals
+        assert!(intervals.len() >= 2);
+    }
+
+    #[test]
+    fn expand_rejects_excessive() {
+        // Complex expression that exceeds MAX_INTERVALS (64).
+        // 4 minutes × 5 hours × 2 DOM × 2 DOW (DOM-and-DOW union doubles) = ~80+
+        let cron = CronExpression::parse("0,15,30,45 9,10,11,12,13 1,15 * 1,2,3,4,5").unwrap();
+        let result = expand_cron(&cron);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn render_plist_basic() {
+        let intervals = vec![CalendarInterval {
+            minute: Some(0),
+            hour: Some(9),
+            day_of_month: None,
+            month: None,
+            day_of_week: None,
+        }];
+        let args = vec![
+            "/usr/local/bin/agent-iron".to_string(),
+            "run".to_string(),
+            "task-1".to_string(),
+        ];
+        let plist = render_plist("s1", &intervals, &args, false);
+        assert!(plist.contains("<string>com.agentiron.task.s1</string>"));
+        assert!(plist.contains("<key>Minute</key>"));
+        assert!(plist.contains("<key>Hour</key>"));
+        assert!(plist.contains("<integer>0</integer>"));
+        assert!(plist.contains("<integer>9</integer>"));
+        assert!(!plist.contains("<key>Disabled</key>"));
+    }
+
+    #[test]
+    fn render_plist_disabled() {
+        let intervals = vec![CalendarInterval {
+            minute: Some(30),
+            hour: Some(5),
+            day_of_month: None,
+            month: None,
+            day_of_week: None,
+        }];
+        let args = vec!["/agent-iron".to_string(), "run".to_string()];
+        let plist = render_plist("s1", &intervals, &args, true);
+        assert!(plist.contains("<key>Disabled</key>"));
+        assert!(plist.contains("<true/>"));
+    }
+
+    #[test]
+    fn render_plist_multiple_intervals() {
+        let intervals = vec![
+            CalendarInterval {
+                minute: Some(0),
+                hour: Some(9),
+                day_of_month: None,
+                month: None,
+                day_of_week: None,
+            },
+            CalendarInterval {
+                minute: Some(0),
+                hour: Some(17),
+                day_of_month: None,
+                month: None,
+                day_of_week: None,
+            },
+        ];
+        let args = vec!["/agent-iron".to_string()];
+        let plist = render_plist("s1", &intervals, &args, false);
+        assert!(plist.contains("<array>"));
+    }
+}

--- a/src/scheduled_task/platform/launchd.rs
+++ b/src/scheduled_task/platform/launchd.rs
@@ -16,6 +16,14 @@ use crate::scheduled_task::host::{
     CommandRunner, HostInstallRequest, HostScheduler, HostSchedulerError, ObservedHostEntry,
 };
 
+/// Escape XML special characters.
+fn escape_xml(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}
+
 /// Label prefix for AgentIron launchd entries.
 pub const LABEL_PREFIX: &str = "com.agentiron.task.";
 
@@ -166,7 +174,7 @@ pub fn render_plist(
     program_args: &[String],
     disabled: bool,
 ) -> String {
-    let label = format!("{}{}", LABEL_PREFIX, schedule_id);
+    let label = format!("{}{}", LABEL_PREFIX, escape_xml(schedule_id));
 
     let mut xml = String::new();
     xml.push_str("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
@@ -185,7 +193,7 @@ pub fn render_plist(
 
     xml.push_str("    <key>ProgramArguments</key>\n    <array>\n");
     for arg in program_args {
-        xml.push_str(&format!("        <string>{}</string>\n", arg));
+        xml.push_str(&format!("        <string>{}</string>\n", escape_xml(arg)));
     }
     xml.push_str("    </array>\n");
 
@@ -250,13 +258,16 @@ fn push_interval_keys(xml: &mut String, interval: &CalendarInterval, indent: &st
 pub struct LaunchdHostScheduler {
     runner: Box<dyn CommandRunner>,
     launchagents_dir: PathBuf,
+    uid: u32,
 }
 
 impl LaunchdHostScheduler {
     pub fn new(runner: Box<dyn CommandRunner>, launchagents_dir: PathBuf) -> Self {
+        let uid = extern_uid();
         Self {
             runner,
             launchagents_dir,
+            uid,
         }
     }
 
@@ -264,6 +275,50 @@ impl LaunchdHostScheduler {
         self.launchagents_dir
             .join(format!("{}{}.plist", LABEL_PREFIX, schedule_id))
     }
+
+    fn domain_target(&self) -> String {
+        format!("gui/{}", self.uid)
+    }
+
+    fn service_target(&self, schedule_id: &str) -> String {
+        format!("{}/{}{}", self.domain_target(), LABEL_PREFIX, schedule_id)
+    }
+
+    /// Bootout (unload) the agent if currently loaded.
+    async fn bootout_if_loaded(&self, schedule_id: &str) {
+        let target = self.service_target(schedule_id);
+        let _ = self.runner.run("launchctl", &["bootout", &target]).await;
+    }
+
+    /// Bootstrap (load) the agent from its plist.
+    async fn bootstrap(&self, schedule_id: &str) -> Result<(), HostSchedulerError> {
+        let plist_path = self.plist_path(schedule_id);
+        let path_str = plist_path.to_string_lossy().to_string();
+        let domain = self.domain_target();
+
+        let output = self
+            .runner
+            .run("launchctl", &["bootstrap", &domain, &path_str])
+            .await
+            .map_err(|e| HostSchedulerError::Io(e.to_string()))?;
+
+        if output.exit_code != 0 && !output.stderr.contains("already") {
+            return Err(HostSchedulerError::Io(format!(
+                "launchctl bootstrap failed: {}",
+                output.stderr
+            )));
+        }
+
+        Ok(())
+    }
+}
+
+/// Get the current process UID without external crate dependencies.
+fn extern_uid() -> u32 {
+    extern "C" {
+        fn getuid() -> u32;
+    }
+    unsafe { getuid() }
 }
 
 #[async_trait]
@@ -280,7 +335,6 @@ impl HostScheduler for LaunchdHostScheduler {
             }
         })?;
 
-        // Build ProgramArguments from the structured request.
         let mut program_args = vec![request.program.display().to_string()];
         program_args.extend(request.args.iter().cloned());
 
@@ -291,7 +345,7 @@ impl HostScheduler for LaunchdHostScheduler {
             !request.enabled,
         );
 
-        // Write plist via launchctl bootstrap or direct file write.
+        // Write plist file.
         let plist_path = self.plist_path(&request.schedule_id);
         let path_str = plist_path.to_string_lossy().to_string();
 
@@ -308,14 +362,39 @@ impl HostScheduler for LaunchdHostScheduler {
             )));
         }
 
+        // Reload: bootout if loaded, then bootstrap.
+        self.bootout_if_loaded(&request.schedule_id).await;
+        self.bootstrap(&request.schedule_id).await?;
+
+        // Apply enabled/disabled state via launchctl.
+        if !request.enabled {
+            let target = self.service_target(&request.schedule_id);
+            let _ = self.runner.run("launchctl", &["disable", &target]).await;
+        }
+
         Ok(())
     }
 
     async fn remove(&self, schedule_id: &str) -> Result<(), HostSchedulerError> {
+        // Unload the agent first.
+        self.bootout_if_loaded(schedule_id).await;
+
+        // Then delete the plist file.
         let plist_path = self.plist_path(schedule_id);
         let path_str = plist_path.to_string_lossy().to_string();
 
-        let _ = self.runner.run("rm", &["-f", &path_str]).await;
+        let output = self
+            .runner
+            .run("rm", &["-f", &path_str])
+            .await
+            .map_err(|e| HostSchedulerError::Io(e.to_string()))?;
+
+        if output.exit_code != 0 {
+            return Err(HostSchedulerError::Io(format!(
+                "failed to remove plist: {}",
+                output.stderr
+            )));
+        }
 
         Ok(())
     }

--- a/src/scheduled_task/platform/launchd.rs
+++ b/src/scheduled_task/platform/launchd.rs
@@ -174,7 +174,10 @@ pub fn render_plist(
     xml.push_str("<plist version=\"1.0\">\n");
     xml.push_str("<dict>\n");
 
-    xml.push_str(&format!("    <key>Label</key>\n    <string>{}</string>\n", label));
+    xml.push_str(&format!(
+        "    <key>Label</key>\n    <string>{}</string>\n",
+        label
+    ));
 
     if disabled {
         xml.push_str("    <key>Disabled</key>\n    <true/>\n");
@@ -208,16 +211,28 @@ pub fn render_plist(
 
 fn push_interval_keys(xml: &mut String, interval: &CalendarInterval, indent: &str) {
     if let Some(m) = interval.minute {
-        xml.push_str(&format!("{}<key>Minute</key>\n{}<integer>{}</integer>\n", indent, indent, m));
+        xml.push_str(&format!(
+            "{}<key>Minute</key>\n{}<integer>{}</integer>\n",
+            indent, indent, m
+        ));
     }
     if let Some(h) = interval.hour {
-        xml.push_str(&format!("{}<key>Hour</key>\n{}<integer>{}</integer>\n", indent, indent, h));
+        xml.push_str(&format!(
+            "{}<key>Hour</key>\n{}<integer>{}</integer>\n",
+            indent, indent, h
+        ));
     }
     if let Some(d) = interval.day_of_month {
-        xml.push_str(&format!("{}<key>Day</key>\n{}<integer>{}</integer>\n", indent, indent, d));
+        xml.push_str(&format!(
+            "{}<key>Day</key>\n{}<integer>{}</integer>\n",
+            indent, indent, d
+        ));
     }
     if let Some(mo) = interval.month {
-        xml.push_str(&format!("{}<key>Month</key>\n{}<integer>{}</integer>\n", indent, indent, mo));
+        xml.push_str(&format!(
+            "{}<key>Month</key>\n{}<integer>{}</integer>\n",
+            indent, indent, mo
+        ));
     }
     if let Some(dow) = interval.day_of_week {
         xml.push_str(&format!(
@@ -265,8 +280,9 @@ impl HostScheduler for LaunchdHostScheduler {
             }
         })?;
 
-        // Split command into program arguments.
-        let program_args: Vec<String> = request.command.split_whitespace().map(String::from).collect();
+        // Build ProgramArguments from the structured request.
+        let mut program_args = vec![request.program.display().to_string()];
+        program_args.extend(request.args.iter().cloned());
 
         let plist_content = render_plist(
             &request.schedule_id,
@@ -299,10 +315,7 @@ impl HostScheduler for LaunchdHostScheduler {
         let plist_path = self.plist_path(schedule_id);
         let path_str = plist_path.to_string_lossy().to_string();
 
-        let _ = self
-            .runner
-            .run("rm", &["-f", &path_str])
-            .await;
+        let _ = self.runner.run("rm", &["-f", &path_str]).await;
 
         Ok(())
     }
@@ -339,9 +352,7 @@ impl HostScheduler for LaunchdHostScheduler {
         schedule_id: &str,
     ) -> Result<Option<ObservedHostEntry>, HostSchedulerError> {
         let list = self.list_owned().await?;
-        Ok(list
-            .into_iter()
-            .find(|e| e.schedule_id == schedule_id))
+        Ok(list.into_iter().find(|e| e.schedule_id == schedule_id))
     }
 }
 

--- a/src/scheduled_task/platform/mod.rs
+++ b/src/scheduled_task/platform/mod.rs
@@ -4,7 +4,7 @@
 //! compilation and content rendering logic is platform-independent so it
 //! can be tested on any host.
 
-pub mod crontab;
 pub mod cron_adapter;
+pub mod crontab;
 pub mod launchd;
 pub mod task_scheduler;

--- a/src/scheduled_task/platform/mod.rs
+++ b/src/scheduled_task/platform/mod.rs
@@ -1,0 +1,10 @@
+//! Platform-specific host scheduler adapters.
+//!
+//! Each adapter is gated by its target platform. The cron expression
+//! compilation and content rendering logic is platform-independent so it
+//! can be tested on any host.
+
+pub mod crontab;
+pub mod cron_adapter;
+pub mod launchd;
+pub mod task_scheduler;

--- a/src/scheduled_task/platform/task_scheduler.rs
+++ b/src/scheduled_task/platform/task_scheduler.rs
@@ -8,7 +8,6 @@
 //! tested here. The actual `schtasks.exe` execution requires Windows.
 
 use async_trait::async_trait;
-use std::path::PathBuf;
 
 use crate::scheduled_task::cron::CronExpression;
 use crate::scheduled_task::host::{
@@ -49,8 +48,7 @@ pub fn expand_cron(cron: &CronExpression) -> Result<TaskTrigger, String> {
     // fields are omitted from the XML rendering entirely.
     let dom_in_xml = if doms.len() < 31 { doms.len() } else { 0 };
     let month_in_xml = if months.len() < 12 { months.len() } else { 0 };
-    let total_xml_values =
-        minutes.len() + hours.len() + dom_in_xml + month_in_xml + dows.len();
+    let total_xml_values = minutes.len() + hours.len() + dom_in_xml + month_in_xml + dows.len();
     if total_xml_values > MAX_TRIGGERS {
         return Err(format!(
             "cron expression has too many field values ({}, max {}); \
@@ -73,8 +71,13 @@ pub fn expand_cron(cron: &CronExpression) -> Result<TaskTrigger, String> {
 // ============================================================================
 
 /// Render a complete Task Scheduler XML definition.
+///
+/// Each unique `(minute, hour)` pair becomes its own `<CalendarTrigger>` with
+/// a `<StartBoundary>` encoding the time of day. Day-of-week restrictions are
+/// emitted as `<ScheduleByWeek>`, day-of-month restrictions as
+/// `<ScheduleByMonth>`. When cron restricts **both** DOM and DOW (OR
+/// semantics), two independent triggers are emitted.
 pub fn render_task_xml(
-    schedule_id: &str,
     trigger: &TaskTrigger,
     executable: &str,
     arguments: &str,
@@ -82,44 +85,53 @@ pub fn render_task_xml(
 ) -> String {
     let mut xml = String::new();
     xml.push_str("<?xml version=\"1.0\" encoding=\"UTF-16\"?>\n");
-    xml.push_str("<Task version=\"1.2\" xmlns=\"http://schemas.microsoft.com/windows/2004/02/mit/task\">\n");
+    xml.push_str(
+        "<Task version=\"1.2\" xmlns=\"http://schemas.microsoft.com/windows/2004/02/mit/task\">\n",
+    );
 
     // Triggers
     xml.push_str("  <Triggers>\n");
-    xml.push_str("    <CalendarTrigger>\n");
 
-    // Schedule by day of month
-    xml.push_str("      <ScheduleByMonth>\n");
+    let dom_restricted = !trigger.days_of_month.is_empty() && trigger.days_of_month.len() < 31;
+    let dow_restricted = !trigger.days_of_week.is_empty() && trigger.days_of_week.len() < 7;
+    let months_restricted = !trigger.months.is_empty() && trigger.months.len() < 12;
 
-    // Days of month
-    if trigger.days_of_month.len() < 31 {
-        xml.push_str("        <DaysOfMonth>\n");
-        for &d in &trigger.days_of_month {
-            xml.push_str(&format!("          <Day>{}</Day>\n", d));
+    for &hour in &trigger.hours {
+        for &minute in &trigger.minutes {
+            let boundary = format!("2024-01-01T{:02}:{:02}:00", hour, minute);
+
+            if dom_restricted {
+                let body = render_schedule_by_month(
+                    &trigger.days_of_month,
+                    months_restricted,
+                    &trigger.months,
+                );
+                xml.push_str(&render_calendar_trigger(&boundary, &body));
+            }
+            if dow_restricted {
+                let body = render_schedule_by_week(
+                    &trigger.days_of_week,
+                    months_restricted,
+                    &trigger.months,
+                );
+                xml.push_str(&render_calendar_trigger(&boundary, &body));
+            }
+            // No day-of-week or day-of-month restriction: a plain daily
+            // trigger that fires at the given StartBoundary.
+            if !dom_restricted && !dow_restricted {
+                xml.push_str(&render_calendar_trigger(&boundary, ""));
+            }
         }
-        xml.push_str("        </DaysOfMonth>\n");
     }
 
-    // Months
-    if trigger.months.len() < 12 {
-        xml.push_str("        <Months>\n");
-        for &m in &trigger.months {
-            let month_name = month_name(m);
-            xml.push_str(&format!("          <{}/>\n", month_name));
-        }
-        xml.push_str("        </Months>\n");
-    }
-
-    xml.push_str("      </ScheduleByMonth>\n");
-    xml.push_str("    </CalendarTrigger>\n");
     xml.push_str("  </Triggers>\n");
 
     // Settings
     xml.push_str("  <Settings>\n");
-    if !enabled {
-        xml.push_str("    <Enabled>false</Enabled>\n");
-    } else {
+    if enabled {
         xml.push_str("    <Enabled>true</Enabled>\n");
+    } else {
+        xml.push_str("    <Enabled>false</Enabled>\n");
     }
     xml.push_str("    <AllowStartIfOnBatteries>true</AllowStartIfOnBatteries>\n");
     xml.push_str("    <DontStopIfGoingOnBatteries>true</DontStopIfGoingOnBatteries>\n");
@@ -129,13 +141,80 @@ pub fn render_task_xml(
     // Actions
     xml.push_str("  <Actions Context=\"Author\">\n");
     xml.push_str("    <Exec>\n");
-    xml.push_str(&format!("      <Command>{}</Command>\n", escape_xml(executable)));
-    xml.push_str(&format!("      <Arguments>{}</Arguments>\n", escape_xml(arguments)));
+    xml.push_str(&format!(
+        "      <Command>{}</Command>\n",
+        escape_xml(executable)
+    ));
+    xml.push_str(&format!(
+        "      <Arguments>{}</Arguments>\n",
+        escape_xml(arguments)
+    ));
     xml.push_str("    </Exec>\n");
     xml.push_str("  </Actions>\n");
 
     xml.push_str("</Task>\n");
     xml
+}
+
+/// Render a single `<CalendarTrigger>` with the given start boundary and
+/// optional schedule body.
+fn render_calendar_trigger(boundary: &str, schedule_body: &str) -> String {
+    let mut s = String::new();
+    s.push_str("    <CalendarTrigger>\n");
+    s.push_str(&format!(
+        "      <StartBoundary>{}</StartBoundary>\n",
+        boundary
+    ));
+    if !schedule_body.is_empty() {
+        s.push_str(schedule_body);
+    }
+    s.push_str("    </CalendarTrigger>\n");
+    s
+}
+
+/// Render a `<ScheduleByMonth>` body containing days of month and optional
+/// months.
+fn render_schedule_by_month(doms: &[u32], include_months: bool, months: &[u32]) -> String {
+    let mut s = String::new();
+    s.push_str("      <ScheduleByMonth>\n");
+    s.push_str("        <DaysOfMonth>\n");
+    for &d in doms {
+        s.push_str(&format!("          <Day>{}</Day>\n", d));
+    }
+    s.push_str("        </DaysOfMonth>\n");
+    if include_months {
+        s.push_str(&render_months(months));
+    }
+    s.push_str("      </ScheduleByMonth>\n");
+    s
+}
+
+/// Render a `<ScheduleByWeek>` body containing days of week and optional
+/// months. Cron day-of-week values use 0=Sunday through 6=Saturday.
+fn render_schedule_by_week(dows: &[u32], include_months: bool, months: &[u32]) -> String {
+    let mut s = String::new();
+    s.push_str("      <ScheduleByWeek>\n");
+    s.push_str("        <DaysOfWeek>\n");
+    for &d in dows {
+        s.push_str(&format!("          <{}/>\n", weekday_name(d)));
+    }
+    s.push_str("        </DaysOfWeek>\n");
+    if include_months {
+        s.push_str(&render_months(months));
+    }
+    s.push_str("      </ScheduleByWeek>\n");
+    s
+}
+
+/// Render a `<Months>` block from month numbers (1-12).
+fn render_months(months: &[u32]) -> String {
+    let mut s = String::new();
+    s.push_str("        <Months>\n");
+    for &m in months {
+        s.push_str(&format!("          <{}/>\n", month_name(m)));
+    }
+    s.push_str("        </Months>\n");
+    s
 }
 
 fn month_name(m: u32) -> &'static str {
@@ -153,6 +232,21 @@ fn month_name(m: u32) -> &'static str {
         11 => "November",
         12 => "December",
         _ => "January",
+    }
+}
+
+/// Map a cron day-of-week value to the Task Scheduler weekday element name.
+/// Cron uses 0=Sunday through 6=Saturday.
+fn weekday_name(dow: u32) -> &'static str {
+    match dow {
+        0 => "Sunday",
+        1 => "Monday",
+        2 => "Tuesday",
+        3 => "Wednesday",
+        4 => "Thursday",
+        5 => "Friday",
+        6 => "Saturday",
+        _ => "Sunday",
     }
 }
 
@@ -180,13 +274,6 @@ impl TaskSchedulerHostScheduler {
     pub fn new(runner: Box<dyn CommandRunner>) -> Self {
         Self { runner }
     }
-
-    fn split_command(command: &str) -> (&str, String) {
-        let mut parts = command.splitn(2, ' ');
-        let exe = parts.next().unwrap_or(command);
-        let args = parts.next().unwrap_or("");
-        (exe, args.to_string())
-    }
 }
 
 #[async_trait]
@@ -203,12 +290,11 @@ impl HostScheduler for TaskSchedulerHostScheduler {
             }
         })?;
 
-        let (exe, args) = Self::split_command(&request.command);
+        let arguments = request.args.join(" ");
         let xml = render_task_xml(
-            &request.schedule_id,
             &trigger,
-            exe,
-            &args,
+            &request.program.display().to_string(),
+            &arguments,
             request.enabled,
         );
 
@@ -265,7 +351,10 @@ impl HostScheduler for TaskSchedulerHostScheduler {
     async fn list_owned(&self) -> Result<Vec<ObservedHostEntry>, HostSchedulerError> {
         let output = self
             .runner
-            .run("schtasks.exe", &["/Query", "/TN", TASK_FOLDER, "/FO", "CSV"])
+            .run(
+                "schtasks.exe",
+                &["/Query", "/TN", TASK_FOLDER, "/FO", "CSV"],
+            )
             .await
             .map_err(|e| HostSchedulerError::Io(e.to_string()))?;
 
@@ -346,15 +435,15 @@ mod tests {
 
     #[test]
     fn render_xml_basic() {
+        // Daily at 9:00 with no weekday or day-of-month restriction.
         let trigger = TaskTrigger {
             minutes: vec![0],
             hours: vec![9],
-            days_of_month: vec![1],
-            months: vec![1],
+            days_of_month: vec![],
+            months: vec![],
             days_of_week: vec![],
         };
         let xml = render_task_xml(
-            "s1",
             &trigger,
             r"C:\agent-iron.exe",
             "run task-1 --config C:\\config.db",
@@ -362,10 +451,88 @@ mod tests {
         );
         assert!(xml.contains("<Task"));
         assert!(xml.contains("<CalendarTrigger>"));
-        assert!(xml.contains("<Day>1</Day>"));
-        assert!(xml.contains("<January/>"));
+        assert!(xml.contains("<StartBoundary>2024-01-01T09:00:00</StartBoundary>"));
+        // No day restriction: neither schedule element should be emitted.
+        assert!(!xml.contains("<ScheduleByMonth>"));
+        assert!(!xml.contains("<ScheduleByWeek>"));
         assert!(xml.contains("<Enabled>true</Enabled>"));
         assert!(xml.contains(r"C:\agent-iron.exe"));
+        assert!(xml.contains("run task-1"));
+    }
+
+    #[test]
+    fn render_xml_weekdays() {
+        // `0 9 * * 1-5` — weekdays only at 9:00 AM.
+        let trigger = TaskTrigger {
+            minutes: vec![0],
+            hours: vec![9],
+            days_of_month: vec![],
+            months: vec![],
+            days_of_week: vec![1, 2, 3, 4, 5],
+        };
+        let xml = render_task_xml(&trigger, "agent-iron.exe", "run t1", true);
+        assert!(xml.contains("<StartBoundary>2024-01-01T09:00:00</StartBoundary>"));
+        assert!(xml.contains("<ScheduleByWeek>"));
+        assert!(xml.contains("<DaysOfWeek>"));
+        assert!(xml.contains("<Monday/>"));
+        assert!(xml.contains("<Friday/>"));
+        assert!(!xml.contains("<Sunday/>"));
+        assert!(!xml.contains("<ScheduleByMonth>"));
+    }
+
+    #[test]
+    fn render_xml_dom_and_months() {
+        // Day of month and month restriction, no weekday restriction.
+        let trigger = TaskTrigger {
+            minutes: vec![30],
+            hours: vec![5],
+            days_of_month: vec![1, 15],
+            months: vec![1, 6],
+            days_of_week: vec![],
+        };
+        let xml = render_task_xml(&trigger, "agent-iron.exe", "run t1", true);
+        assert!(xml.contains("<StartBoundary>2024-01-01T05:30:00</StartBoundary>"));
+        assert!(xml.contains("<ScheduleByMonth>"));
+        assert!(xml.contains("<Day>1</Day>"));
+        assert!(xml.contains("<Day>15</Day>"));
+        assert!(xml.contains("<January/>"));
+        assert!(xml.contains("<June/>"));
+        assert!(!xml.contains("<ScheduleByWeek>"));
+    }
+
+    #[test]
+    fn render_xml_dom_and_dow_emits_two_triggers() {
+        // Both DOM and DOW restricted — cron OR semantics produce two triggers.
+        let trigger = TaskTrigger {
+            minutes: vec![0],
+            hours: vec![12],
+            days_of_month: vec![1],
+            months: vec![],
+            days_of_week: vec![1],
+        };
+        let xml = render_task_xml(&trigger, "agent-iron.exe", "run t1", true);
+        // Exactly two CalendarTrigger blocks for the single time pair.
+        let trigger_count = xml.matches("<CalendarTrigger>").count();
+        assert_eq!(trigger_count, 2);
+        assert!(xml.contains("<ScheduleByMonth>"));
+        assert!(xml.contains("<ScheduleByWeek>"));
+        assert!(xml.contains("<Monday/>"));
+        assert!(xml.contains("<Day>1</Day>"));
+    }
+
+    #[test]
+    fn render_xml_multiple_times() {
+        // Two times expand to two triggers.
+        let trigger = TaskTrigger {
+            minutes: vec![0, 30],
+            hours: vec![9],
+            days_of_month: vec![],
+            months: vec![],
+            days_of_week: vec![],
+        };
+        let xml = render_task_xml(&trigger, "agent-iron.exe", "run t1", true);
+        assert!(xml.contains("<StartBoundary>2024-01-01T09:00:00</StartBoundary>"));
+        assert!(xml.contains("<StartBoundary>2024-01-01T09:30:00</StartBoundary>"));
     }
 
     #[test]
@@ -377,7 +544,7 @@ mod tests {
             months: vec![],
             days_of_week: vec![],
         };
-        let xml = render_task_xml("s1", &trigger, "agent-iron.exe", "run t1", false);
+        let xml = render_task_xml(&trigger, "agent-iron.exe", "run t1", false);
         assert!(xml.contains("<Enabled>false</Enabled>"));
     }
 
@@ -390,7 +557,7 @@ mod tests {
             months: vec![],
             days_of_week: vec![],
         };
-        let xml = render_task_xml("s1", &trigger, "normal", "arg <test> & stuff", true);
+        let xml = render_task_xml(&trigger, "normal", "arg <test> & stuff", true);
         assert!(xml.contains("&lt;test&gt;"));
         assert!(xml.contains("&amp; stuff"));
     }

--- a/src/scheduled_task/platform/task_scheduler.rs
+++ b/src/scheduled_task/platform/task_scheduler.rs
@@ -358,19 +358,15 @@ impl HostScheduler for TaskSchedulerHostScheduler {
             request.schedule_id
         );
 
-        // Write XML to temp file.
-        let write_output = self
-            .runner
-            .run_with_stdin("cmd", &["/c", "tee", &temp_file], &xml)
+        // Write XML as UTF-16LE with BOM (required by schtasks.exe).
+        let mut xml_bytes = Vec::with_capacity(xml.len() * 2 + 2);
+        xml_bytes.extend_from_slice(&[0xFF, 0xFE]); // UTF-16LE BOM
+        for unit in xml.encode_utf16() {
+            xml_bytes.extend_from_slice(&unit.to_le_bytes());
+        }
+        tokio::fs::write(&temp_file, &xml_bytes)
             .await
             .map_err(|e| HostSchedulerError::Io(e.to_string()))?;
-
-        if write_output.exit_code != 0 {
-            return Err(HostSchedulerError::Io(format!(
-                "failed to write XML: {}",
-                write_output.stderr
-            )));
-        }
 
         // Register task from XML.
         let output = self

--- a/src/scheduled_task/platform/task_scheduler.rs
+++ b/src/scheduled_task/platform/task_scheduler.rs
@@ -261,6 +261,59 @@ fn task_path(schedule_id: &str) -> String {
     format!("{}{}", TASK_FOLDER, schedule_id)
 }
 
+/// Extract the text between the first occurrence of `open` and its matching
+/// `close` tag in `text`.
+fn extract_xml_block<'a>(text: &'a str, open: &str, close: &str) -> Option<&'a str> {
+    let start = text.find(open)? + open.len();
+    let end = text[start..].find(close)? + start;
+    Some(&text[start..end])
+}
+
+/// Reverse the entity escaping applied by [`escape_xml`].
+fn unescape_xml(s: &str) -> String {
+    s.replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&amp;", "&")
+}
+
+/// Parse a Task Scheduler XML document into `(enabled, corrupt, observed_command)`.
+///
+/// Returns `None` if the document does not resemble a task definition
+/// (missing `<Task` or `<Actions>`), indicating corruption. When `Some` is
+/// returned, `corrupt` is always `false`.
+fn parse_task_xml(xml_text: &str) -> Option<(bool, bool, Option<String>)> {
+    if !xml_text.contains("<Task") || !xml_text.contains("<Actions") {
+        return None;
+    }
+
+    let enabled = extract_xml_block(xml_text, "<Settings>", "</Settings>")
+        .map(|block| block.contains("<Enabled>true</Enabled>"))
+        .unwrap_or(true);
+
+    let observed_command = extract_xml_block(xml_text, "<Exec>", "</Exec>").and_then(|exec| {
+        let command = extract_xml_block(exec, "<Command>", "</Command>").map(unescape_xml);
+        let arguments = extract_xml_block(exec, "<Arguments>", "</Arguments>").map(unescape_xml);
+        match (command, arguments) {
+            (Some(c), Some(a)) if !a.is_empty() => Some(format!("{c} {a}")),
+            (Some(c), _) => Some(c),
+            (None, Some(a)) => Some(a),
+            (None, None) => None,
+        }
+    });
+
+    Some((enabled, false, observed_command))
+}
+
+/// Extract a schedule id from a CSV task-list line containing the AgentIron
+/// task folder.
+fn schedule_id_from_csv_line(line: &str) -> Option<&str> {
+    let idx = line.find(TASK_FOLDER)?;
+    let after = &line[idx + TASK_FOLDER.len()..];
+    let end = after.find([',', '"']).unwrap_or(after.len());
+    Some(&after[..end])
+}
+
 // ============================================================================
 // Adapter
 // ============================================================================
@@ -349,28 +402,27 @@ impl HostScheduler for TaskSchedulerHostScheduler {
     }
 
     async fn list_owned(&self) -> Result<Vec<ObservedHostEntry>, HostSchedulerError> {
-        let output = self
+        let output = match self
             .runner
-            .run(
-                "schtasks.exe",
-                &["/Query", "/TN", TASK_FOLDER, "/FO", "CSV"],
-            )
+            .run("schtasks.exe", &["/Query", "/FO", "CSV", "/NH"])
             .await
-            .map_err(|e| HostSchedulerError::Io(e.to_string()))?;
+        {
+            Ok(o) => o,
+            Err(_) => return Ok(Vec::new()),
+        };
+
+        if output.exit_code != 0 {
+            return Ok(Vec::new());
+        }
 
         let mut entries = Vec::new();
         for line in output.stdout.lines() {
-            if line.contains(TASK_FOLDER) {
-                if let Some(id) = line.strip_prefix(TASK_FOLDER) {
-                    let id = id.split(',').next().unwrap_or(id).trim_matches('"');
-                    entries.push(ObservedHostEntry {
-                        schedule_id: id.to_string(),
-                        enabled: true,
-                        corrupt: false,
-                        raw_schedule: None,
-                        observed_command: None,
-                        metadata: None,
-                    });
+            if !line.contains(TASK_FOLDER) {
+                continue;
+            }
+            if let Some(id) = schedule_id_from_csv_line(line) {
+                if let Some(entry) = self.inspect(id).await? {
+                    entries.push(entry);
                 }
             }
         }
@@ -384,7 +436,7 @@ impl HostScheduler for TaskSchedulerHostScheduler {
         let path = task_path(schedule_id);
         let output = self
             .runner
-            .run("schtasks.exe", &["/Query", "/TN", &path, "/FO", "CSV"])
+            .run("schtasks.exe", &["/Query", "/TN", &path, "/XML"])
             .await
             .map_err(|e| HostSchedulerError::Io(e.to_string()))?;
 
@@ -392,12 +444,15 @@ impl HostScheduler for TaskSchedulerHostScheduler {
             return Ok(None);
         }
 
+        let (enabled, corrupt, observed_command) =
+            parse_task_xml(&output.stdout).unwrap_or((true, true, None));
+
         Ok(Some(ObservedHostEntry {
             schedule_id: schedule_id.to_string(),
-            enabled: output.stdout.contains("Ready"),
-            corrupt: false,
+            enabled,
+            corrupt,
             raw_schedule: None,
-            observed_command: None,
+            observed_command,
             metadata: None,
         }))
     }

--- a/src/scheduled_task/platform/task_scheduler.rs
+++ b/src/scheduled_task/platform/task_scheduler.rs
@@ -1,0 +1,402 @@
+//! Windows Task Scheduler host scheduler adapter.
+//!
+//! Manages tasks under `\AgentIron\Tasks\<id>` using generated Task Scheduler
+//! XML. Uses `schtasks.exe` for lifecycle operations. Cron expressions are
+//! compiled into Task Scheduler triggers.
+//!
+//! The XML rendering and cron expansion logic is platform-independent and
+//! tested here. The actual `schtasks.exe` execution requires Windows.
+
+use async_trait::async_trait;
+use std::path::PathBuf;
+
+use crate::scheduled_task::cron::CronExpression;
+use crate::scheduled_task::host::{
+    CommandRunner, HostInstallRequest, HostScheduler, HostSchedulerError, ObservedHostEntry,
+};
+
+/// Task folder path for AgentIron tasks.
+pub const TASK_FOLDER: &str = r"\AgentIron\Tasks\";
+
+/// Maximum number of triggers before rejecting.
+pub const MAX_TRIGGERS: usize = 64;
+
+// ============================================================================
+// Cron to Task Scheduler trigger expansion
+// ============================================================================
+
+/// A Task Scheduler calendar trigger specification.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TaskTrigger {
+    pub minutes: Vec<u32>,
+    pub hours: Vec<u32>,
+    pub days_of_month: Vec<u32>,
+    pub months: Vec<u32>,
+    pub days_of_week: Vec<u32>,
+}
+
+/// Expand a cron expression into Task Scheduler triggers.
+///
+/// Returns `Err` if the expansion would exceed `MAX_TRIGGERS`.
+pub fn expand_cron(cron: &CronExpression) -> Result<TaskTrigger, String> {
+    let minutes = cron.minutes().to_vec();
+    let hours = cron.hours().to_vec();
+    let doms = cron.days_of_month().to_vec();
+    let months = cron.months().to_vec();
+    let dows = cron.days_of_week().to_vec();
+
+    // Only count non-wildcard field values toward complexity. Wildcard
+    // fields are omitted from the XML rendering entirely.
+    let dom_in_xml = if doms.len() < 31 { doms.len() } else { 0 };
+    let month_in_xml = if months.len() < 12 { months.len() } else { 0 };
+    let total_xml_values =
+        minutes.len() + hours.len() + dom_in_xml + month_in_xml + dows.len();
+    if total_xml_values > MAX_TRIGGERS {
+        return Err(format!(
+            "cron expression has too many field values ({}, max {}); \
+             use a simpler expression",
+            total_xml_values, MAX_TRIGGERS
+        ));
+    }
+
+    Ok(TaskTrigger {
+        minutes,
+        hours,
+        days_of_month: doms,
+        months,
+        days_of_week: dows,
+    })
+}
+
+// ============================================================================
+// XML rendering
+// ============================================================================
+
+/// Render a complete Task Scheduler XML definition.
+pub fn render_task_xml(
+    schedule_id: &str,
+    trigger: &TaskTrigger,
+    executable: &str,
+    arguments: &str,
+    enabled: bool,
+) -> String {
+    let mut xml = String::new();
+    xml.push_str("<?xml version=\"1.0\" encoding=\"UTF-16\"?>\n");
+    xml.push_str("<Task version=\"1.2\" xmlns=\"http://schemas.microsoft.com/windows/2004/02/mit/task\">\n");
+
+    // Triggers
+    xml.push_str("  <Triggers>\n");
+    xml.push_str("    <CalendarTrigger>\n");
+
+    // Schedule by day of month
+    xml.push_str("      <ScheduleByMonth>\n");
+
+    // Days of month
+    if trigger.days_of_month.len() < 31 {
+        xml.push_str("        <DaysOfMonth>\n");
+        for &d in &trigger.days_of_month {
+            xml.push_str(&format!("          <Day>{}</Day>\n", d));
+        }
+        xml.push_str("        </DaysOfMonth>\n");
+    }
+
+    // Months
+    if trigger.months.len() < 12 {
+        xml.push_str("        <Months>\n");
+        for &m in &trigger.months {
+            let month_name = month_name(m);
+            xml.push_str(&format!("          <{}/>\n", month_name));
+        }
+        xml.push_str("        </Months>\n");
+    }
+
+    xml.push_str("      </ScheduleByMonth>\n");
+    xml.push_str("    </CalendarTrigger>\n");
+    xml.push_str("  </Triggers>\n");
+
+    // Settings
+    xml.push_str("  <Settings>\n");
+    if !enabled {
+        xml.push_str("    <Enabled>false</Enabled>\n");
+    } else {
+        xml.push_str("    <Enabled>true</Enabled>\n");
+    }
+    xml.push_str("    <AllowStartIfOnBatteries>true</AllowStartIfOnBatteries>\n");
+    xml.push_str("    <DontStopIfGoingOnBatteries>true</DontStopIfGoingOnBatteries>\n");
+    xml.push_str("    <ExecutionTimeLimit>PT24H</ExecutionTimeLimit>\n");
+    xml.push_str("  </Settings>\n");
+
+    // Actions
+    xml.push_str("  <Actions Context=\"Author\">\n");
+    xml.push_str("    <Exec>\n");
+    xml.push_str(&format!("      <Command>{}</Command>\n", escape_xml(executable)));
+    xml.push_str(&format!("      <Arguments>{}</Arguments>\n", escape_xml(arguments)));
+    xml.push_str("    </Exec>\n");
+    xml.push_str("  </Actions>\n");
+
+    xml.push_str("</Task>\n");
+    xml
+}
+
+fn month_name(m: u32) -> &'static str {
+    match m {
+        1 => "January",
+        2 => "February",
+        3 => "March",
+        4 => "April",
+        5 => "May",
+        6 => "June",
+        7 => "July",
+        8 => "August",
+        9 => "September",
+        10 => "October",
+        11 => "November",
+        12 => "December",
+        _ => "January",
+    }
+}
+
+fn escape_xml(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}
+
+fn task_path(schedule_id: &str) -> String {
+    format!("{}{}", TASK_FOLDER, schedule_id)
+}
+
+// ============================================================================
+// Adapter
+// ============================================================================
+
+/// Windows Task Scheduler host scheduler.
+pub struct TaskSchedulerHostScheduler {
+    runner: Box<dyn CommandRunner>,
+}
+
+impl TaskSchedulerHostScheduler {
+    pub fn new(runner: Box<dyn CommandRunner>) -> Self {
+        Self { runner }
+    }
+
+    fn split_command(command: &str) -> (&str, String) {
+        let mut parts = command.splitn(2, ' ');
+        let exe = parts.next().unwrap_or(command);
+        let args = parts.next().unwrap_or("");
+        (exe, args.to_string())
+    }
+}
+
+#[async_trait]
+impl HostScheduler for TaskSchedulerHostScheduler {
+    fn platform(&self) -> &'static str {
+        "task-scheduler"
+    }
+
+    async fn install(&self, request: &HostInstallRequest) -> Result<(), HostSchedulerError> {
+        let trigger = expand_cron(&request.cron).map_err(|reason| {
+            HostSchedulerError::UnsupportedSchedule {
+                platform: "task-scheduler",
+                reason,
+            }
+        })?;
+
+        let (exe, args) = Self::split_command(&request.command);
+        let xml = render_task_xml(
+            &request.schedule_id,
+            &trigger,
+            exe,
+            &args,
+            request.enabled,
+        );
+
+        let path = task_path(&request.schedule_id);
+        let temp_file = format!(
+            "{}\\agentiron_task_{}.xml",
+            std::env::temp_dir().display(),
+            request.schedule_id
+        );
+
+        // Write XML to temp file.
+        let write_output = self
+            .runner
+            .run_with_stdin("cmd", &["/c", "tee", &temp_file], &xml)
+            .await
+            .map_err(|e| HostSchedulerError::Io(e.to_string()))?;
+
+        if write_output.exit_code != 0 {
+            return Err(HostSchedulerError::Io(format!(
+                "failed to write XML: {}",
+                write_output.stderr
+            )));
+        }
+
+        // Register task from XML.
+        let output = self
+            .runner
+            .run(
+                "schtasks.exe",
+                &["/Create", "/TN", &path, "/XML", &temp_file, "/F"],
+            )
+            .await
+            .map_err(|e| HostSchedulerError::Io(e.to_string()))?;
+
+        if output.exit_code != 0 {
+            return Err(HostSchedulerError::Io(format!(
+                "schtasks /Create failed: {}",
+                output.stderr
+            )));
+        }
+
+        Ok(())
+    }
+
+    async fn remove(&self, schedule_id: &str) -> Result<(), HostSchedulerError> {
+        let path = task_path(schedule_id);
+        let _ = self
+            .runner
+            .run("schtasks.exe", &["/Delete", "/TN", &path, "/F"])
+            .await;
+        Ok(())
+    }
+
+    async fn list_owned(&self) -> Result<Vec<ObservedHostEntry>, HostSchedulerError> {
+        let output = self
+            .runner
+            .run("schtasks.exe", &["/Query", "/TN", TASK_FOLDER, "/FO", "CSV"])
+            .await
+            .map_err(|e| HostSchedulerError::Io(e.to_string()))?;
+
+        let mut entries = Vec::new();
+        for line in output.stdout.lines() {
+            if line.contains(TASK_FOLDER) {
+                if let Some(id) = line.strip_prefix(TASK_FOLDER) {
+                    let id = id.split(',').next().unwrap_or(id).trim_matches('"');
+                    entries.push(ObservedHostEntry {
+                        schedule_id: id.to_string(),
+                        enabled: true,
+                        corrupt: false,
+                        raw_schedule: None,
+                        observed_command: None,
+                        metadata: None,
+                    });
+                }
+            }
+        }
+        Ok(entries)
+    }
+
+    async fn inspect(
+        &self,
+        schedule_id: &str,
+    ) -> Result<Option<ObservedHostEntry>, HostSchedulerError> {
+        let path = task_path(schedule_id);
+        let output = self
+            .runner
+            .run("schtasks.exe", &["/Query", "/TN", &path, "/FO", "CSV"])
+            .await
+            .map_err(|e| HostSchedulerError::Io(e.to_string()))?;
+
+        if output.exit_code != 0 {
+            return Ok(None);
+        }
+
+        Ok(Some(ObservedHostEntry {
+            schedule_id: schedule_id.to_string(),
+            enabled: output.stdout.contains("Ready"),
+            corrupt: false,
+            raw_schedule: None,
+            observed_command: None,
+            metadata: None,
+        }))
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn expand_daily() {
+        let cron = CronExpression::parse("0 9 * * *").unwrap();
+        let trigger = expand_cron(&cron).unwrap();
+        assert_eq!(trigger.minutes, vec![0]);
+        assert_eq!(trigger.hours, vec![9]);
+    }
+
+    #[test]
+    fn expand_every_15_min() {
+        let cron = CronExpression::parse("*/15 * * * *").unwrap();
+        let trigger = expand_cron(&cron).unwrap();
+        assert_eq!(trigger.minutes, vec![0, 15, 30, 45]);
+    }
+
+    #[test]
+    fn expand_rejects_excessive() {
+        let cron = CronExpression::parse("* * * * *").unwrap();
+        let result = expand_cron(&cron);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn render_xml_basic() {
+        let trigger = TaskTrigger {
+            minutes: vec![0],
+            hours: vec![9],
+            days_of_month: vec![1],
+            months: vec![1],
+            days_of_week: vec![],
+        };
+        let xml = render_task_xml(
+            "s1",
+            &trigger,
+            r"C:\agent-iron.exe",
+            "run task-1 --config C:\\config.db",
+            true,
+        );
+        assert!(xml.contains("<Task"));
+        assert!(xml.contains("<CalendarTrigger>"));
+        assert!(xml.contains("<Day>1</Day>"));
+        assert!(xml.contains("<January/>"));
+        assert!(xml.contains("<Enabled>true</Enabled>"));
+        assert!(xml.contains(r"C:\agent-iron.exe"));
+    }
+
+    #[test]
+    fn render_xml_disabled() {
+        let trigger = TaskTrigger {
+            minutes: vec![30],
+            hours: vec![5],
+            days_of_month: vec![],
+            months: vec![],
+            days_of_week: vec![],
+        };
+        let xml = render_task_xml("s1", &trigger, "agent-iron.exe", "run t1", false);
+        assert!(xml.contains("<Enabled>false</Enabled>"));
+    }
+
+    #[test]
+    fn render_xml_escapes_special_chars() {
+        let trigger = TaskTrigger {
+            minutes: vec![0],
+            hours: vec![0],
+            days_of_month: vec![],
+            months: vec![],
+            days_of_week: vec![],
+        };
+        let xml = render_task_xml("s1", &trigger, "normal", "arg <test> & stuff", true);
+        assert!(xml.contains("&lt;test&gt;"));
+        assert!(xml.contains("&amp; stuff"));
+    }
+
+    #[test]
+    fn task_path_format() {
+        assert_eq!(task_path("s1"), r"\AgentIron\Tasks\s1");
+    }
+}

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -253,9 +253,15 @@ async fn task_timeout_used_as_fallback() {
         db_path.to_str().unwrap().to_string(),
     ];
     let env = vec![];
-    let (code, _out, err) = run_cli(&args, &mut env.clone()).await;
+    let (code, _out, _err) = run_cli(&args, &mut env.clone()).await;
     assert_eq!(code, EXIT_COMPLETED);
-    assert!(err.contains("timeout:"));
+    // Verify the persisted configured fallback value is 300 seconds.
+    let task = store
+        .get_automation_task("daily-report")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(task.timeout_seconds, 300);
 }
 
 #[tokio::test]

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -253,15 +253,14 @@ async fn task_timeout_used_as_fallback() {
         db_path.to_str().unwrap().to_string(),
     ];
     let env = vec![];
-    let (code, _out, _err) = run_cli(&args, &mut env.clone()).await;
+    let (code, _out, err) = run_cli(&args, &mut env.clone()).await;
     assert_eq!(code, EXIT_COMPLETED);
-    // Verify the persisted configured fallback value is 300 seconds.
-    let task = store
-        .get_automation_task("daily-report")
-        .await
-        .unwrap()
-        .unwrap();
-    assert_eq!(task.timeout_seconds, 300);
+    // Verify the execution-boundary timeout resolved from the task-level
+    // fallback (300s), not just the seeded store value.
+    assert!(
+        err.contains("timeout: 300s"),
+        "expected execution timeout of 300s in stderr, got: {err}"
+    );
 }
 
 #[tokio::test]

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -172,9 +172,11 @@ async fn seed_prompt_and_task(store: &ConfigStore, profile_id: &str) {
     store
         .set_automation_task(&AutomationTaskInput {
             id: "daily-report".to_string(),
-            name: "Daily Report".to_string(),
+            display_name: "Daily Report".to_string(),
             stored_prompt_id: "report-prompt".to_string(),
             expected_outcome: "A summary of today's activity".to_string(),
+            project_root: std::env::temp_dir(),
+            timeout_seconds: 300,
         })
         .await
         .unwrap();
@@ -236,7 +238,7 @@ async fn usage_missing_task_id() {
 }
 
 #[tokio::test]
-async fn usage_missing_timeout() {
+async fn task_timeout_used_as_fallback() {
     let dir = tempfile::tempdir().unwrap();
     let db_path = dir.path().join("config.db");
     let store = open_store(&db_path).await;
@@ -251,8 +253,9 @@ async fn usage_missing_timeout() {
         db_path.to_str().unwrap().to_string(),
     ];
     let env = vec![];
-    let (code, _out, _err) = run_cli(&args, &mut env.clone()).await;
-    assert_eq!(code, EXIT_USAGE);
+    let (code, _out, err) = run_cli(&args, &mut env.clone()).await;
+    assert_eq!(code, EXIT_COMPLETED);
+    assert!(err.contains("timeout:"));
 }
 
 #[tokio::test]

--- a/tests/config_store_tests.rs
+++ b/tests/config_store_tests.rs
@@ -1016,7 +1016,7 @@ async fn test_migrations_v1_to_v2() {
         .fetch_one(&mut *conn)
         .await
         .unwrap();
-    assert_eq!(version, 7);
+    assert_eq!(version, 8);
 
     // Verify v2/v3 tables exist by using the new APIs
     store
@@ -1368,7 +1368,7 @@ async fn test_migrations_v2_to_v3_custom_models_columns() {
         .fetch_one(&mut *conn)
         .await
         .unwrap();
-    assert_eq!(version, 7);
+    assert_eq!(version, 8);
 
     // Verify the new columns have correct defaults for existing rows
     let retrieved = store


### PR DESCRIPTION
## Summary

- add persisted automation-task and scheduled-task models with normalized identity, project context, timeout validation, and ConfigStore migrations
- add strict five-field cron parsing plus Linux cron, macOS launchd, and Windows Task Scheduler host adapters
- add schedule inspection and reconciliation with ownership boundaries, drift diagnostics, reference validation, and inspect-before-mutate behavior
- extend headless task execution and CLI defaults for safe scheduled automation runs
- include the OpenSpec proposal, design, specifications, and completed task checklist

## Safety

- schedules reference existing automation tasks rather than arbitrary commands
- platform adapters preserve cron semantics or reject unsupported schedules
- host operations only mutate AgentIron-owned scheduler entries
- ConfigStore failures do not trigger destructive host removal

## Verification

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all-targets` (1255 passed, 14 ignored)

Closes #64

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added durable scheduled automation tasks with cron scheduling, enable/disable, inspection/reconciliation, and rich status diagnostics including orphan detection.
  * Added cross-platform scheduling support for Linux crontab, macOS launchd, and Windows Task Scheduler, with stricter cron validation.
  * Automation tasks now use normalized display names plus validated project roots and persisted execution timeouts; headless runs inherit the configured timeout, and CLI workspace/timeout resolution uses task defaults.
* **Bug Fixes**
  * Rejects duplicate automation-task names after normalization and blocks deletion when referenced by schedules.
  * Tightened CLI resolution by removing the implicit workspace fallback and making missing/invalid workspace and timeout errors surface consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->