### PR TITLE
fix: restore published crate compatibility

### DIFF
--- a/.github/scripts/check-package-consumer.sh
+++ b/.github/scripts/check-package-consumer.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+temp_dir="$(mktemp -d)"
+consumer_dir="$temp_dir/consumer"
+trap 'rm -rf "$temp_dir"' EXIT
+
+cargo new --quiet --lib "$consumer_dir"
+cargo add --quiet \
+  --manifest-path "$consumer_dir/Cargo.toml" \
+  iron-core \
+  --path "$repo_root" \
+  --features embedded-python
+cargo build --manifest-path "$consumer_dir/Cargo.toml"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -73,3 +73,45 @@ jobs:
             } else {
               await github.rest.issues.createComment({ owner, repo, issue_number, body });
             }
+
+  platform-link:
+    name: Link (${{ matrix.os }})
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.96.0
+
+      - name: Cache Rust artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build and link all targets
+        run: cargo build --locked --manifest-path Cargo.toml --all-targets --all-features
+
+      - name: Test native scheduler adapter
+        run: cargo test --locked --manifest-path Cargo.toml --lib scheduled_task::platform
+
+  package-consumer:
+    name: Fresh embedded-python consumer
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.96.0
+
+      - name: Cache Rust artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build from a fresh consumer resolution
+        run: bash .github/scripts/check-package-consumer.sh

--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -77,6 +77,10 @@ jobs:
           cargo test --locked --manifest-path Cargo.toml
           cargo audit --file Cargo.lock
 
+      - name: Verify fresh embedded-python consumer
+        if: steps.release_gate.outputs.should_release == 'true'
+        run: bash .github/scripts/check-package-consumer.sh
+
       - name: Bump version
         if: steps.release_gate.outputs.should_release == 'true'
         id: version

--- a/.github/workflows/release-patch.yml
+++ b/.github/workflows/release-patch.yml
@@ -70,6 +70,10 @@ jobs:
           cargo test --locked --manifest-path Cargo.toml
           cargo audit --file Cargo.lock
 
