### PR TITLE
Add atomic minimum-valid-profile deletion policy

### DIFF
--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -13,6 +13,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 concurrency:
   group: release-master
@@ -97,10 +98,16 @@ jobs:
           git tag -a "v${VERSION}" -m "v${VERSION}"
           git push origin main "v${VERSION}"
 
-      - name: Skip crates.io publish
+      - name: Authenticate with crates.io
         if: steps.release_gate.outputs.should_release == 'true'
-        run: |
-          printf '%s\n' 'Skipping crates.io publish because Cargo.toml still contains the git-only monty dependency.'
+        id: crates_io_auth
+        uses: rust-lang/crates-io-auth-action@v1
+
+      - name: Publish to crates.io
+        if: steps.release_gate.outputs.should_release == 'true'
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates_io_auth.outputs.token }}
+        run: cargo publish --all-features --locked
 
       - name: Create GitHub release
         if: steps.release_gate.outputs.should_release == 'true'

--- a/.github/workflows/release-patch.yml
+++ b/.github/workflows/release-patch.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 concurrency:
   group: release-master
@@ -90,10 +91,16 @@ jobs:
           git tag -a "v${VERSION}" -m "v${VERSION}"
           git push origin main "v${VERSION}"
 
-      - name: Skip crates.io publish
+      - name: Authenticate with crates.io
         if: steps.release_gate.outputs.should_release == 'true'
-        run: |
-          printf '%s\n' 'Skipping crates.io publish because Cargo.toml still contains the git-only monty dependency.'
+        id: crates_io_auth
+        uses: rust-lang/crates-io-auth-action@v1
+
+      - name: Publish to crates.io
+        if: steps.release_gate.outputs.should_release == 'true'
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates_io_auth.outputs.token }}
+        run: cargo publish --all-features --locked
 
       - name: Create GitHub release
         if: steps.release_gate.outputs.should_release == 'true'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,9 +138,9 @@ checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "apple-native-keyring-store"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7be2f067ccd8d4b4d4a66ddafe0f32a5dff31732f32dbff85fefc40929b1f72"