+      - name: Verify fresh embedded-python consumer
+        if: steps.release_gate.outputs.should_release == 'true'
+        run: bash .github/scripts/check-package-consumer.sh
+
       - name: Bump patch version
         if: steps.release_gate.outputs.should_release == 'true'
         id: version

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2394,6 +2394,7 @@ dependencies = [
  "directories",
  "extism",
  "futures",
+ "get-size2",
  "globset",
  "grep-regex",
  "grep-searcher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,12 +74,15 @@ cfg-if = "1"
 #
 # Bump version deliberately after verifying against the iron-core test suite.
 monty = { version = "0.0.19-beta.4", optional = true }
+# get-size2 0.10.2 changed its compact_str dependency incompatibly with the
+# Ruff versions used by Monty. Remove this pin after Monty/Ruff use a compatible graph.
+get-size2 = { version = "=0.10.1", optional = true }
 num-bigint = { version = "0.4", optional = true }
 num-traits = { version = "0.2", optional = true }
 
 [features]
 default = []
-embedded-python = ["monty", "num-bigint", "num-traits"]
+embedded-python = ["monty", "get-size2", "num-bigint", "num-traits"]
 
 [[bin]]
 name = "agent-iron"

--- a/openspec/changes/fix-published-crate-consumer-regressions/.openspec.yaml
+++ b/openspec/changes/fix-published-crate-consumer-regressions/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-17

--- a/openspec/changes/fix-published-crate-consumer-regressions/design.md
+++ b/openspec/changes/fix-published-crate-consumer-regressions/design.md
@@ -1,0 +1,106 @@
+## Context
+
+Issue 102 identifies three consumer-visible regressions in 0.1.35. `scheduled_task::platform` declares all adapters on every target even though the factory selects them with `cfg_if!`; consequently the Windows archive contains launchd's unresolved `getuid` reference. The committed lockfile selects `get-size2` 0.10.1, but the published manifest permits 0.10.2, whose patch-level `compact_str` change is incompatible with Monty's Ruff graph. Finally, the facade's `checkpoint()` preserves old precondition checks but always returns a placeholder error, while `/compact` already reaches model-driven compression through `IronConnection::handle_prompt`.
+
+The current pull-request and release workflows build only on Ubuntu and use `--locked`. This validates the repository state but not the target linker or dependency graph seen by a fresh downstream consumer.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Ensure each supported target compiles and links only its native scheduler implementation.
+- Make the published `embedded-python` feature resolve to the known-compatible Monty/Ruff graph without a producer lockfile.
+- Verify package consumption through native linking and lockfile-independent dependency resolution.
+- Restore `AgentSession::checkpoint()` as a facade entry point to the existing model-driven compaction turn.
+- Keep each fix independently releasable and independently covered by regression tests.
+
+**Non-Goals:**
+
+- Redesign host scheduler adapters or their public contract.
+- Fork or patch Monty, Ruff, `get-size2`, or `compact_str` source code.
+- Permanently own transitive version selection after upstream dependencies become compatible.
+- Reintroduce hidden summarizer-based compaction or guarantee that a model chooses a valid compression range.
+- Change compaction thresholds, compression range validation, or lifecycle event schemas.
+
+## Decisions
+
+### Gate adapter modules at their platform boundary
+
+Apply target configuration to the module declarations: Linux owns `cron_adapter` and `crontab`, macOS owns `launchd`, and Windows owns `task_scheduler`. This aligns compilation with the already target-gated factory and prevents unsupported foreign-function or operating-system assumptions from entering an artifact.
+
+```text
+                 scheduled_task::host factory
+                            |
+          +-----------------+-----------------+
+          |                 |                 |
+       Linux              macOS             Windows
+          |                 |                 |
+   cron_adapter          launchd       task_scheduler
+      crontab             getuid         schtasks.exe
+```
+
+Platform-independent adapter rendering tests remain colocated and run on their native CI target. If future work needs every renderer test on every host, pure conversion/rendering code can be extracted into target-neutral modules; that extraction is not required to fix the linker defect.
+
+Alternative considered: gate only `extern_uid()`. Rejected because it leaves unsupported adapters compiled on every target and perpetuates the mismatch between module documentation and actual boundaries.
+
+### Add a temporary direct compatibility constraint
+
+Declare `get-size2` as an exact, optional compatibility dependency enabled by `embedded-python`, pinned to the known-compatible 0.10.1 release. A direct published constraint participates in downstream resolution; the producer's `Cargo.lock` does not. The manifest comment records the Ruff/`compact_str` mismatch and the removal condition: upgrade Monty/Ruff to versions compatible with the newer `get-size2` graph, then remove the pin after fresh-resolution verification passes.
+
+Alternative considered: use only `<0.10.2`. This expresses the incompatibility more semantically, but an exact known-good patch minimizes exposure to another semver-breaking 0.10.x release while this is a temporary transitive guard. Alternative considered: patch crates.io source. Rejected because patches do not belong in a reusable library manifest for this case and would create source ownership overhead.
+
+### Test from the downstream consumer boundary
+
+CI will have two complementary checks:
+
+- A native Windows job runs a linking command against all relevant targets/features, catching unresolved symbols that `cargo check` cannot detect.
+- A fresh temporary consumer outside the repository workspace depends on the package/path with `embedded-python`, starts without a lockfile, and runs a build. This catches incompatible transitive updates hidden by the repository lockfile.
+
+Release workflows retain locked reproducibility checks, but package-consumer smoke verification runs before publication. The same smoke procedure should be shared or kept structurally identical across pull-request and release workflows so release behavior cannot drift.
+
+Alternative considered: run `cargo update` in the repository. Rejected because it mutates the producer lockfile and still does not accurately model a downstream package consumer. Alternative considered: use cross-compilation from Ubuntu for Windows. Rejected as the sole check because installing a cross linker is more fragile and less representative than a native runner.
+
+### Route checkpoint through the existing compact command path
+
+After preserving its idle and context-management preconditions, `AgentSession::checkpoint()` invokes the facade's error-preserving prompt path with `/compact`. `try_prompt()` already calls `IronConnection::handle_prompt`, where `/compact` is replaced by the compression-focused instruction before the prompt is added to durable history. This gives ACP and facade callers one behavior rather than duplicating prompt-runner setup or compression instructions.
+
+```text
+AgentSession::checkpoint()
+          |
+          v
+ AgentSession::try_prompt("/compact")
+          |
+          v
+ IronConnection::handle_prompt
+          |
+          +--> replace command with compaction instruction
+          +--> run model turn with built-in compress tool
+```
+
+`checkpoint()` returns `Ok(())` when the compression-focused prompt turn completes and propagates connection-level prompt failures. It does not claim that the model necessarily selected a useful valid range; durable compressed-block changes and lifecycle events remain the authoritative evidence of actual compaction.
+
+Alternative considered: duplicate the prompt runner and invoke `compress` directly. Rejected because summaries and ranges are model-authored, and a second orchestration path would drift from `/compact` behavior.
+
+## Risks / Trade-offs
+
+- [Gating whole adapter modules reduces cross-host unit-test coverage] -> Run adapter tests on native target jobs and defer pure-renderer extraction unless CI cost or platform availability requires it.
+- [An exact transitive pin can block a compatible patch] -> Document it as temporary and remove it only with an upstream Monty/Ruff upgrade plus fresh-resolution coverage.
+- [Native Windows CI increases latency and runner cost] -> Keep the job focused on linking and targeted tests rather than duplicating every Linux quality check.
+- [Fresh resolution can fail because of unrelated registry changes] -> Treat this as intentional early warning for a published library; preserve locked checks for deterministic diagnosis.
+- [A model-driven checkpoint turn may complete without compacting] -> Define success as successful execution of the requested turn and verify durable compaction separately in integration tests where the mock model calls `compress`.
+- [Idle precheck races with another prompt] -> Rely on the existing runtime prompt-start guard as the final authority and propagate its failure.
+
+## Migration Plan
+
+1. Add target gates and verify native Linux, macOS, and Windows compilation paths as available.
+2. Add the temporary compatibility dependency, regenerate the repository lockfile, and prove a clean external consumer can build `embedded-python`.
+3. Add consumer-focused CI checks to pull-request and release gates before publication.
+4. Route facade checkpoint through the shared compact turn and replace the placeholder regression assertion with model-driven behavior tests.
+5. Publish a patch release and verify a fresh crates.io consumer on Windows and with `embedded-python`.
+
+Rollback can revert the checkpoint routing and CI changes independently. The compatibility pin must not be removed in a rollback unless the published dependency graph is otherwise constrained to a verified compatible set; target gates should remain because removing them restores the Windows linker defect.
+
+## Open Questions
+
+- Should native macOS linking become a required pull-request check now that launchd tests no longer compile on Linux, or is release-time macOS verification sufficient?
+- Should the downstream smoke fixture consume an unpacked `cargo package` artifact for maximum fidelity, or is an external path dependency adequate if `cargo package --list` is checked separately?

--- a/openspec/changes/fix-published-crate-consumer-regressions/proposal.md
+++ b/openspec/changes/fix-published-crate-consumer-regressions/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+The published `iron-core` 0.1.35 crate cannot link on Windows and cannot build with `embedded-python` after a fresh dependency resolution, even though the repository's locked Linux CI passes. The same report also exposes a facade API regression: `AgentSession::checkpoint()` is publicly available but can only return a placeholder error instead of entering the model-driven compaction flow.
+
+## What Changes
+
+- Compile only the scheduled-task host adapter for the current target while preserving platform-independent rendering tests on appropriate targets.
+- Constrain the incompatible `get-size2` transitive release in the published dependency graph until the Monty/Ruff dependency chain can be upgraded coherently.
+- Add package-consumer verification that links on Windows and resolves `embedded-python` without inheriting the repository lockfile.
+- Make `AgentSession::checkpoint()` initiate the existing model-driven compression turn and report whether compaction completed successfully.
+- Add regression coverage for target linking, fresh dependency resolution, and facade-level checkpoint behavior.
+
+## Capabilities
+
+### New Capabilities
+
+- `published-crate-compatibility`: Defines cross-target linking and fresh-resolution checks from the perspective of a downstream crates.io consumer.
+
+### Modified Capabilities
+
+- `scheduled-automation-tasks`: Require platform-specific host adapter implementations to compile only on their supported targets.
+- `dependency-version-guidance`: Require embedded-Python dependency constraints to preserve a coherent fresh-resolve graph and document temporary compatibility pins.
+- `context-compaction`: Require facade checkpoint calls to invoke model-driven compaction rather than return an unconditional placeholder error.
+
+## Impact
+
+- Scheduled-task platform module declarations and target-specific adapter tests.
+- `Cargo.toml` dependency constraints and the resolved `Cargo.lock`.
+- Pull-request and release verification workflows, including a Windows linker job and a lockfile-independent consumer fixture or package smoke test.
+- `AgentSession::checkpoint()`, the shared `/compact` prompt transformation, and context-management integration tests.
+- Published crate behavior for Windows users and consumers enabling `embedded-python`; no intended breaking API change.

--- a/openspec/changes/fix-published-crate-consumer-regressions/specs/context-compaction/spec.md
+++ b/openspec/changes/fix-published-crate-consumer-regressions/specs/context-compaction/spec.md
@@ -1,0 +1,20 @@
+## MODIFIED Requirements
+
+### Requirement: Slash compact runs an immediate compression turn
+The `/compact` command and facade checkpoint operation SHALL immediately run a model turn whose task is to compress resolved context through the `compress` tool. Both entry points SHALL use the same model-driven compaction instruction and SHALL NOT execute a hidden runtime summarizer.
+
+#### Scenario: User invokes compact command
+- **WHEN** the user invokes `/compact`
+- **THEN** the runtime starts a compression-focused model turn immediately
+- **AND** the model receives a strong compression nudge
+- **AND** hidden runtime summarizer compaction is not executed
+
+#### Scenario: Facade consumer invokes checkpoint
+- **WHEN** a facade consumer calls `AgentSession::checkpoint()` for an idle session with context management enabled
+- **THEN** the runtime starts the same compression-focused model turn used by `/compact`
+- **AND** the checkpoint call reports prompt execution failures instead of returning an unconditional not-implemented error
+
+#### Scenario: Checkpoint preconditions fail
+- **WHEN** a facade consumer calls `AgentSession::checkpoint()` while the session is active or context management is disabled
+- **THEN** the call returns an actionable precondition error
+- **AND** no compression turn starts

--- a/openspec/changes/fix-published-crate-consumer-regressions/specs/dependency-version-guidance/spec.md
+++ b/openspec/changes/fix-published-crate-consumer-regressions/specs/dependency-version-guidance/spec.md
@@ -1,0 +1,14 @@
+## ADDED Requirements
+
+### Requirement: Embedded Python dependency graph SHALL remain resolvable
+The project SHALL constrain known-incompatible transitive releases required by `embedded-python` until the owning direct dependency can be upgraded to a compatible graph. Compatibility constraints SHALL be included in the published manifest rather than relying on the repository lockfile.
+
+#### Scenario: Incompatible get-size2 patch is excluded
+- **WHEN** a consumer freshly resolves `iron-core` with `embedded-python`
+- **THEN** Cargo does not select a `get-size2` release whose `compact_str` type is incompatible with the Ruff dependency graph
+- **AND** `ruff_python_ast` derives its size implementation successfully
+
+#### Scenario: Temporary compatibility constraint is documented
+- **WHEN** a maintainer inspects the embedded-Python dependencies in `Cargo.toml`
+- **THEN** the manifest identifies the upstream incompatibility guarded by the constraint
+- **AND** states the condition under which the constraint can be removed

--- a/openspec/changes/fix-published-crate-consumer-regressions/specs/published-crate-compatibility/spec.md
+++ b/openspec/changes/fix-published-crate-consumer-regressions/specs/published-crate-compatibility/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: Published crate SHALL link on supported targets
+The packaged `iron-core` crate SHALL compile and link on Linux, macOS, and Windows without referencing symbols unavailable on the selected target.
+
+#### Scenario: Windows consumer links iron-core
+- **WHEN** CI builds a downstream consumer of the packaged crate on a native Windows runner
+- **THEN** the consumer links successfully
+- **AND** no macOS or Unix-only scheduler symbol is included in the Windows artifact
+
+#### Scenario: Supported platform verification exercises the linker
+- **WHEN** CI verifies a supported native target
+- **THEN** it runs a build or test command that performs linking rather than relying only on `cargo check`
+
+### Requirement: Published features SHALL build from a fresh resolution
+The packaged `iron-core` crate SHALL build with each supported public feature combination when resolved without the repository's `Cargo.lock`.
+
+#### Scenario: Fresh embedded-Python consumer resolves dependencies
+- **WHEN** CI creates a new downstream crate with no existing lockfile and enables `iron-core/embedded-python`
+- **THEN** Cargo resolves one compatible dependency graph
+- **AND** the downstream crate builds successfully
+
+#### Scenario: Consumer verification uses packaged metadata
+- **WHEN** CI verifies lockfile-independent resolution
+- **THEN** it consumes the package contents or an equivalent downstream path dependency from outside the repository workspace
+- **AND** it does not copy or inherit the repository `Cargo.lock`

--- a/openspec/changes/fix-published-crate-consumer-regressions/specs/scheduled-automation-tasks/spec.md
+++ b/openspec/changes/fix-published-crate-consumer-regressions/specs/scheduled-automation-tasks/spec.md
@@ -1,0 +1,14 @@
+## ADDED Requirements
+
+### Requirement: Host adapter compilation SHALL follow the target platform
+Platform-specific host scheduler implementation modules SHALL compile only for their supported target operating system. Target-independent scheduling contracts MAY remain available on every target.
+
+#### Scenario: Windows excludes launchd implementation
+- **WHEN** `iron-core` is compiled for Windows
+- **THEN** the macOS launchd implementation is excluded from the artifact
+- **AND** no reference to the Unix `getuid` symbol is emitted
+
+#### Scenario: Platform factory resolves an available module
+- **WHEN** the host scheduler factory is compiled for Linux, macOS, or Windows
+- **THEN** the adapter selected by its target-specific branch is available for that target
+- **AND** adapters for other targets are not required to compile or link

--- a/openspec/changes/fix-published-crate-consumer-regressions/tasks.md
+++ b/openspec/changes/fix-published-crate-consumer-regressions/tasks.md
@@ -33,5 +33,5 @@
 - [x] 5.2 Run `cargo clippy --locked --manifest-path Cargo.toml --all-targets --all-features -- -D warnings`
 - [x] 5.3 Run `cargo test --locked --manifest-path Cargo.toml` and the targeted context-management tests
 - [x] 5.4 Run the fresh external `embedded-python` consumer build without a preexisting lockfile
-- [ ] 5.5 Confirm native Windows CI performs a successful link and native macOS CI compiles the launchd adapter
+- [x] 5.5 Confirm native Windows CI performs a successful link and native macOS CI compiles the launchd adapter
 - [x] 5.6 Run `openspec validate fix-published-crate-consumer-regressions --strict`

--- a/openspec/changes/fix-published-crate-consumer-regressions/tasks.md
+++ b/openspec/changes/fix-published-crate-consumer-regressions/tasks.md
@@ -1,0 +1,37 @@
+## 1. Platform-Correct Scheduler Compilation
+
+- [x] 1.1 Add target configuration to the scheduled-task platform module declarations for Linux cron/crontab, macOS launchd, and Windows Task Scheduler
+- [x] 1.2 Update any imports or tests that assume foreign platform adapter modules are available on the current target
+- [x] 1.3 Verify the Linux scheduler factory and adapter tests still compile and pass after module gating
+- [x] 1.4 Add native Windows linking coverage that builds `iron-core` with the supported feature set and catches unresolved platform symbols
+- [x] 1.5 Add or confirm native macOS coverage for launchd compilation and its colocated rendering tests
+
+## 2. Fresh Embedded-Python Resolution
+
+- [x] 2.1 Add an optional exact `get-size2` 0.10.1 compatibility dependency to `Cargo.toml` and enable it only through `embedded-python`
+- [x] 2.2 Document the upstream Ruff/`compact_str` incompatibility and the condition for removing the temporary constraint
+- [x] 2.3 Regenerate `Cargo.lock` and verify the embedded-Python graph contains the compatible `get-size2` and `compact_str` versions
+- [x] 2.4 Add an external consumer smoke test with no inherited lockfile that enables `embedded-python` and builds against the package contents or equivalent external path dependency
+
+## 3. Facade Checkpoint Compaction
+
+- [x] 3.1 Route `AgentSession::checkpoint()` through the error-preserving `/compact` prompt path after its existing idle and context-management precondition checks
+- [x] 3.2 Replace the placeholder-error regression test with a mock-provider flow that invokes `compress` and verifies durable compressed context is produced
+- [x] 3.3 Add checkpoint tests for prompt execution failure propagation and preserve tests for disabled context management and active-session rejection
+- [x] 3.4 Verify direct facade `prompt("/compact")` and `checkpoint()` receive the same compression-focused instruction without persisting the literal command
+
+## 4. Consumer CI And Release Gates
+
+- [x] 4.1 Integrate the native Windows linker check into pull-request CI using the pinned Rust toolchain
+- [x] 4.2 Integrate the lockfile-independent embedded-Python consumer smoke test into pull-request CI
+- [x] 4.3 Run the same consumer smoke checks before publication in patch and manual release workflows without replacing the existing locked reproducibility checks
+- [x] 4.4 Keep duplicated workflow commands synchronized through a shared script or an explicitly identical command sequence
+
+## 5. Verification
+
+- [x] 5.1 Run `cargo fmt --manifest-path Cargo.toml -- --check`
+- [x] 5.2 Run `cargo clippy --locked --manifest-path Cargo.toml --all-targets --all-features -- -D warnings`
+- [x] 5.3 Run `cargo test --locked --manifest-path Cargo.toml` and the targeted context-management tests
+- [x] 5.4 Run the fresh external `embedded-python` consumer build without a preexisting lockfile
+- [ ] 5.5 Confirm native Windows CI performs a successful link and native macOS CI compiles the launchd adapter
+- [x] 5.6 Run `openspec validate fix-published-crate-consumer-regressions --strict`

--- a/src/facade.rs
+++ b/src/facade.rs
@@ -2486,9 +2486,7 @@ impl AgentSession {
             return Err("Context management is not enabled".into());
         }
 
-        // Checkpointing is now model-driven via the compress tool.
-        // Hidden runtime compaction has been removed.
-        Err("Checkpoint is not yet implemented with model-driven compression".into())
+        self.try_prompt("/compact").await.map(|_| ())
     }
 
     /// Export a handoff bundle for transferring this session to another agent.

--- a/src/scheduled_task/platform/mod.rs
+++ b/src/scheduled_task/platform/mod.rs
@@ -4,7 +4,11 @@
 //! compilation and content rendering logic is platform-independent so it
 //! can be tested on any host.
 
+#[cfg(target_os = "linux")]
 pub mod cron_adapter;
+#[cfg(target_os = "linux")]
 pub mod crontab;
+#[cfg(target_os = "macos")]
 pub mod launchd;
+#[cfg(target_os = "windows")]
 pub mod task_scheduler;

--- a/tests/context_management_tests.rs
+++ b/tests/context_management_tests.rs
@@ -889,6 +889,31 @@ impl iron_providers::Provider for MockProvider {
     }
 }
 
+#[derive(Clone)]
+struct PendingProvider;
+
+impl iron_providers::Provider for PendingProvider {
+    fn infer(
+        &self,
+        _request: iron_providers::InferenceRequest,
+    ) -> iron_providers::ProviderFuture<'_, Vec<iron_providers::ProviderEvent>> {
+        Box::pin(std::future::pending())
+    }
+
+    fn infer_stream(
+        &self,
+        _request: iron_providers::InferenceRequest,
+    ) -> iron_providers::ProviderFuture<
+        '_,
+        futures::stream::BoxStream<
+            'static,
+            iron_providers::ProviderResult<iron_providers::ProviderEvent>,
+        >,
+    > {
+        Box::pin(std::future::pending())
+    }
+}
+
 fn run_local<F>(future: F) -> F::Output
 where
     F: std::future::Future,