+checksum = "797f94b6a53d7d10b56dc18290e0d40a2158352f108bb4ff32350825081a9f29"
 dependencies = [
  "keyring-core",
  "log",
@@ -418,9 +418,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 dependencies = [
  "serde_core",
 ]
@@ -503,9 +503,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.12.3"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
+checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
 dependencies = [
  "memchr",
  "regex-automata",
@@ -582,7 +582,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8144c22e24bbcf26ade86cb6501a0916c46b7e4787abdb0045a467eb1645a1d"
 dependencies = [
  "ambient-authority",
- "rand 0.8.6",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -649,9 +649,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.66"
+version = "1.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
+checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -667,9 +667,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
@@ -1766,9 +1766,9 @@ dependencies = [
 
 [[package]]
 name = "get-size-derive2"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1da24fbda09ec01bca7cfa1797c0e520e75123bccb01dcdf9041f8aa65183bc2"
+checksum = "33ce01473d0fed9913c71114f0384807cdf584673424d093c102263645bf2a31"
 dependencies = [
  "attribute-derive",
  "quote",
@@ -1859,9 +1859,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "globset"
-version = "0.4.18"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+checksum = "e47d37d2ae4464254884b60ab7071be2b876a9c35b696bd018ddcc76847309cd"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -1872,9 +1872,9 @@ dependencies = [
 
 [[package]]
 name = "grep-matcher"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36d7b71093325ab22d780b40d7df3066ae4aebb518ba719d38c697a8228a8023"
+checksum = "f9417543f4870fc8f1c8e1af870afae2431007626d9e703fce6471c468d33847"
 dependencies = [
  "memchr",
 ]
@@ -1894,9 +1894,9 @@ dependencies = [
 
 [[package]]
 name = "grep-searcher"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac63295322dc48ebb20a25348147905d816318888e64f531bfc2a2bc0577dc34"
+checksum = "72348823a0eafc4bc2e9051064f28b5b42cc100b571b3a35d67918d711efcbc6"
 dependencies = [
  "bstr",
  "encoding_rs",
@@ -2054,9 +2054,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
@@ -2064,9 +2064,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2292,9 +2292,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2adf14691c72bcfc1058740436a35bdd3ae9c07d1a941ef00b749e9ea16aefa7"
+checksum = "d4ffa3a0547a138e59ddd6fa3b7c672ed47e6ad6a3cd177984ff1116aa5ba742"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -2428,9 +2428,9 @@ dependencies = [
 
 [[package]]
 name = "iron-providers"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e89419b49d98e55a3502486adeae2cfba19d5ff217fd52a26d277c248f6515b"
+checksum = "642263708851d386ff230f7540499f2d456e6d3887b25350c32add2ed9d44ea0"
 dependencies = [
  "async-stream",
  "base64",
@@ -2624,9 +2624,9 @@ dependencies = [
 
 [[package]]
 name = "keyring"
-version = "4.1.4"
+version = "4.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ee8d4dae108d4177d0a0ce241f98acc1ef28e20837bdef43cff4d160cf70fe"
+checksum = "0298a59b384c540e408a600c8b375a09b49c3f97debc080e2c30675d79a6368a"
 dependencies = [
  "apple-native-keyring-store",
  "keyring-core",
@@ -2871,9 +2871,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
@@ -3150,7 +3150,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand 0.8.6",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -3516,9 +3516,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -3683,9 +3683,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3695,9 +3695,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3930,9 +3930,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.41"
+version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -4316,15 +4316,15 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "simd_cesu8"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
 dependencies = [
  "rustc_version",
  "simdutf8",
@@ -4369,9 +4369,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -4390,9 +4390,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]
@@ -4651,9 +4651,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4863,9 +4863,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "317fafbbe3f02fc663dad00ea6186197de963cd4190e86a26d8d0fae095539af"
 dependencies = [
  "bytes",
  "libc",
@@ -4971,14 +4971,14 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.12+spec-1.1.0"
+version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap 2.14.0",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.3",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -4987,14 +4987,14 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.3",
+ "winnow 1.0.4",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tower"
@@ -5196,7 +5196,7 @@ dependencies = [
  "getopts",
  "log",
  "phf_codegen",
- "rand 0.8.6",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -5276,9 +5276,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.4"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -6129,9 +6129,9 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]
@@ -6251,7 +6251,7 @@ dependencies = [
  "uds_windows",
  "uuid",
  "windows-sys 0.61.2",
- "winnow 1.0.3",
+ "winnow 1.0.4",
  "zbus_macros",
  "zbus_names",
  "zvariant",
@@ -6290,7 +6290,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1039ca249fee9559680f3a9f05b55e0761fee51af4f6c1e7d8c1f31e549721d2"
 dependencies = [
  "serde",
- "winnow 1.0.3",
+ "winnow 1.0.4",
  "zvariant",
 ]
 
@@ -6376,9 +6376,9 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zstd"
@@ -6417,7 +6417,7 @@ dependencies = [
  "endi",
  "enumflags2",
  "serde",
- "winnow 1.0.3",
+ "winnow 1.0.4",
  "zvariant_derive",
  "zvariant_utils",
 ]
@@ -6445,5 +6445,5 @@ dependencies = [
  "quote",
  "serde",
  "syn",
- "winnow 1.0.3",
+ "winnow 1.0.4",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
 ]
 
 [dependencies]
-iron-providers = "0.2.12"
+iron-providers = "0.2.14"
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["compat"] }
 serde = { version = "1", features = ["derive"] }

--- a/openspec/changes/atomic-minimum-valid-profile-deletion/.openspec.yaml
+++ b/openspec/changes/atomic-minimum-valid-profile-deletion/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-16

--- a/openspec/changes/atomic-minimum-valid-profile-deletion/design.md
+++ b/openspec/changes/atomic-minimum-valid-profile-deletion/design.md
@@ -1,0 +1,118 @@
+## Context
+
+`ConfigManagementService::delete_profile` currently protects the built-in default identity, delegates to `ConfigStore::delete_profile_checked`, and removes the profile from an attached registry only after durable deletion. The store transaction checks prompt schema support, decodes every prompt to prove reference safety, rejects direct references, deletes the profile, and commits.
+
+Consumers that require at least one persisted usable profile currently call a list/count API before deletion. That count occurs outside the deletion transaction. Because the current SQLx transaction is deferred, separate processes can both read the same two-profile snapshot and delete different records before either observes the other's result.
+
+The store contains opaque, versioned profile rows. Management listing treats a row as valid only when its schema is supported, its payload decodes as `AgentProfile`, and the decoded profile passes structural profile validation. Unsupported, malformed, reserved, and otherwise invalid records are reported as `ManagedRecord::NeedsAttention`, not usable profiles. The deletion policy must use the same classification without introducing a second interpretation of profile validity.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make a caller-selected minimum-valid-profile invariant atomic across separate SQLite connections and processes.
+- Preserve prompt integrity and direct-reference protection in the same transaction as the minimum check and deletion.
+- Reuse one profile-validity classification for management reads and deletion counting.
+- Preserve existing unrestricted deletion APIs and behavior.
+- Return structured minimum/remaining values at both config-store and management boundaries.
+- Preserve durable-first registry synchronization and existing partial-operation reporting.
+
+**Non-Goals:**
+
+- Require every consumer to retain a persisted profile; the policy remains opt-in.
+- Count the built-in in-memory `default` profile as a persisted valid profile.
+- Repair, migrate, or delete malformed or unsupported profile records automatically.
+- Change prompt-reference rules, add cascading deletion, or change dependency-impact DTOs.
+- Make the durable SQLite transaction and in-memory registry update atomic with each other.
+- Add a database migration or persisted policy setting.
+
+## Decisions
+
+### Add one public policy type and preserve existing entry points
+
+Expose `ProfileDeletePolicy` as a public profile-domain type with `AllowZero` and `RequireMinimumValid(usize)`. Both `ConfigStore` and `ConfigManagementService` can use the type without creating a config-to-management dependency.
+
+Add a policy-aware checked store operation and `ConfigManagementService::delete_profile_with_policy`. Keep existing `ConfigStore::delete_profile`, `ConfigStore::delete_profile_checked`, and `ConfigManagementService::delete_profile` entry points, delegating them to `AllowZero`. `RequireMinimumValid(0)` is valid and imposes the same count floor as `AllowZero`, while still using the policy-aware path.
+
+Alternative considered: change `delete_profile` to always require one valid profile. Rejected because zero persisted profiles is currently valid and existing callers rely on unrestricted deletion.
+
+Alternative considered: represent the minimum as `Option<usize>`. Rejected because the named enum makes caller intent and future policy extension explicit.
+
+### Share record-local profile validity with management reads
+
+Extract or otherwise centralize a pure profile-record classification that accepts the stable ID, schema version, and raw payload and applies the rules used to decide whether management listing returns `ManagedRecord::Ready`. A profile counts only when:
+
+1. Its schema version equals `PROFILE_SCHEMA_VERSION`.
+2. Its payload is valid JSON that decodes as `AgentProfile`.
+3. Its stable ID and decoded profile pass the same structural validation used by management reads, including protected-default and supported approval rules.
+
+The count does not include the built-in in-memory default profile. It also does not depend on registry membership, provider credential availability, or prompt references. Record-local classification intentionally does not introduce new cross-record duplicate-name behavior beyond the rules already used by management listing.
+
+Alternative considered: count rows with the current schema version in SQL. Rejected because malformed and structurally invalid payloads would satisfy the minimum.
+
+Alternative considered: call `ConfigManagementService::list_profiles` from the store. Rejected because it would invert the dependency boundary, perform multiple non-transactional reads, and make atomicity impossible.
+
+### Reserve the SQLite writer before any integrity read
+
+The policy-aware store operation begins its transaction with SQLite `BEGIN IMMEDIATE` before reading prompts or profiles. SQLx 0.9 exposes `Pool::begin_with`, which returns a normal transaction that can execute queries and commit or roll back while using the custom begin statement. The existing configured busy timeout remains authoritative when another process holds the writer reservation.
+
+Within that transaction, operations occur in this order:
+
+```text
+BEGIN IMMEDIATE
+  -> verify supported prompt schemas
+  -> decode prompts and identify direct references
+  -> reject integrity-unknown or reference conflicts
+  -> read and classify all persisted profile rows
+  -> total_valid = number classified valid
+  -> target_is_valid = target row exists and is classified valid
+  -> remaining = total_valid - target_is_valid_as_0_or_1
+  -> reject when remaining < requested minimum
+  -> DELETE target row
+COMMIT
+```
+
+This order preserves existing prompt-integrity and reference-conflict precedence. Once `BEGIN IMMEDIATE` succeeds, other SQLite writers cannot insert a new prompt reference, change profile validity, or delete a profile until this transaction commits or rolls back. A second policy-aware deleter therefore reads the first deleter's committed state rather than the same stale snapshot.
+
+Alternative considered: begin a deferred transaction and issue a no-op write before counting. Rejected because the lock acquisition is implicit and easier to regress; `BEGIN IMMEDIATE` states the concurrency requirement directly.
+
+Alternative considered: use an in-process mutex. Rejected because it cannot coordinate separate `ConfigStore` instances in different processes.
+
+### Compute the target's contribution instead of assuming every target is valid
+
+The remaining valid count is the total valid count minus one only if the exact target row is classified valid. A malformed, unsupported, structurally invalid, or missing target contributes zero.
+
+Deletion remains idempotent for a missing target when the requested minimum is already satisfied and prompt integrity can be proven. The policy still rejects any operation whose computed remaining count is below the requested minimum, even when the target contributes zero; this reports that the requested postcondition cannot be met rather than claiming policy success.
+
+Alternative considered: reject malformed targets unconditionally. Rejected because existing unrestricted deletion permits cleanup of opaque records and the minimum policy only needs to prevent loss of valid records.
+
+### Add typed errors and retain post-commit synchronization
+
+Add `ConfigError::MinimumValidProfiles { minimum, remaining }` and map it to a distinct `ManagementError::MinimumValidProfiles { minimum, remaining }`. Adapters can branch on the variant and display structured values without parsing strings.
+
+The service performs registry removal only after the policy-aware store transaction commits. Policy, prompt-integrity, reference, busy-timeout, and other pre-commit failures leave the registry unchanged. A registry failure after commit retains the existing `ManagementError::Partial` behavior.
+
+Alternative considered: map the minimum failure to generic validation or conflict text. Rejected because the caller needs the requested and computed values and issue #100 explicitly requires typed adapter handling.
+
+## Risks / Trade-offs
+
+- [Classifying every profile while holding the SQLite writer reservation increases write-lock duration] -> Keep classification pure and bounded to profile rows; correctness is preferred for a user-scale configuration database, and no schema migration or external I/O occurs inside the transaction.
+- [Management and store validity semantics can drift later] -> Route both through one shared classifier and add paired tests for `ManagedRecord::Ready` versus minimum-count eligibility.
+- [A high requested minimum can reject cleanup of malformed records when the database is already below that floor] -> Document the policy as a required postcondition; callers performing repair can use `AllowZero` or a lower explicit minimum.
+- [Concurrent tests can pass without exercising separate connection locking] -> Use two independently opened file-backed `ConfigStore` instances, synchronize deletion attempts, and assert both result count and final durable state.
+- [Changing from deferred to immediate acquisition can surface busy-timeout errors earlier] -> Preserve the existing typed busy-timeout mapping and document that writer reservation is intentional.
+- [Registry state can diverge after durable success] -> Preserve and test the existing typed partial-operation contract rather than pretending SQLite and memory share one transaction.
+
+## Migration Plan
+
+1. Add and export the policy and typed error variants without changing existing deletion call sites.
+2. Centralize profile-record classification and switch management listing to use it without changing observable diagnostics.
+3. Add the write-reserved policy-aware checked store operation and delegate existing checked deletion to `AllowZero`.
+4. Add the management policy method and delegate existing management deletion to `AllowZero`.
+5. Add store, management, and concurrent file-backed tests before consumers remove their command-level prechecks.
+
+No database migration is required. Rollback to an older binary preserves all stored data; callers compiled against the new API must be rolled back with the library because the new policy and error variants will no longer exist.
+
+## Open Questions
+
+None. Issue #100 defines the policy shape, validity requirement, atomicity boundary, compatibility contract, and error data needed for implementation.

--- a/openspec/changes/atomic-minimum-valid-profile-deletion/proposal.md
+++ b/openspec/changes/atomic-minimum-valid-profile-deletion/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+Consumers that must retain at least one usable profile currently count profiles before calling `ConfigManagementService::delete_profile`, but that check and the durable deletion occur in separate transactions. Two processes can therefore validate the same snapshot and delete different profiles, leaving no valid profile configuration.
+
+## What Changes
+
+- Add an opt-in profile deletion policy that can require a caller-selected minimum number of valid persisted profiles to remain after deletion.
+- Keep the existing unrestricted `delete_profile` behavior and API compatible for callers that permit zero persisted profiles.
+- Evaluate prompt-reference safety, profile validity, the target's contribution to the valid count, and deletion within one write-serialized SQLite transaction.
+- Count only supported, decodable, structurally valid profile records; malformed and unsupported records do not satisfy the minimum.
+- Return typed config-store and management errors containing the requested minimum and computed remaining valid count.
+- Preserve post-commit profile-registry synchronization and its existing typed partial-operation behavior.
+- Add store and management tests for malformed and unsupported records, missing and malformed targets, prompt conflicts, compatibility, and concurrent deletion from separate file-backed stores.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `agent-profiles`: Add an opt-in minimum-valid-profile deletion policy, define which persisted profiles count as valid, expose a typed management failure, and retain unrestricted deletion compatibility.
+- `core-config-store`: Require policy-aware profile validation and deletion to execute atomically under a write reservation shared across SQLite connections and processes.
+
+## Impact
+
+- Extends the public profile-management API with `ProfileDeletePolicy` and `delete_profile_with_policy` while retaining `delete_profile`.
+- Extends `ConfigStore`'s checked profile deletion path and adds a typed `ConfigError::MinimumValidProfiles` mapped to a corresponding `ManagementError` variant.
+- Reuses the profile schema, decoding, and structural validation rules already used by management profile loading; no database migration is required.
+- Changes SQLite transaction acquisition for checked profile deletion so the writer lock is reserved before reading prompt or profile state.
+- Builds on the completed `add-typed-management-apis` change and does not alter typed dependency-impact DTOs or registry synchronization ordering.

--- a/openspec/changes/atomic-minimum-valid-profile-deletion/specs/agent-profiles/spec.md
+++ b/openspec/changes/atomic-minimum-valid-profile-deletion/specs/agent-profiles/spec.md
@@ -1,0 +1,64 @@
+## ADDED Requirements
+
+### Requirement: Core SHALL support an opt-in minimum-valid-profile deletion policy
+Core SHALL expose a public `ProfileDeletePolicy` that distinguishes unrestricted deletion from deletion requiring a caller-selected minimum number of valid persisted profiles to remain. `ConfigManagementService` SHALL expose a policy-aware profile deletion operation, and its existing `delete_profile` operation SHALL retain unrestricted behavior.
+
+For this policy, a persisted profile SHALL count as valid only when its schema version is supported, its payload decodes as the current `AgentProfile`, and its stable ID and decoded fields pass the same structural validity rules used for a ready management profile record. Malformed, unsupported, structurally invalid, and built-in in-memory profiles SHALL NOT count.
+
+#### Scenario: Deleting the only valid persisted profile is rejected
+- **WHEN** one valid persisted profile exists and a caller deletes it with `RequireMinimumValid(1)`
+- **THEN** the management operation returns a typed minimum-valid-profile error with `minimum` equal to 1 and `remaining` equal to 0
+- **AND** the profile remains persisted
+
+#### Scenario: Malformed records do not satisfy the minimum
+- **WHEN** one valid persisted profile and one or more malformed, unsupported, or structurally invalid profile records exist
+- **AND** a caller deletes the valid profile with `RequireMinimumValid(1)`
+- **THEN** deletion is rejected with `remaining` equal to 0
+- **AND** invalid records are not counted as valid profiles
+
+#### Scenario: Deleting an invalid target does not reduce the valid count
+- **WHEN** one valid persisted profile and one malformed, unsupported, or structurally invalid target profile exist
+- **AND** a caller deletes the invalid target with `RequireMinimumValid(1)`
+- **THEN** deletion succeeds
+- **AND** the valid profile remains persisted
+
+#### Scenario: Deleting a missing target does not reduce the valid count
+- **WHEN** the requested minimum is already satisfied and the target profile does not exist
+- **AND** a caller deletes the missing target with `RequireMinimumValid(1)`
+- **THEN** the operation succeeds as an idempotent deletion
+- **AND** the valid persisted profile count is unchanged
+
+#### Scenario: Requested postcondition is not already satisfied
+- **WHEN** the computed remaining valid profile count is below the requested minimum even though the target is missing or invalid
+- **THEN** the operation returns a typed minimum-valid-profile error containing the requested minimum and computed remaining count
+- **AND** no profile record is deleted
+
+#### Scenario: Zero minimum permits zero valid profiles
+- **WHEN** a caller deletes a profile with `RequireMinimumValid(0)`
+- **THEN** the minimum policy does not reject deletion solely because zero valid persisted profiles will remain
+
+### Requirement: Policy-aware deletion SHALL preserve management deletion semantics
+Policy-aware management deletion SHALL continue to protect the built-in default profile, preserve prompt-reference and integrity checks, persist before synchronizing an attached profile registry, and report registry synchronization failure as the existing typed partial operation. Minimum-policy rejection SHALL use a distinct `ManagementError` variant containing `minimum` and `remaining` values.
+
+#### Scenario: Referenced profile also violates the minimum
+- **WHEN** a profile is directly referenced by a stored prompt and deleting it would also violate the requested minimum
+- **THEN** deletion returns the existing typed reference conflict
+- **AND** neither the profile nor its registry entry is removed
+
+#### Scenario: Prompt integrity cannot be proven
+- **WHEN** malformed or unsupported prompt records prevent profile-reference verification during policy-aware deletion
+- **THEN** deletion returns the existing typed integrity-unknown error
+- **AND** minimum counting does not permit deletion to bypass prompt safety
+
+#### Scenario: Minimum policy rejects before registry synchronization
+- **WHEN** durable deletion is rejected because too few valid profiles would remain
+- **THEN** the attached profile registry remains unchanged
+
+#### Scenario: Registry synchronization fails after policy-aware deletion
+- **WHEN** policy-aware durable deletion commits and attached registry removal fails
+- **THEN** the service returns the existing typed partial-operation error identifying durable success
+
+#### Scenario: Existing unrestricted management deletion remains compatible
+- **WHEN** an existing caller invokes `ConfigManagementService::delete_profile`
+- **THEN** deletion retains its current unrestricted minimum-count behavior
+- **AND** existing default protection, prompt safety, and registry synchronization behavior remain in effect

--- a/openspec/changes/atomic-minimum-valid-profile-deletion/specs/core-config-store/spec.md
+++ b/openspec/changes/atomic-minimum-valid-profile-deletion/specs/core-config-store/spec.md
@@ -1,0 +1,48 @@
+## ADDED Requirements
+
+### Requirement: Policy-aware profile deletion SHALL atomically enforce the valid-profile minimum
+The SQLite-backed `ConfigStore` SHALL acquire a write reservation before reading prompt or profile state for policy-aware checked profile deletion. Prompt integrity checks, prompt-reference checks, profile classification, target contribution calculation, minimum enforcement, and deletion SHALL occur in the same transaction.
+
+The store SHALL return `ConfigError::MinimumValidProfiles { minimum, remaining }` when the computed remaining valid profile count is below the requested minimum. Transaction failure or policy rejection SHALL preserve the target and all other records.
+
+#### Scenario: Two stores concurrently delete different valid profiles
+- **WHEN** two independently opened file-backed `ConfigStore` clients share a database containing exactly two valid profiles
+- **AND** both clients concurrently delete different profiles with `RequireMinimumValid(1)`
+- **THEN** at most one deletion succeeds
+- **AND** at least one valid persisted profile remains after both operations complete
+
+#### Scenario: Concurrent writer changes profile state
+- **WHEN** one policy-aware deletion has acquired its write reservation and another connection attempts to insert, update, or delete a profile
+- **THEN** SQLite serializes the writes using the configured busy timeout
+- **AND** the deleting transaction computes its decision from one protected database state
+
+#### Scenario: Concurrent writer creates a prompt reference
+- **WHEN** policy-aware deletion has acquired its write reservation and another connection attempts to persist a prompt referencing the target profile
+- **THEN** the prompt write cannot interleave between reference verification and profile deletion
+- **AND** the database does not commit a successful checked deletion based on stale prompt-reference state
+
+#### Scenario: Prompt conflict takes precedence over minimum failure
+- **WHEN** the target profile is referenced by a supported decodable prompt and deleting it would leave fewer valid profiles than requested
+- **THEN** the checked store operation returns `ConfigError::ProfileReferencedByPrompts`
+- **AND** preserves the target profile
+
+#### Scenario: Invalid target contributes zero to the valid count
+- **WHEN** the target profile is malformed, unsupported, or structurally invalid
+- **THEN** the transaction computes `remaining` without subtracting the target from the valid count
+
+#### Scenario: Missing target contributes zero to the valid count
+- **WHEN** no profile row matches the target ID
+- **THEN** the transaction computes `remaining` without subtracting from the valid count
+- **AND** the delete remains idempotent when the requested minimum is satisfied
+
+### Requirement: Existing ConfigStore profile deletion SHALL remain unrestricted
+Existing `ConfigStore::delete_profile` and checked deletion callers SHALL retain their current behavior by using the unrestricted deletion policy. They SHALL continue to enforce prompt integrity and direct-reference safety but SHALL NOT acquire a minimum-valid-profile requirement unless the caller opts into one.
+
+#### Scenario: Existing store caller deletes the last valid profile
+- **WHEN** an existing caller invokes unrestricted profile deletion for the only valid persisted profile and no prompt blocks deletion
+- **THEN** deletion succeeds
+- **AND** zero valid persisted profiles may remain
+
+#### Scenario: Existing store caller deletes an invalid profile
+- **WHEN** an existing caller invokes unrestricted profile deletion for a malformed or unsupported profile and prompt integrity can be proven
+- **THEN** deletion retains its current cleanup behavior

--- a/openspec/changes/atomic-minimum-valid-profile-deletion/tasks.md
+++ b/openspec/changes/atomic-minimum-valid-profile-deletion/tasks.md
@@ -1,0 +1,49 @@
+## 1. Public Policy And Validity Boundary
+
+- [x] 1.1 Add the public `ProfileDeletePolicy` enum in the profile domain and re-export it from the crate API.
+- [x] 1.2 Centralize raw profile record classification so supported schema, decoding, stable-ID validation, profile-field validation, and management diagnostics use one implementation.
+- [x] 1.3 Refactor management profile get/list paths to use the shared classifier without changing ready versus needs-attention outcomes or diagnostic categories.
+- [x] 1.4 Add focused classifier tests covering valid, malformed JSON, unsupported schema, reserved default, unsupported approval, and structurally invalid profile records.
+
+## 2. Typed Errors
+
+- [x] 2.1 Add `ConfigError::MinimumValidProfiles { minimum, remaining }` with public field documentation and an actionable display message.
+- [x] 2.2 Add `ManagementError::MinimumValidProfiles { minimum, remaining }` and map the config-store variant without reducing it to a string or generic storage error.
+- [x] 2.3 Add error-mapping tests that assert both typed variants preserve the requested minimum and computed remaining count.
+
+## 3. Atomic Store Deletion
+
+- [x] 3.1 Add a policy-aware checked profile deletion method that starts with SQLx `Pool::begin_with("BEGIN IMMEDIATE")` before any prompt or profile read.
+- [x] 3.2 Preserve existing prompt schema, decode-integrity, sorted direct-reference checks, and their error precedence inside the write-reserved transaction.
+- [x] 3.3 Read and classify profile rows inside the transaction, subtract one only when the exact target is valid, and reject when the computed remaining count is below the requested minimum.
+- [x] 3.4 Delete and commit only after all checks pass, relying on transaction rollback for integrity, reference, policy, query, and busy-timeout failures.
+- [x] 3.5 Delegate existing `ConfigStore::delete_profile` and checked deletion APIs to `AllowZero` so current callers retain unrestricted behavior.
+
+## 4. Management API And Registry Synchronization
+
+- [x] 4.1 Add and document `ConfigManagementService::delete_profile_with_policy`, preserving protected-default validation and delegating durable checks to the store.
+- [x] 4.2 Keep attached profile-registry removal after durable commit and preserve the existing typed partial-operation result for registry failure.
+- [x] 4.3 Delegate existing `ConfigManagementService::delete_profile` to `AllowZero` without changing its public signature or behavior.
+- [x] 4.4 Update crate and module API documentation to describe valid-profile counting, opt-in semantics, typed failures, and unrestricted compatibility.
+
+## 5. Store Tests
+
+- [x] 5.1 Test that one valid profile plus malformed, unsupported, and structurally invalid records cannot satisfy `RequireMinimumValid(1)` when deleting the valid profile.
+- [x] 5.2 Test deleting malformed, unsupported, structurally invalid, and missing targets when one valid profile satisfies the minimum, verifying each target contributes zero.
+- [x] 5.3 Test that a missing or invalid target is rejected with accurate values when the requested postcondition is already unsatisfied.
+- [x] 5.4 Test `RequireMinimumValid(0)` and existing unrestricted deletion, including deletion of the final valid profile and cleanup of invalid records.
+- [x] 5.5 Test prompt-reference conflict and prompt-integrity-unknown precedence when the minimum policy would also reject deletion.
+- [x] 5.6 Test transaction rollback and durable target preservation for minimum, prompt, and storage failures.
+
+## 6. Cross-Connection Concurrency Tests
+
+- [x] 6.1 Open two independent file-backed `ConfigStore` clients against one temporary database and synchronize deletion attempts for two valid profiles with `RequireMinimumValid(1)`.
+- [x] 6.2 Assert at most one concurrent deletion succeeds, the loser returns a typed minimum or actionable busy-timeout result as appropriate, and at least one valid profile remains durably stored.
+- [x] 6.3 Add a cross-connection prompt-write/delete test proving a new prompt reference cannot interleave between checked reference reads and profile deletion.
+
+## 7. Management Tests And Verification
+
+- [x] 7.1 Add management-service tests for minimum rejection, invalid and missing targets, prompt conflict precedence, and typed error values.
+- [x] 7.2 Add attached-registry tests proving pre-commit rejection leaves memory unchanged and post-commit registry failure retains the existing partial-operation shape.
+- [x] 7.3 Add backward-compatibility tests proving existing management deletion can remove the final valid persisted profile when no prompt blocks it.
+- [x] 7.4 Run targeted config-store and management tests, then `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and the full test suite.

--- a/src/config/error.rs
+++ b/src/config/error.rs
@@ -126,6 +126,18 @@ pub enum ConfigError {
         /// Human-readable details about the unreadable records.
         details: String,
     },
+
+    /// Policy-aware profile deletion would leave fewer valid persisted
+    /// profiles than the caller requested.
+    #[error(
+        "Cannot delete profile: {remaining} valid profile(s) would remain, below the requested minimum of {minimum}"
+    )]
+    MinimumValidProfiles {
+        /// The minimum valid-profile count the caller requested to remain.
+        minimum: usize,
+        /// The computed valid-profile count that would remain after deletion.
+        remaining: usize,
+    },
 }
 
 impl From<sqlx::Error> for ConfigError {

--- a/src/config/store.rs
+++ b/src/config/store.rs
@@ -307,6 +307,10 @@ impl ConfigStore {
     }
 
     /// Delete a profile by ID.
+    ///
+    /// Delegates to [`ConfigStore::delete_profile_checked`] with the
+    /// unrestricted deletion policy, preserving the original behavior that
+    /// permits zero persisted profiles to remain.
     pub async fn delete_profile(&self, id: &str) -> Result<(), ConfigError> {
         self.delete_profile_checked(id).await
     }
@@ -2764,23 +2768,55 @@ impl ConfigStore {
 
     /// Delete a profile by ID, blocking if prompts reference it.
     ///
-    /// Returns `ConfigError::ProfileReferencedByPrompts` if stored prompts
-    /// reference this profile.
-    /// Delete a profile by ID, blocking if prompts reference it.
-    ///
     /// Performs all integrity and reference checks within a single transaction
     /// so no concurrent insert can interleave between verification and deletion.
     /// Returns `ConfigError::ProfileReferencedByPrompts` if stored prompts
     /// reference this profile, or `ConfigError::IntegrityUnknown` if malformed
-    /// prompt records prevent reliable reference checking.
+    /// prompt records prevent reliable reference checking. Uses the unrestricted
+    /// [`crate::profile::ProfileDeletePolicy::AllowZero`] policy.
     pub async fn delete_profile_checked(&self, id: &str) -> Result<(), ConfigError> {
+        self.delete_profile_with_policy(id, crate::profile::ProfileDeletePolicy::AllowZero)
+            .await
+    }
+
+    /// Delete a profile by ID under a caller-selected minimum-valid-profile
+    /// policy.
+    ///
+    /// Acquires the SQLite write reservation before reading prompt or profile
+    /// state (via `BEGIN IMMEDIATE`), then performs prompt integrity checks,
+    /// prompt-reference checks, valid-profile counting, minimum enforcement,
+    /// and deletion within the same transaction.
+    ///
+    /// A persisted profile counts as valid only when its schema version is
+    /// supported, its payload decodes as [`crate::profile::AgentProfile`], and
+    /// its stable ID and decoded fields pass the structural validity rules
+    /// shared with management reads. Malformed, unsupported, structurally
+    /// invalid, and missing target records do not reduce the valid count.
+    ///
+    /// Returns [`ConfigError::MinimumValidProfiles`] when the computed
+    /// remaining valid profile count is below the requested minimum.
+    /// Prompt-reference and integrity failures retain precedence over the
+    /// minimum check.
+    pub async fn delete_profile_with_policy(
+        &self,
+        id: &str,
+        policy: crate::profile::ProfileDeletePolicy,
+    ) -> Result<(), ConfigError> {
         use crate::stored_prompt::{
             LEGACY_STORED_PROMPT_SCHEMA_VERSION, STORED_PROMPT_SCHEMA_VERSION,
         };
 
-        let mut tx = self.pool.begin().await.map_err(ConfigError::from)?;
+        // Acquire the write reservation before any read so concurrent writers
+        // cannot validate against the same snapshot. The configured busy
+        // timeout remains authoritative when another process holds the writer.
+        let mut tx = self
+            .pool
+            .begin_with("BEGIN IMMEDIATE")
+            .await
+            .map_err(ConfigError::from)?;
 
-        // Verify all prompts have supported schema versions.
+        // Prompt integrity checks take precedence over the minimum-valid-
+        // profile policy: verify every prompt uses a supported schema version.
         let unsupported: Vec<(String,)> = sqlx::query_as(
             "SELECT id FROM prompts WHERE schema_version NOT IN (?, ?) ORDER BY id ASC",
         )
@@ -2801,9 +2837,9 @@ impl ConfigStore {
             });
         }
 
-        // Decode every prompt and check the profile reference directly.
-        // Any decode failure means we cannot prove the target is unreferenced.
-        let rows = sqlx::query("SELECT id, payload FROM prompts ORDER BY id ASC")
+        // Decode every prompt and check the profile reference directly. Any
+        // decode failure means we cannot prove the target is unreferenced.
+        let prompt_rows = sqlx::query("SELECT id, payload FROM prompts ORDER BY id ASC")
             .fetch_all(&mut *tx)
             .await
             .map_err(|e| ConfigError::IntegrityUnknown {
@@ -2812,7 +2848,7 @@ impl ConfigStore {
 
         let mut referencing_prompts = Vec::new();
         let mut malformed_prompts = Vec::new();
-        for row in rows {
+        for row in prompt_rows {
             let prompt_id: String = row.get("id");
             let payload: String = row.get("payload");
             match serde_json::from_str::<crate::stored_prompt::StoredPrompt>(&payload) {
@@ -2844,6 +2880,41 @@ impl ConfigStore {
                 profile_id: id.to_string(),
                 prompt_ids: referencing_prompts,
             });
+        }
+
+        // Count valid persisted profiles and compute the target's contribution.
+        // A row counts only when it classifies as valid; a malformed,
+        // unsupported, structurally invalid, or missing target contributes zero.
+        let rows = sqlx::query("SELECT id, schema_version, payload FROM profiles ORDER BY id ASC")
+            .fetch_all(&mut *tx)
+            .await
+            .map_err(ConfigError::from)?;
+
+        let mut total_valid = 0usize;
+        let mut target_is_valid = false;
+        for row in &rows {
+            let row_id: String = row.get("id");
+            let schema_version: i64 = row.get("schema_version");
+            let payload: String = row.get("payload");
+            let is_target = row_id == id;
+            let valid = serde_json::from_str::<serde_json::Value>(&payload)
+                .ok()
+                .and_then(|value| {
+                    crate::profile::classify_profile_record(&row_id, schema_version, &value).ok()
+                })
+                .is_some();
+            if valid {
+                total_valid += 1;
+            }
+            if is_target {
+                target_is_valid = valid;
+            }
+        }
+
+        let remaining = total_valid - usize::from(target_is_valid);
+        let minimum = policy.minimum();
+        if remaining < minimum {
+            return Err(ConfigError::MinimumValidProfiles { minimum, remaining });
         }
 
         sqlx::query("DELETE FROM profiles WHERE id = ?")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -240,9 +240,10 @@ pub use headless::{
     run_automation, HeadlessBootstrapError, HeadlessRuntime,
 };
 pub use profile::{
-    default_identity_prompt, managed_profile_prompt_context, normalize_profile_name, AgentApproval,
-    AgentProfile, AgentProfileEntry, AgentProfileId, AgentProfileProvider, ProfileLoadDiagnostic,
-    ProfileLoadIssue, ProfileLoadReport, ResolvedProfileProvider, SkillFilter, ToolFilter,
+    classify_profile_record, default_identity_prompt, managed_profile_prompt_context,
+    normalize_profile_name, AgentApproval, AgentProfile, AgentProfileEntry, AgentProfileId,
+    AgentProfileProvider, ProfileDeletePolicy, ProfileLoadDiagnostic, ProfileLoadIssue,
+    ProfileLoadReport, ProfileRecordError, ResolvedProfileProvider, SkillFilter, ToolFilter,
     PROFILE_SCHEMA_VERSION,
 };
 pub use prompt_turn::PromptTurn;

--- a/src/management/mod.rs
+++ b/src/management/mod.rs
@@ -64,6 +64,11 @@ pub enum ManagementError {
     #[error("Cannot verify referential integrity: {details}")]
     IntegrityUnknown { details: String },
 
+    #[error(
+        "Cannot delete profile: {remaining} valid profile(s) would remain, below the requested minimum of {minimum}"
+    )]
+    MinimumValidProfiles { minimum: usize, remaining: usize },
+
     #[error("Scheduler is not attached")]
     SchedulerUnavailable,
 
@@ -127,6 +132,9 @@ impl From<ConfigError> for ManagementError {
             },
             ConfigError::IntegrityUnknown { details } => {
                 ManagementError::IntegrityUnknown { details }
+            }
+            ConfigError::MinimumValidProfiles { minimum, remaining } => {
+                ManagementError::MinimumValidProfiles { minimum, remaining }
             }
             other => ManagementError::Storage(other),
         }
@@ -529,41 +537,21 @@ impl ConfigManagementService {
             }
             Err(e) => return Err(e.into()),
         };
-        if record.schema_version != PROFILE_SCHEMA_VERSION {
-            return Ok(Some(ManagedProfileRecord::NeedsAttention {
+        match crate::profile::classify_profile_record(
+            &record.id,
+            record.schema_version,
+            &record.payload,
+        ) {
+            Ok(profile) => Ok(Some(ManagedProfileRecord::Ready(ManagedProfileEntry {
+                id: AgentProfileId::from(record.id),
+                profile,
+                created_at: record.created_at,
+                updated_at: record.updated_at,
+            }))),
+            Err(error) => Ok(Some(ManagedProfileRecord::NeedsAttention {
                 id: record.id,
                 decoded: None,
-                diagnostics: vec![RecordDiagnostic {
-                    category: DiagnosticCategory::UnsupportedSchemaVersion,
-                    message: format!(
-                        "Profile schema version {} is not supported",
-                        record.schema_version
-                    ),
-                }],
-            }));
-        }
-        match serde_json::from_value::<AgentProfile>(record.payload.clone()) {
-            Ok(profile) => {
-                let diagnostics = Self::validate_decoded_profile(&record.id, &profile);
-                if diagnostics.is_empty() {
-                    Ok(Some(ManagedProfileRecord::Ready(ManagedProfileEntry {
-                        id: AgentProfileId::from(record.id),
-                        profile,
-                        created_at: record.created_at,
-                        updated_at: record.updated_at,
-                    })))
-                } else {
-                    Ok(Some(ManagedProfileRecord::NeedsAttention {
-                        id: record.id,
-                        decoded: None,
-                        diagnostics,
-                    }))
-                }
-            }
-            Err(e) => Ok(Some(ManagedProfileRecord::NeedsAttention {
-                id: record.id,
-                decoded: None,
-                diagnostics: Self::profile_decode_diagnostics(&record.payload, e),
+                diagnostics: Self::profile_record_diagnostics(error),
             })),
         }
     }
@@ -589,43 +577,24 @@ impl ConfigManagementService {
                 }
                 Err(e) => return Err(e.into()),
             };
-            if record.schema_version != PROFILE_SCHEMA_VERSION {
-                results.push(ManagedProfileRecord::NeedsAttention {
-                    id: record.id,
-                    decoded: None,
-                    diagnostics: vec![RecordDiagnostic {
-                        category: DiagnosticCategory::UnsupportedSchemaVersion,
-                        message: format!(
-                            "Profile schema version {} is not supported",
-                            record.schema_version
-                        ),
-                    }],
-                });
-                continue;
-            }
-            match serde_json::from_value::<AgentProfile>(record.payload.clone()) {
+            match crate::profile::classify_profile_record(
+                &record.id,
+                record.schema_version,
+                &record.payload,
+            ) {
                 Ok(profile) => {
-                    let diagnostics = Self::validate_decoded_profile(&record.id, &profile);
-                    if diagnostics.is_empty() {
-                        results.push(ManagedProfileRecord::Ready(ManagedProfileEntry {
-                            id: AgentProfileId::from(record.id),
-                            profile,
-                            created_at: record.created_at,
-                            updated_at: record.updated_at,
-                        }));
-                    } else {
-                        results.push(ManagedProfileRecord::NeedsAttention {
-                            id: record.id,
-                            decoded: None,
-                            diagnostics,
-                        });
-                    }
+                    results.push(ManagedProfileRecord::Ready(ManagedProfileEntry {
+                        id: AgentProfileId::from(record.id),
+                        profile,
+                        created_at: record.created_at,
+                        updated_at: record.updated_at,
+                    }));
                 }
-                Err(e) => {
+                Err(error) => {
                     results.push(ManagedProfileRecord::NeedsAttention {
                         id: record.id,
                         decoded: None,
-                        diagnostics: Self::profile_decode_diagnostics(&record.payload, e),
+                        diagnostics: Self::profile_record_diagnostics(error),
                     });
                 }
             }
@@ -638,8 +607,27 @@ impl ConfigManagementService {
     /// Returns `ManagementError::Conflict` if prompts reference this profile.
     /// Returns `ManagementError::IntegrityUnknown` if malformed records
     /// prevent safe reference checking. All checks are transactional in the
-    /// store layer.
+    /// store layer. Uses the unrestricted deletion policy, which permits zero
+    /// valid persisted profiles to remain.
     pub async fn delete_profile(&self, id: &str) -> Result<(), ManagementError> {
+        self.delete_profile_with_policy(id, crate::profile::ProfileDeletePolicy::AllowZero)
+            .await
+    }
+
+    /// Delete a profile under a caller-selected minimum-valid-profile policy.
+    ///
+    /// Preserves protected-default validation, prompt-reference and integrity
+    /// checks, and durable-first registry synchronization. Returns
+    /// [`ManagementError::MinimumValidProfiles`] when the computed remaining
+    /// valid persisted profile count is below the requested minimum. Prompt-
+    /// reference and integrity failures retain precedence over the minimum
+    /// check. A registry synchronization failure after durable commit retains
+    /// the existing [`ManagementError::Partial`] behavior.
+    pub async fn delete_profile_with_policy(
+        &self,
+        id: &str,
+        policy: crate::profile::ProfileDeletePolicy,
+    ) -> Result<(), ManagementError> {
         let trimmed_id = id.trim();
         if trimmed_id.eq_ignore_ascii_case("default") {
             return Err(ManagementError::Validation(
@@ -647,9 +635,11 @@ impl ConfigManagementService {
             ));
         }
 
-        self.store.delete_profile_checked(trimmed_id).await?;
+        self.store
+            .delete_profile_with_policy(trimmed_id, policy)
+            .await?;
 
-        // Sync attached registry.
+        // Sync attached registry only after the durable transaction commits.
         if let Some(registry) = &self.profile_registry {
             registry
                 .remove(&AgentProfileId::from(trimmed_id))
@@ -2080,21 +2070,8 @@ impl ConfigManagementService {
         schema_version: i64,
         payload: serde_json::Value,
     ) -> Result<AgentProfile, String> {
-        if schema_version != PROFILE_SCHEMA_VERSION {
-            return Err(format!("unsupported schema version {}", schema_version));
-        }
-        let profile = serde_json::from_value::<AgentProfile>(payload)
-            .map_err(|e| format!("could not be decoded: {}", e))?;
-        let diagnostics = Self::validate_decoded_profile(id, &profile);
-        if diagnostics.is_empty() {
-            Ok(profile)
-        } else {
-            Err(diagnostics
-                .into_iter()
-                .map(|diagnostic| diagnostic.message)
-                .collect::<Vec<_>>()
-                .join("; "))
-        }
+        crate::profile::classify_profile_record(id, schema_version, &payload)
+            .map_err(profile_record_error_to_impact_reason)
     }
 
     fn decode_prompt_for_impact(
@@ -2159,64 +2136,42 @@ impl ConfigManagementService {
         Ok((references, diagnostics))
     }
 
-    /// Validate a decoded profile's fields and return diagnostics for any
-    /// issues found. An empty vector means the profile is valid.
-    fn validate_decoded_profile(id: &str, profile: &AgentProfile) -> Vec<RecordDiagnostic> {
-        let mut diagnostics = Vec::new();
-        if !crate::profile::is_valid_profile_id(id) {
-            diagnostics.push(RecordDiagnostic {
-                category: DiagnosticCategory::InvalidPayload,
-                message: format!("Profile ID '{}' is invalid or reserved", id),
-            });
-        }
-        if crate::profile::normalize_profile_name(&profile.name).is_none() {
-            diagnostics.push(RecordDiagnostic {
-                category: DiagnosticCategory::InvalidPayload,
-                message: format!("Profile name '{}' is invalid or reserved", profile.name),
-            });
-        }
-        if let AgentProfileProvider::Managed {
-            provider_slug,
-            model,
-        } = &profile.provider
-        {
-            if provider_slug.as_str().trim().is_empty() || model.trim().is_empty() {
-                diagnostics.push(RecordDiagnostic {
-                    category: DiagnosticCategory::InvalidPayload,
-                    message: "Managed profile has empty provider_slug or model".to_string(),
-                });
-            }
-        }
-        diagnostics
-    }
-
-    /// Build diagnostics for a profile payload that failed deserialization.
-    ///
-    /// Detects unsupported approval values (`ReadOnly`/`RequireApproval`) in
-    /// the raw payload so they surface under [`DiagnosticCategory::ReadOnlyRejected`].
-    /// All other decode failures retain the underlying error message under
-    /// [`DiagnosticCategory::InvalidPayload`].
-    fn profile_decode_diagnostics(
-        payload: &serde_json::Value,
-        error: serde_json::Error,
+    /// Map a record-local profile classification failure to the same management
+    /// diagnostics that direct reads produced before classification was
+    /// centralized.
+    fn profile_record_diagnostics(
+        error: crate::profile::ProfileRecordError,
     ) -> Vec<RecordDiagnostic> {
-        let rejected = payload
-            .get("approval")
-            .and_then(|v| v.as_str())
-            .filter(|a| matches!(*a, "ReadOnly" | "RequireApproval"));
-        if let Some(approval) = rejected {
-            vec![RecordDiagnostic {
-                category: DiagnosticCategory::ReadOnlyRejected,
-                message: format!(
-                    "{} is not a valid user-facing profile approval value",
-                    approval
-                ),
-            }]
-        } else {
-            vec![RecordDiagnostic {
-                category: DiagnosticCategory::InvalidPayload,
-                message: format!("Profile payload could not be decoded: {}", error),
-            }]
+        use crate::profile::ProfileRecordError;
+        match error {
+            ProfileRecordError::UnsupportedSchemaVersion { actual } => {
+                vec![RecordDiagnostic {
+                    category: DiagnosticCategory::UnsupportedSchemaVersion,
+                    message: format!("Profile schema version {} is not supported", actual),
+                }]
+            }
+            ProfileRecordError::ReadOnlyRejected { approval } => {
+                vec![RecordDiagnostic {
+                    category: DiagnosticCategory::ReadOnlyRejected,
+                    message: format!(
+                        "{} is not a valid user-facing profile approval value",
+                        approval
+                    ),
+                }]
+            }
+            ProfileRecordError::DecodeFailure { error } => {
+                vec![RecordDiagnostic {
+                    category: DiagnosticCategory::InvalidPayload,
+                    message: format!("Profile payload could not be decoded: {}", error),
+                }]
+            }
+            ProfileRecordError::InvalidFields { messages } => messages
+                .into_iter()
+                .map(|message| RecordDiagnostic {
+                    category: DiagnosticCategory::InvalidPayload,
+                    message,
+                })
+                .collect(),
         }
     }
 
@@ -2816,6 +2771,25 @@ fn provider_slug_of(profile: &AgentProfile) -> Option<String> {
     }
 }
 
+/// Render a record-local profile classification failure as the single-line
+/// reason used by dependency-impact diagnostics. Preserves the wording the
+/// pre-centralization impact traversal produced.
+fn profile_record_error_to_impact_reason(error: crate::profile::ProfileRecordError) -> String {
+    use crate::profile::ProfileRecordError;
+    match error {
+        ProfileRecordError::UnsupportedSchemaVersion { actual } => {
+            format!("unsupported schema version {}", actual)
+        }
+        ProfileRecordError::ReadOnlyRejected { approval } => format!(
+            "could not be decoded: {} is not a valid user-facing profile approval value",
+            approval
+        ),
+        ProfileRecordError::DecodeFailure { error } => {
+            format!("could not be decoded: {}", error)
+        }
+        ProfileRecordError::InvalidFields { messages } => messages.join("; "),
+    }
+}
 // ============================================================================
 // Managed entry types
 // ============================================================================
@@ -2864,6 +2838,37 @@ impl ManagedPromptRecord {
 mod tests {
     use super::*;
 
+    #[test]
+    fn config_error_minimum_valid_profiles_maps_to_management_variant() {
+        let config_err = ConfigError::MinimumValidProfiles {
+            minimum: 1,
+            remaining: 0,
+        };
+        let management_err = ManagementError::from(config_err);
+        assert!(
+            matches!(
+                management_err,
+                ManagementError::MinimumValidProfiles {
+                    minimum: 1,
+                    remaining: 0
+                }
+            ),
+            "expected typed MinimumValidProfiles mapping, got {:?}",
+            management_err
+        );
+    }
+
+    #[test]
+    fn config_error_minimum_valid_profiles_display_reports_values() {
+        let err = ConfigError::MinimumValidProfiles {
+            minimum: 2,
+            remaining: 1,
+        };
+        let message = err.to_string();
+        assert!(message.contains("minimum of 2"), "{}", message);
+        assert!(message.contains("1 valid profile"), "{}", message);
+    }
+
     struct FailingProfileRegistry;
     impl ProfileRegistry for FailingProfileRegistry {
         fn insert(&self, _id: AgentProfileId, _profile: AgentProfile) -> Result<(), String> {
@@ -2871,6 +2876,25 @@ mod tests {
         }
         fn remove(&self, _id: &AgentProfileId) -> Result<(), String> {
             Ok(())
+        }
+        fn find_by_normalized_name(
+            &self,
+            _name: &str,
+            _excluding_id: &AgentProfileId,
+        ) -> Option<AgentProfileId> {
+            None
+        }
+    }
+
+    /// Registry that records removals but reports failure, to exercise the
+    /// partial-operation path after a durable policy-aware deletion commits.
+    struct RemoveFailingProfileRegistry;
+    impl ProfileRegistry for RemoveFailingProfileRegistry {
+        fn insert(&self, _id: AgentProfileId, _profile: AgentProfile) -> Result<(), String> {
+            Ok(())
+        }
+        fn remove(&self, _id: &AgentProfileId) -> Result<(), String> {
+            Err("simulated profile registry remove failure".to_string())
         }
         fn find_by_normalized_name(
             &self,
@@ -3638,6 +3662,150 @@ mod tests {
             other => panic!("expected sorted conflict, got {:?}", other),
         }
         assert!(svc.get_profile("prof").await.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn delete_profile_with_policy_rejects_below_minimum() {
+        use crate::profile::ProfileDeletePolicy;
+
+        let store = ConfigStore::open_in_memory().await.unwrap();
+        let svc = ConfigManagementService::new(store);
+
+        svc.save_profile("prof", &AgentProfile::with_name("Profile"))
+            .await
+            .unwrap();
+
+        let result = svc
+            .delete_profile_with_policy("prof", ProfileDeletePolicy::RequireMinimumValid(1))
+            .await;
+        match result {
+            Err(ManagementError::MinimumValidProfiles { minimum, remaining }) => {
+                assert_eq!(minimum, 1);
+                assert_eq!(remaining, 0);
+            }
+            other => panic!("expected MinimumValidProfiles, got {:?}", other),
+        }
+        assert!(svc.get_profile("prof").await.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn delete_profile_with_policy_invalid_target_contributes_zero() {
+        use crate::profile::ProfileDeletePolicy;
+
+        let store = ConfigStore::open_in_memory().await.unwrap();
+        let svc = ConfigManagementService::new(store.clone());
+
+        svc.save_profile("valid", &AgentProfile::with_name("Valid"))
+            .await
+            .unwrap();
+        // Persist a structurally invalid profile directly through the store.
+        store
+            .set_profile(&crate::config::ProfileInput {
+                id: "invalid".to_string(),
+                schema_version: crate::profile::PROFILE_SCHEMA_VERSION,
+                payload: serde_json::json!({"name": ""}),
+            })
+            .await
+            .unwrap();
+
+        svc.delete_profile_with_policy("invalid", ProfileDeletePolicy::RequireMinimumValid(1))
+            .await
+            .unwrap();
+        assert!(svc.get_profile("valid").await.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn delete_profile_with_policy_prompt_conflict_precedes_minimum() {
+        use crate::profile::ProfileDeletePolicy;
+
+        let store = ConfigStore::open_in_memory().await.unwrap();
+        let svc = ConfigManagementService::new(store);
+
+        svc.save_profile("prof", &AgentProfile::with_name("Profile"))
+            .await
+            .unwrap();
+        svc.create_prompt(
+            "Alpha",
+            "Instructions",
+            vec![],
+            Some(AgentProfileId::from("prof")),
+        )
+        .await
+        .unwrap();
+
+        let result = svc
+            .delete_profile_with_policy("prof", ProfileDeletePolicy::RequireMinimumValid(1))
+            .await;
+        assert!(matches!(result, Err(ManagementError::Conflict { .. })));
+        assert!(svc.get_profile("prof").await.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn delete_profile_with_policy_rejection_leaves_registry_unchanged() {
+        use crate::profile::ProfileDeletePolicy;
+
+        let store = ConfigStore::open_in_memory().await.unwrap();
+        let registry = Arc::new(parking_lot::RwLock::new(HashMap::new()));
+        let svc = ConfigManagementService::new(store).with_profile_registry(registry.clone());
+
+        svc.save_profile("prof", &AgentProfile::with_name("Profile"))
+            .await
+            .unwrap();
+        assert!(registry.read().contains_key(&AgentProfileId::from("prof")));
+
+        let result = svc
+            .delete_profile_with_policy("prof", ProfileDeletePolicy::RequireMinimumValid(1))
+            .await;
+        assert!(matches!(
+            result,
+            Err(ManagementError::MinimumValidProfiles { .. })
+        ));
+        // Pre-commit rejection must leave the registry entry intact.
+        assert!(registry.read().contains_key(&AgentProfileId::from("prof")));
+    }
+
+    #[tokio::test]
+    async fn delete_profile_with_policy_partial_when_registry_remove_fails() {
+        use crate::profile::ProfileDeletePolicy;
+
+        let store = ConfigStore::open_in_memory().await.unwrap();
+        let svc = ConfigManagementService::new(store.clone())
+            .with_profile_registry_for_test(Arc::new(RemoveFailingProfileRegistry));
+
+        svc.save_profile("prof", &AgentProfile::with_name("Profile"))
+            .await
+            .unwrap();
+        // Provide a second valid profile so RequireMinimumValid(1) is satisfied.
+        svc.save_profile("other", &AgentProfile::with_name("Other"))
+            .await
+            .unwrap();
+
+        let result = svc
+            .delete_profile_with_policy("prof", ProfileDeletePolicy::RequireMinimumValid(1))
+            .await;
+        assert!(matches!(
+            result,
+            Err(ManagementError::Partial {
+                durable_succeeded: true,
+                ..
+            })
+        ));
+        // Durable deletion committed despite the registry failure.
+        assert!(svc.get_profile("prof").await.unwrap().is_none());
+        assert!(svc.get_profile("other").await.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn existing_delete_profile_removes_final_valid_profile() {
+        let store = ConfigStore::open_in_memory().await.unwrap();
+        let svc = ConfigManagementService::new(store);
+
+        svc.save_profile("prof", &AgentProfile::with_name("Profile"))
+            .await
+            .unwrap();
+
+        svc.delete_profile("prof").await.unwrap();
+        assert!(svc.get_profile("prof").await.unwrap().is_none());
     }
 
     #[tokio::test]

--- a/src/profile/mod.rs
+++ b/src/profile/mod.rs
@@ -387,6 +387,138 @@ pub fn normalize_profile_name(name: &str) -> Option<String> {
     Some(trimmed.to_string())
 }
 
+/// Opt-in policy governing how many valid persisted profiles must remain after
+/// a profile deletion.
+///
+/// The unrestricted default ([`ProfileDeletePolicy::AllowZero`]) preserves the
+/// original `delete_profile` semantics, which permit zero persisted profiles.
+/// [`ProfileDeletePolicy::RequireMinimumValid`] requests an atomic check that
+/// at least `minimum` valid persisted profiles remain after the deletion
+/// commits.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProfileDeletePolicy {
+    /// Permit zero valid persisted profiles after deletion (unrestricted).
+    AllowZero,
+    /// Require at least `minimum` valid persisted profiles to remain.
+    RequireMinimumValid(usize),
+}
+
+impl ProfileDeletePolicy {
+    /// The minimum valid-profile count this policy requires to remain, or zero
+    /// for [`ProfileDeletePolicy::AllowZero`].
+    pub fn minimum(self) -> usize {
+        match self {
+            ProfileDeletePolicy::AllowZero => 0,
+            ProfileDeletePolicy::RequireMinimumValid(minimum) => minimum,
+        }
+    }
+}
+
+/// Why a raw persisted profile record failed record-local validity
+/// classification.
+///
+/// This is the single source of truth used by both management reads (to build
+/// per-record diagnostics) and policy-aware deletion counting (to decide
+/// whether a row counts as a valid profile). A record counts as valid only when
+/// [`classify_profile_record`] returns [`Ok`].
+#[derive(Debug, Clone, PartialEq)]
+pub enum ProfileRecordError {
+    /// The record's schema version is not the supported profile schema version.
+    UnsupportedSchemaVersion {
+        /// The unsupported schema version stored alongside the payload.
+        actual: i64,
+    },
+    /// The payload decoded far enough to reveal an approval value that is not a
+    /// valid user-facing managed profile approval policy.
+    ReadOnlyRejected {
+        /// The rejected approval value found in the payload.
+        approval: String,
+    },
+    /// The payload could not be decoded as an [`AgentProfile`] for any other
+    /// reason.
+    DecodeFailure {
+        /// The underlying deserialization error message.
+        error: String,
+    },
+    /// The payload decoded but one or more structural fields failed validation.
+    InvalidFields {
+        /// One human-readable message per failed field check.
+        messages: Vec<String>,
+    },
+}
+
+/// Classify a raw persisted profile record using the same rules that decide
+/// whether management listing returns a ready profile record.
+///
+/// A record is valid only when its schema version equals
+/// [`PROFILE_SCHEMA_VERSION`], its payload decodes as [`AgentProfile`], and its
+/// stable ID and decoded fields pass the structural validation shared with
+/// management reads (protected-default identity and supported approval rules).
+///
+/// This function is pure and allocation-bounded; it performs no I/O and does
+/// not consult registry membership, provider credentials, or prompt references.
+pub fn classify_profile_record(
+    id: &str,
+    schema_version: i64,
+    payload: &serde_json::Value,
+) -> Result<AgentProfile, ProfileRecordError> {
+    if schema_version != PROFILE_SCHEMA_VERSION {
+        return Err(ProfileRecordError::UnsupportedSchemaVersion {
+            actual: schema_version,
+        });
+    }
+    match serde_json::from_value::<AgentProfile>(payload.clone()) {
+        Ok(profile) => {
+            let messages = validate_profile_fields(id, &profile);
+            if messages.is_empty() {
+                Ok(profile)
+            } else {
+                Err(ProfileRecordError::InvalidFields { messages })
+            }
+        }
+        Err(error) => {
+            let rejected = payload
+                .get("approval")
+                .and_then(|value| value.as_str())
+                .filter(|approval| matches!(*approval, "ReadOnly" | "RequireApproval"));
+            if let Some(approval) = rejected {
+                Err(ProfileRecordError::ReadOnlyRejected {
+                    approval: approval.to_string(),
+                })
+            } else {
+                Err(ProfileRecordError::DecodeFailure {
+                    error: error.to_string(),
+                })
+            }
+        }
+    }
+}
+
+/// Validate a decoded profile's structural fields, returning one message per
+/// failed check. An empty vector means the profile is structurally valid.
+pub(crate) fn validate_profile_fields(id: &str, profile: &AgentProfile) -> Vec<String> {
+    let mut messages = Vec::new();
+    if !is_valid_profile_id(id) {
+        messages.push(format!("Profile ID '{}' is invalid or reserved", id));
+    }
+    if normalize_profile_name(&profile.name).is_none() {
+        messages.push(format!(
+            "Profile name '{}' is invalid or reserved",
+            profile.name
+        ));
+    }
+    if let AgentProfileProvider::Managed {
+        provider_slug,
+        model,
+    } = &profile.provider
+    {
+        if provider_slug.as_str().trim().is_empty() || model.trim().is_empty() {
+            messages.push("Managed profile has empty provider_slug or model".to_string());
+        }
+    }
+    messages
+}
+
 /// Build a managed `ProviderPromptContext` from a profile without a profile API key.
 pub fn managed_profile_prompt_context(
     provider: &AgentProfileProvider,
@@ -621,5 +753,85 @@ mod tests {
             profile.effective_identity_prompt(),
             default_identity_prompt()
         );
+    }
+
+    #[test]
+    fn classify_valid_profile_record() {
+        let payload = serde_json::to_value(AgentProfile::with_name("Valid")).unwrap();
+        let result = classify_profile_record("prof", PROFILE_SCHEMA_VERSION, &payload);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().name, "Valid");
+    }
+
+    #[test]
+    fn classify_unsupported_schema_version() {
+        let payload = serde_json::to_value(AgentProfile::with_name("Valid")).unwrap();
+        let result = classify_profile_record("prof", 999, &payload);
+        assert_eq!(
+            result,
+            Err(ProfileRecordError::UnsupportedSchemaVersion { actual: 999 })
+        );
+    }
+
+    #[test]
+    fn classify_malformed_json_payload() {
+        let payload = serde_json::json!({"unexpected": true});
+        let result = classify_profile_record("prof", PROFILE_SCHEMA_VERSION, &payload);
+        assert!(matches!(
+            result,
+            Err(ProfileRecordError::DecodeFailure { .. })
+        ));
+    }
+
+    #[test]
+    fn classify_read_only_approval_rejected() {
+        let mut payload = serde_json::to_value(AgentProfile::with_name("Valid")).unwrap();
+        payload
+            .as_object_mut()
+            .unwrap()
+            .insert("approval".to_string(), serde_json::json!("ReadOnly"));
+        let result = classify_profile_record("prof", PROFILE_SCHEMA_VERSION, &payload);
+        assert_eq!(
+            result,
+            Err(ProfileRecordError::ReadOnlyRejected {
+                approval: "ReadOnly".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn classify_reserved_default_id_invalid() {
+        let payload = serde_json::to_value(AgentProfile::with_name("Valid")).unwrap();
+        let result = classify_profile_record("default", PROFILE_SCHEMA_VERSION, &payload);
+        assert!(matches!(
+            result,
+            Err(ProfileRecordError::InvalidFields { .. })
+        ));
+    }
+
+    #[test]
+    fn classify_structurally_invalid_fields() {
+        let profile = AgentProfile {
+            name: String::new(),
+            ..AgentProfile::with_name("placeholder")
+        };
+        let mut payload = serde_json::to_value(profile).unwrap();
+        payload
+            .as_object_mut()
+            .unwrap()
+            .insert("name".to_string(), serde_json::json!(""));
+        let result = classify_profile_record("prof", PROFILE_SCHEMA_VERSION, &payload);
+        match result {
+            Err(ProfileRecordError::InvalidFields { messages }) => {
+                assert!(messages.iter().any(|m| m.contains("Profile name")));
+            }
+            other => panic!("expected InvalidFields, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn delete_policy_minimum_resolves() {
+        assert_eq!(ProfileDeletePolicy::AllowZero.minimum(), 0);
+        assert_eq!(ProfileDeletePolicy::RequireMinimumValid(3).minimum(), 3);
     }
 }

--- a/tests/profile_deletion_policy_tests.rs
+++ b/tests/profile_deletion_policy_tests.rs
@@ -1,0 +1,405 @@
+//! ConfigStore-level tests for the atomic minimum-valid-profile deletion
+//! policy and its cross-connection concurrency guarantees.
+
+use iron_core::config::crypto::XChaCha20Poly1305Cipher;
+use iron_core::config::{ConfigError, ConfigStore, OpenOptions, ProfileInput, PromptInput};
+use iron_core::profile::{
+    AgentProfile, AgentProfileId, ProfileDeletePolicy, PROFILE_SCHEMA_VERSION,
+};
+use iron_core::stored_prompt::{normalize_prompt_name, StoredPrompt, STORED_PROMPT_SCHEMA_VERSION};
+use serde_json::json;
+use std::sync::Arc;
+
+/// Persist a structurally valid profile under the current schema version.
+async fn save_valid_profile(store: &ConfigStore, id: &str, name: &str) {
+    store
+        .set_profile(&ProfileInput {
+            id: id.to_string(),
+            schema_version: PROFILE_SCHEMA_VERSION,
+            payload: serde_json::to_value(AgentProfile::with_name(name)).unwrap(),
+        })
+        .await
+        .unwrap();
+}
+
+/// Persist a raw profile row bypassing typed validation.
+async fn save_raw_profile(
+    store: &ConfigStore,
+    id: &str,
+    schema_version: i64,
+    payload: serde_json::Value,
+) {
+    store
+        .set_profile(&ProfileInput {
+            id: id.to_string(),
+            schema_version,
+            payload,
+        })
+        .await
+        .unwrap();
+}
+
+/// Persist a prompt that directly references a profile.
+async fn save_prompt_referencing(store: &ConfigStore, id: &str, display: &str, profile_id: &str) {
+    let prompt = StoredPrompt {
+        display_name: display.to_string(),
+        normalized_name: normalize_prompt_name(display),
+        instructions: "Do the work".to_string(),
+        skills: vec![],
+        profile: Some(AgentProfileId::from(profile_id)),
+    };
+    store
+        .set_prompt(&PromptInput {
+            id: id.to_string(),
+            schema_version: STORED_PROMPT_SCHEMA_VERSION,
+            payload: serde_json::to_value(&prompt).unwrap(),
+            display_name: display.to_string(),
+            normalized_name: normalize_prompt_name(display),
+        })
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn require_minimum_rejects_deleting_only_valid_profile() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+    save_valid_profile(&store, "prof", "Profile").await;
+
+    let err = store
+        .delete_profile_with_policy("prof", ProfileDeletePolicy::RequireMinimumValid(1))
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        ConfigError::MinimumValidProfiles {
+            minimum: 1,
+            remaining: 0
+        }
+    ));
+    assert!(store.get_profile("prof").await.unwrap().is_some());
+}
+
+#[tokio::test]
+async fn malformed_unsupported_and_invalid_records_do_not_satisfy_minimum() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+    save_valid_profile(&store, "valid", "Valid").await;
+    // Malformed JSON payload.
+    save_raw_profile(
+        &store,
+        "malformed",
+        PROFILE_SCHEMA_VERSION,
+        json!({"nope": true}),
+    )
+    .await;
+    // Unsupported schema version with an otherwise valid payload.
+    save_raw_profile(
+        &store,
+        "unsupported",
+        999,
+        serde_json::to_value(AgentProfile::with_name("Unsupported")).unwrap(),
+    )
+    .await;
+    // Structurally invalid: empty name.
+    save_raw_profile(
+        &store,
+        "invalid-name",
+        PROFILE_SCHEMA_VERSION,
+        json!({"name": ""}),
+    )
+    .await;
+
+    let err = store
+        .delete_profile_with_policy("valid", ProfileDeletePolicy::RequireMinimumValid(1))
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        ConfigError::MinimumValidProfiles {
+            minimum: 1,
+            remaining: 0
+        }
+    ));
+}
+
+#[tokio::test]
+async fn deleting_invalid_target_contributes_zero_to_count() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+    save_valid_profile(&store, "valid", "Valid").await;
+    save_raw_profile(
+        &store,
+        "malformed",
+        PROFILE_SCHEMA_VERSION,
+        json!({"nope": true}),
+    )
+    .await;
+    save_raw_profile(
+        &store,
+        "unsupported",
+        999,
+        serde_json::to_value(AgentProfile::with_name("Unsupported")).unwrap(),
+    )
+    .await;
+    save_raw_profile(
+        &store,
+        "invalid-name",
+        PROFILE_SCHEMA_VERSION,
+        json!({"name": ""}),
+    )
+    .await;
+
+    for target in &["malformed", "unsupported", "invalid-name"] {
+        store
+            .delete_profile_with_policy(target, ProfileDeletePolicy::RequireMinimumValid(1))
+            .await
+            .unwrap();
+        assert!(
+            store.get_profile("valid").await.unwrap().is_some(),
+            "valid profile must remain after deleting {}",
+            target
+        );
+    }
+}
+
+#[tokio::test]
+async fn deleting_missing_target_with_satisfied_minimum_is_idempotent() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+    save_valid_profile(&store, "valid", "Valid").await;
+
+    store
+        .delete_profile_with_policy("missing", ProfileDeletePolicy::RequireMinimumValid(1))
+        .await
+        .unwrap();
+    assert!(store.get_profile("valid").await.unwrap().is_some());
+}
+
+#[tokio::test]
+async fn missing_or_invalid_target_rejected_when_postcondition_unsatisfied() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+    // No valid profiles at all; a minimum of 1 cannot be satisfied.
+    save_raw_profile(
+        &store,
+        "malformed",
+        PROFILE_SCHEMA_VERSION,
+        json!({"nope": true}),
+    )
+    .await;
+
+    let err = store
+        .delete_profile_with_policy("missing", ProfileDeletePolicy::RequireMinimumValid(1))
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        ConfigError::MinimumValidProfiles {
+            minimum: 1,
+            remaining: 0
+        }
+    ));
+
+    let err = store
+        .delete_profile_with_policy("malformed", ProfileDeletePolicy::RequireMinimumValid(1))
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        ConfigError::MinimumValidProfiles {
+            minimum: 1,
+            remaining: 0
+        }
+    ));
+}
+
+#[tokio::test]
+async fn zero_minimum_permits_deleting_final_valid_profile() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+    save_valid_profile(&store, "valid", "Valid").await;
+
+    store
+        .delete_profile_with_policy("valid", ProfileDeletePolicy::RequireMinimumValid(0))
+        .await
+        .unwrap();
+    assert!(store.get_profile("valid").await.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn unrestricted_deletion_removes_final_valid_profile() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+    save_valid_profile(&store, "valid", "Valid").await;
+
+    store.delete_profile("valid").await.unwrap();
+    assert!(store.get_profile("valid").await.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn unrestricted_deletion_cleans_up_invalid_record() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+    save_raw_profile(
+        &store,
+        "malformed",
+        PROFILE_SCHEMA_VERSION,
+        json!({"nope": true}),
+    )
+    .await;
+
+    store.delete_profile_checked("malformed").await.unwrap();
+    assert!(store.get_profile_raw("malformed").await.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn prompt_reference_conflict_precedes_minimum_failure() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+    save_valid_profile(&store, "prof", "Profile").await;
+    save_prompt_referencing(&store, "prompt-a", "Alpha", "prof").await;
+
+    let err = store
+        .delete_profile_with_policy("prof", ProfileDeletePolicy::RequireMinimumValid(1))
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        ConfigError::ProfileReferencedByPrompts { .. }
+    ));
+    assert!(store.get_profile("prof").await.unwrap().is_some());
+}
+
+#[tokio::test]
+async fn minimum_failure_preserves_target_and_other_records() {
+    let store = ConfigStore::open_in_memory().await.unwrap();
+    save_valid_profile(&store, "alpha", "Alpha").await;
+    save_valid_profile(&store, "beta", "Beta").await;
+
+    let err = store
+        .delete_profile_with_policy("alpha", ProfileDeletePolicy::RequireMinimumValid(2))
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        ConfigError::MinimumValidProfiles {
+            minimum: 2,
+            remaining: 1
+        }
+    ));
+    assert!(store.get_profile("alpha").await.unwrap().is_some());
+    assert!(store.get_profile("beta").await.unwrap().is_some());
+}
+
+// ============================================================================
+// Cross-connection concurrency
+// ============================================================================
+
+/// Shared cipher so two file-backed stores can read the same database.
+fn shared_cipher() -> Arc<dyn iron_core::config::crypto::CredentialCipher> {
+    let key = XChaCha20Poly1305Cipher::generate_key();
+    Arc::new(XChaCha20Poly1305Cipher::new(&key))
+}
+
+async fn open_file_store(
+    path: &std::path::Path,
+    cipher: Arc<dyn iron_core::config::crypto::CredentialCipher>,
+) -> ConfigStore {
+    ConfigStore::open_at_with_options(
+        path,
+        OpenOptions {
+            cipher: Some(cipher),
+            busy_timeout: None,
+        },
+    )
+    .await
+    .unwrap()
+}
+
+#[tokio::test]
+async fn concurrent_deletions_leave_at_least_one_valid_profile() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("policy.db");
+    let cipher = shared_cipher();
+
+    // Seed both profiles through the first client.
+    {
+        let store = open_file_store(&db_path, cipher.clone()).await;
+        save_valid_profile(&store, "alpha", "Alpha").await;
+        save_valid_profile(&store, "beta", "Beta").await;
+    }
+
+    let store_a = open_file_store(&db_path, cipher.clone()).await;
+    let store_b = open_file_store(&db_path, cipher).await;
+
+    // Both clients concurrently delete a different valid profile while
+    // requiring at least one valid profile to remain.
+    let (result_a, result_b) = tokio::join!(
+        store_a.delete_profile_with_policy("alpha", ProfileDeletePolicy::RequireMinimumValid(1)),
+        store_b.delete_profile_with_policy("beta", ProfileDeletePolicy::RequireMinimumValid(1)),
+    );
+
+    let successes = [&result_a, &result_b].iter().filter(|r| r.is_ok()).count();
+    assert!(
+        successes <= 1,
+        "at most one concurrent deletion may succeed, got {} (a={:?}, b={:?})",
+        successes,
+        result_a.as_ref().err(),
+        result_b.as_ref().err()
+    );
+
+    // At least one valid profile remains durably.
+    let a_present = store_a.get_profile("alpha").await.unwrap().is_some();
+    let b_present = store_a.get_profile("beta").await.unwrap().is_some();
+    assert!(
+        a_present || b_present,
+        "at least one valid profile must remain"
+    );
+    // Exactly one remains.
+    assert_eq!(a_present as u8 + b_present as u8, 1);
+
+    // The loser must receive a typed minimum-valid-profile failure (the second
+    // deleter observes the first's committed state, not the stale snapshot).
+    let loser = if result_a.is_ok() {
+        &result_b
+    } else {
+        &result_a
+    };
+    match loser.as_ref().unwrap_err() {
+        ConfigError::MinimumValidProfiles { minimum, remaining } => {
+            assert_eq!(*minimum, 1);
+            assert_eq!(*remaining, 0);
+        }
+        other => panic!("expected typed MinimumValidProfiles, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn prompt_reference_protection_survives_concurrent_unrelated_writer() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("refs.db");
+    let cipher = shared_cipher();
+
+    // profile "prof" is referenced by a prompt; "other" is unreferenced.
+    {
+        let store = open_file_store(&db_path, cipher.clone()).await;
+        save_valid_profile(&store, "prof", "Profile").await;
+        save_valid_profile(&store, "other", "Other").await;
+        save_prompt_referencing(&store, "prompt-a", "Alpha", "prof").await;
+    }
+
+    let store_a = open_file_store(&db_path, cipher.clone()).await;
+    let store_b = open_file_store(&db_path, cipher).await;
+
+    // Concurrently: delete the referenced profile (must stay blocked) and
+    // delete the unrelated profile (must succeed). The write reservation
+    // serializes them, and the prompt-reference check is not bypassed.
+    let (delete_prof, delete_other) = tokio::join!(
+        store_a.delete_profile_with_policy("prof", ProfileDeletePolicy::AllowZero),
+        store_b.delete_profile_with_policy("other", ProfileDeletePolicy::AllowZero),
+    );
+
+    assert!(
+        matches!(
+            delete_prof.unwrap_err(),
+            ConfigError::ProfileReferencedByPrompts { .. }
+        ),
+        "referenced profile must remain protected under concurrency"
+    );
+    delete_other.unwrap();
+
+    assert!(store_a.get_profile("prof").await.unwrap().is_some());
+    assert!(store_a.get_profile("other").await.unwrap().is_none());
+}


### PR DESCRIPTION
## Summary

Closes #100.

Adds an opt-in `ProfileDeletePolicy` so consumers can require a minimum number of valid persisted profiles to remain after deletion, closing the cross-process race where two clients each observe the same count snapshot and delete different profiles.

- **Atomic policy-aware deletion** — `ConfigStore::delete_profile_with_policy` acquires the SQLite write reservation (`BEGIN IMMEDIATE`) before reading prompt or profile state, then runs prompt integrity → prompt reference → valid-profile counting → minimum enforcement → delete in one transaction.
- **Shared validity rule** — centralized `classify_profile_record` is now the single source of truth for management reads, dependency-impact traversal, and deletion counting. A row counts only when schema is supported, it decodes as `AgentProfile`, and its ID/fields pass structural validation. Malformed/unsupported/missing targets contribute zero.
- **Typed errors** — `ConfigError::MinimumValidProfiles { minimum, remaining }` mapped to a matching `ManagementError` variant; adapters branch without parsing strings.
- **Backward compatible** — existing `delete_profile` / `delete_profile_checked` delegate to `AllowZero`, preserving current unrestricted behavior.

## Store behavior

```
BEGIN IMMEDIATE
  -> verify supported prompt schemas
  -> decode prompts, identify direct references
  -> reject integrity-unknown / reference conflicts (precedence)
  -> read & classify all profile rows
  -> remaining = total_valid - (target_is_valid ? 1 : 0)
  -> reject when remaining < requested minimum
  -> DELETE target row
COMMIT
```

Prompt-reference and integrity failures retain precedence over the minimum check. Post-commit profile-registry synchronization preserves the existing typed partial-operation behavior.

## Verification

- `cargo fmt --check`: clean
- `cargo clippy --all-targets --all-features -- -D warnings`: no issues
- `cargo test`: 1399 passed, 0 failed
- `openspec validate --strict`: valid
- Concurrency test (two file-backed stores) verified stable across repeated runs; the loser receives a typed `MinimumValidProfiles` with `remaining == 0`.

## Includes

- `chore(deps)`: iron-providers `0.2.12` → `0.2.14`, plus pinning `get-size2` to `0.10.1` (0.10.2 splits `compact_str` and breaks the `embedded-python` build).
- `ci`: publish iron-core to crates.io via OIDC keyless auth (`rust-lang/crates-io-auth-action`), matching iron-providers. **Requires** adding a crates.io publishing identity trusting `repo:AgentIron/iron-core` before the next release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in profile deletion policy that can require a minimum number of valid profiles to remain.
  * Added clear errors when deletion would violate the requested minimum.
  * Improved profile validation and diagnostics across profile listing, reading, and deletion.
  * Added atomic safeguards for concurrent profile deletions and prompt-reference protection.

* **Bug Fixes**
  * Updated the `iron-providers` dependency.
  * Enabled authenticated publishing to crates.io in release workflows.

* **Tests**
  * Added comprehensive coverage for deletion policies, invalid records, concurrency, and integrity checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->