@@ -975,7 +1000,6 @@ fn provider_message_text(m: &iron_providers::Message) -> String {
 fn facade_checkpoint_triggers_compaction() {
     run_local(async {
         use iron_core::{Config, IronAgent, PromptOutcome};
-        use iron_providers::ProviderEvent;
 
         let provider = MockProvider::with_infer_responses(vec![
             vec![
@@ -985,11 +1009,23 @@ fn facade_checkpoint_triggers_compaction() {
                 ProviderEvent::Complete,
             ],
             vec![
-                ProviderEvent::Output {
-                    content: r#"{"objective": "Post-checkpoint", "next_step": "Continue"}"#.into(),
+                ProviderEvent::ToolCall {
+                    call: ToolCall::new(
+                        "checkpoint-compress",
+                        "compress",
+                        serde_json::json!({
+                            "topic": "Greeting",
+                            "content": [{
+                                "start_message_id": "m0001",
+                                "end_message_id": "m0002",
+                                "summary": "The user greeted the agent and the agent replied."
+                            }]
+                        }),
+                    ),
                 },
                 ProviderEvent::Complete,
             ],
+            vec![ProviderEvent::Complete],
         ]);
 
         let config = Config::new().with_context_management(
@@ -998,7 +1034,7 @@ fn facade_checkpoint_triggers_compaction() {
                 .with_maintenance_threshold(999_999),
         );
 
-        let agent = IronAgent::new(config, provider);
+        let agent = IronAgent::new(config, provider.clone());
         let conn = agent.connect();
         let session = conn.create_session().unwrap();
 
@@ -1011,23 +1047,40 @@ fn facade_checkpoint_triggers_compaction() {
         assert!(session.uncompacted_tokens() > 0);
 
         let result = session.checkpoint().await;
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("not yet implemented"));
+        assert!(result.is_ok(), "checkpoint failed: {result:?}");
+        assert_eq!(session.compressed_blocks().len(), 1);
+
+        let requests = provider.requests.lock().unwrap();
+        let checkpoint_request = &requests[1];
+        let transcript_text: String = checkpoint_request
+            .context
+            .transcript
+            .messages
+            .iter()
+            .map(provider_message_text)
+            .collect();
+        assert!(transcript_text.contains("context compaction"));
+        assert!(!transcript_text.contains("/compact"));
     });
 }
 
 #[test]
 fn facade_checkpoint_rejects_non_idle_session() {
-    use iron_core::{Config, ContextManagementConfig, IronAgent};
+    run_local(async {
+        use iron_core::{Config, ContextManagementConfig, IronAgent};
 
-    let config = Config::new().with_context_management(ContextManagementConfig::new().enabled());
+        let config =
+            Config::new().with_context_management(ContextManagementConfig::new().enabled());
+        let agent = IronAgent::new(config, PendingProvider);
+        let conn = agent.connect();
+        let session = conn.create_session().unwrap();
 
-    let provider = MockProvider::with_infer_responses(vec![]);
-    let agent = IronAgent::new(config, provider);
-    let conn = agent.connect();
-    let session = conn.create_session().unwrap();
+        let (_handle, _events) = session.prompt_stream("active prompt");
+        tokio::task::yield_now().await;
 
-    assert!(session.is_idle());
+        let error = session.checkpoint().await.unwrap_err();
+        assert!(error.contains("not idle"), "unexpected error: {error}");
+    });
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- gate scheduled-task adapters by target so Windows does not link macOS symbols
- constrain the embedded Python dependency graph to the compatible `get-size2` release
- restore facade checkpoint compaction through the existing `/compact` flow
- add native Windows/macOS linker coverage and a fresh downstream consumer smoke test

## Verification

- `cargo fmt --manifest-path Cargo.toml -- --check`
- `cargo clippy --locked --manifest-path Cargo.toml --all-targets --all-features -- -D warnings`
- `cargo test --locked --manifest-path Cargo.toml` (1,380 passed, 14 ignored)
- `bash .github/scripts/check-package-consumer.sh`
- `actionlint`
- `openspec validate fix-published-crate-consumer-regressions --strict`

Closes #102

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `AgentSession::checkpoint()` now triggers model-driven `/compact`-style context compression and returns success/failure results.

* **Bug Fixes**
  * Scheduled-task platform adapters now compile only for their supported operating systems (Linux/macOS/Windows).
  * Embedded-Python feature dependency resolution is adjusted to stay compatible for fresh downstream consumers.

* **Tests**
  * Added cross-platform build verification and downstream “fresh consumer” checks to catch packaging regressions before release.

* **Documentation**
  * Added/updated OpenSpec guidance covering consumer compatibility, platform linking, and checkpoint/compaction behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->