### PR TITLE
docs: add strict rustdoc and Pages publishing

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,64 @@
+name: Deploy Documentation
+
+on:
+  push:
+    branches:
+      - main
+
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build documentation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.96.0
+
+      - name: Cache Rust artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Generate rustdoc
+        run: |
+          RUSTDOCFLAGS="-D warnings -D missing-docs" \
+            cargo doc --manifest-path Cargo.toml --no-deps --all-features
+
+      - name: Add landing-page redirect
+        run: |
+          echo '<meta http-equiv="refresh" content="0;url=iron_core/index.html">' \
+            > target/doc/index.html
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: target/doc
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Cache Rust artifacts
         uses: Swatinem/rust-cache@v2
 
+      - name: Install Python task runner
+        run: python -m pip install invoke
+
       - name: Install cargo-audit
         run: cargo install cargo-audit --locked
 
@@ -40,6 +43,9 @@ jobs:
 
       - name: Test
         run: cargo test --locked --manifest-path Cargo.toml
+
+      - name: Documentation
+        run: inv docs
 
       - name: Security audit
         id: audit

--- a/README.md
+++ b/README.md
@@ -1,65 +1,61 @@
 # iron-core
 
-`iron-core` is the core embedding crate for AgentIron.
+`iron-core` is the core embedding crate for AgentIron. It provides the agent
+runtime, durable session state, tool registration, provider integration, and
+ACP transport adapters.
 
-It provides:
-
-- the stream-first `IronAgent` / `AgentConnection` / `AgentSession` facade
-- durable messages, timeline entries, and tool-call records
-- tool registration with JSON Schema argument validation
-- approval-gated tool execution
-- ACP-native transports for in-process, stdio, and TCP integrations
-- context compaction, active-context accounting, and handoff export/import
-- layered prompt composition with repository instruction loading and runtime context injection
-- optional embedded Python execution via the `embedded-python` feature
-- WASM integration plugins via Extism with install lifecycle, manifest extraction, session-scoped enablement, auth-gated tool availability, and a 30-second execution timeout
-
-The facade/runtime API is the supported integration surface.
+The recommended entry point for embedded applications is the stream-first
+`IronAgent` / `AgentConnection` / `AgentSession` facade. All modules and items
+that are public in the crate are part of the public API; the facade and
+`prelude` are recommendations for discovery, not a boundary around the API.
 
 ## Requirements
 
-- Rust 1.95+
-- Tokio for async embedding code
+- Rust 1.96 or newer
+- Tokio for asynchronous embedding code
 
 ## Install
 
-Use the git dependency for now:
+`iron-core` is published on crates.io. Add the released crates to your
+application:
 
 ```toml
 [dependencies]
-iron-core = { git = "https://github.com/AgentIron/iron-core", branch = "main" }
-iron-providers = "0.2.2"
+iron-core = "0.1"
+iron-providers = "0.2"
 serde_json = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 ```
 
-`iron-core` is not ready for crates.io publication yet because the optional `embedded-python` feature depends on `monty` from git until a usable crates.io release exists.
-
-If you need the built-in `python_exec` tool, enable the feature explicitly:
+The default feature set is empty. Enable `embedded-python` only when the
+built-in `python_exec` tool is needed:
 
 ```toml
 [dependencies]
-iron-core = { git = "https://github.com/AgentIron/iron-core", branch = "main", features = ["embedded-python"] }
-iron-providers = "0.2.2"
-serde_json = "1"
-tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+iron-core = { version = "0.1", features = ["embedded-python"] }
 ```
 
 ## Quick Start
 
-```rust,ignore
+The following example compiles as a documentation test but is not run because
+it reads an API key and sends a provider request over the network.
+
+```rust,no_run
 use iron_core::{Config, FunctionTool, IronAgent, PromptEvent, ToolDefinition};
 use iron_providers::{ApiFamily, ProviderConnection, ProviderProfile, RuntimeConfig};
 use serde_json::json;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let config = Config::new().with_model("gpt-4o");
     let provider = ProviderConnection::from_profile(
-        ProviderProfile::new("openai", ApiFamily::Responses, "https://api.openai.com/v1"),
+        ProviderProfile::new(
+            "openai",
+            ApiFamily::Responses,
+            "https://api.openai.com/v1",
+        ),
         RuntimeConfig::new(std::env::var("OPENAI_API_KEY")?),
     )?;
-    let agent = IronAgent::new(config, provider);
+    let agent = IronAgent::new(Config::new().with_model("gpt-4o"), provider);
 
     agent.register_tool(FunctionTool::new(
         ToolDefinition::new(
@@ -76,15 +72,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         |args| Ok(json!({ "echo": args["text"].clone() })),
     ));
 
-    let connection = agent.connect();
-    let session = connection.create_session()?;
+    let session = agent.connect().create_session()?;
     let (handle, mut events) = session.prompt_stream("Call echo with hello.");
 
     while let Some(event) = events.next().await {
         match event {
             PromptEvent::Output { text } => print!("{text}"),
             PromptEvent::ApprovalRequest { call_id, .. } => {
-                handle.approve(&call_id).expect("approval should be pending");
+                handle.approve(&call_id)?;
             }
             PromptEvent::Complete { outcome } => {
                 println!("\nprompt finished: {outcome:?}");
@@ -98,93 +93,119 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
-The canonical interaction model is stream-first:
+The canonical interaction model is stream-first: call
+`AgentSession::prompt_stream`, consume `PromptEvent` values, and use the
+returned `PromptHandle` to approve, deny, or cancel an active prompt.
 
-- call `session.prompt_stream(...)`
-- consume `PromptEvent`s as they arrive
-- use `PromptHandle` to approve, deny, or cancel an active prompt
+## Capabilities
 
-## Built-In Tools
+- Durable messages, timeline entries, tool-call records, context accounting,
+  compaction, and handoff export/import
+- Custom tool registration with JSON Schema argument validation and approval
+  strategies
+- Layered prompt composition with repository instructions and runtime context
+- Operational in-process ACP transport, with reserved stdio and TCP entry points
+  that currently return compatibility errors
+- Headless automation, scheduled tasks, profiles, stored prompts, provider
+  credentials, skills, management APIs, and debug observation
+- Optional embedded Python execution through the `embedded-python` feature
 
-`iron-core` can register built-in `read`, `write`, `edit`, `glob`, `grep`, and `webfetch` tools, plus `bash` or `powershell` when a shell is available.
+### Built-In Tools
 
-Use `BuiltinToolConfig` to scope filesystem access, disable specific tools, and tune limits such as command timeouts and output caps.
+`IronAgent::register_builtin_tools` can register `read`, `write`, `edit`,
+`multiedit`, `glob`, `grep`, and `webfetch`, plus either `bash` or `powershell`
+when that shell is available. `BuiltinToolConfig` controls allowed filesystem
+roots, disabled tools, approval and network policy, shell selection, timeouts,
+and result-size limits. Built-in tools enforce their configured policies at
+execution time.
 
-## MCP Servers
+### MCP Servers
 
-`iron-core` supports session-scoped MCP (Model Context Protocol) servers as a tool source alongside built-in and custom tools. The full implementation covers:
+Runtime-managed MCP servers can provide tools alongside built-in and custom
+tools. The public MCP APIs cover server inventory and health, stdio and HTTP
+transport configuration, connection lifecycle, session-effective tool
+catalogs, approval handling, and unavailable-tool diagnostics. MCP server state
+is runtime-local and is not included in handoff bundles.
 
-- Runtime-local MCP server inventory with per-server configuration
-- Session-scoped enablement governed by a single runtime-default policy
-- Canonical session-effective tool catalog with precise unavailable-tool diagnostics
-- Approval strategy enforcement for MCP tool calls
-- Transport clients for stdio, HTTP, and HTTP+SSE
-- Connection lifecycle management with single-flight connect guarding
-- Handoff exclusion — MCP state is runtime-local and not portable
+### Integration Plugins
 
-## Integration Plugins
-
-`iron-core` includes a WASM-based integration-plugin surface powered by [Extism](https://extism.org). Plugins are a third tool source alongside built-in tools and MCP servers.
-
-The plugin system is fully implemented:
-
-- **Install lifecycle** — fetch (local or HTTPS+checksum), cache, manifest extraction from WASM binaries, identity validation, and Extism-backed WASM host loading
-- **WASM execution** — tools are invoked via `tool_{name}` exports with a JSON request/response envelope and a 30-second timeout
-- **Session-scoped enablement** — runtime-level defaults materialised at session creation, with per-session overrides
-- **Canonical tool availability** — single-source-of-truth `compute_tool_availability()` gates tools on health, auth requirements, and scope satisfaction
-- **Auth model** — runtime-governed auth state, credential bindings, and per-tool scope checks
-- **Tool diagnostics** — structured `UnavailableReason` variants for actionable error messages
-- **Network policy** — allowlist, blocklist, and wildcard policies declared in plugin manifests
+The `plugin` module provides Extism-backed WASM integration-plugin APIs for
+local or HTTPS artifacts, checksums, manifest extraction, registry and install
+state, session enablement, authentication requirements, tool availability,
+network policy declarations, and rich output. Plugin calls use a 30-second host
+timeout. Availability and policy APIs describe and gate tools; embedders remain
+responsible for configuring credentials, network access, and user-facing auth
+flows.
 
 ## Development
 
-Install the security tooling if you want to run the same audit check CI reports:
+The repository requires Rust 1.96. Install the Python
+[`invoke`](https://www.pyinvoke.org/) package to use the convenience tasks, and
+install `cargo-audit` for the security task:
 
 ```bash
-cargo install cargo-audit
-```
-
-Configure the repository pre-commit hook after cloning:
-
-```bash
+cargo install cargo-audit --locked
 git config core.hooksPath .githooks
 ```
 
-The pre-commit hook runs `cargo fmt --manifest-path Cargo.toml -- --check` when staged Rust files are present. Before opening or updating a pull request, run the same checks CI validates:
-
-```bash
-cargo build --manifest-path Cargo.toml --all-targets
-cargo fmt --manifest-path Cargo.toml -- --check
-cargo clippy --manifest-path Cargo.toml --all-targets --all-features -- -D warnings
-cargo test --manifest-path Cargo.toml
-cargo audit --file Cargo.lock
-```
-
-The local `invoke` tasks in `tasks.py` are a convenience layer over these checks:
+The pre-commit hook checks formatting when staged Rust files are present. Run
+the repository task groups before opening a pull request:
 
 ```bash
 inv build
 inv test
+inv docs
 inv security
 ```
 
-The `Pull Request` workflow runs build, format, lint, and test checks on every PR to `main`. It also runs `cargo audit` as a non-blocking audit and posts the output as a PR comment.
+`inv build` runs build, format, and all-feature Clippy checks; `inv test` runs
+the test suite; `inv docs` runs strict all-feature rustdoc and doctests; and
+`inv security` runs `cargo audit`. The corresponding documentation commands
+are:
 
-Merges to `main` trigger an automatic patch release that bumps `Cargo.toml`, creates a `vX.Y.Z` tag, and creates a GitHub release. Publishing to crates.io is skipped until `monty` is available from crates.io because crates.io rejects manifests containing git dependencies.
+```bash
+RUSTDOCFLAGS="-D warnings -D missing-docs" cargo doc --manifest-path Cargo.toml --no-deps --all-features
+cargo test --manifest-path Cargo.toml --doc
+```
+
+The current `Pull Request` workflow runs locked build, format, all-feature
+Clippy, test, and `inv docs` checks on Linux; all-feature link and scheduler
+checks on macOS and Windows; and a fresh `embedded-python` consumer build. Its
+`cargo audit` step is non-blocking and posts the result on same-repository pull
+requests. Pull requests validate documentation but do not deploy it.
+
+Pushes to `main` with unreleased changes run the patch-release workflow. After
+its build, lint, test, audit, and fresh-consumer checks pass, the workflow bumps
+the patch version, commits and tags it, publishes all features to crates.io
+using trusted publishing, and creates a GitHub release. A manually dispatched
+workflow performs the same process for minor or major releases. See the
+[current releases](https://github.com/AgentIron/iron-core/releases) for published versions.
 
 ## Documentation
 
+- [Published release API documentation](https://docs.rs/iron-core/latest/iron_core/)
 - [Architecture Overview](docs/architecture-overview.md)
 - [Getting Started](docs/getting-started-iron-core.md)
 - [Integration Plugins](docs/integration-plugins.md)
+- [Model Switching](docs/model-switching.md)
+- [Model Switching Examples](docs/model-switching-examples.md)
 - [Prompt Composition](docs/prompt-composition.md)
-- [Architecture Cleanup Checklist](docs/architecture-cleanup-checklist.md)
 
-Build the API docs locally with:
+GitHub Pages is configured as a public workflow deployment with the custom
+domain `core.agentiron.ai`. The `Deploy Documentation` workflow runs on pushes
+to `main` and manual dispatch, builds strict all-feature rustdoc, publishes
+`target/doc`, and redirects the site root to `iron_core/index.html`. Current
+`main` API documentation is available at `https://core.agentiron.ai/` after a
+successful deployment. The published docs.rs link above remains available
+independently.
+
+Build the same all-feature API documentation locally with:
 
 ```bash
-cargo doc -p iron-core --no-deps
+RUSTDOCFLAGS="-D warnings -D missing-docs" cargo doc --manifest-path Cargo.toml --no-deps --all-features
 ```
+
+Then open `target/doc/iron_core/index.html`.
 
 ## License
 

--- a/openspec/changes/add-automated-documentation/.openspec.yaml
+++ b/openspec/changes/add-automated-documentation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-17

--- a/openspec/changes/add-automated-documentation/design.md
+++ b/openspec/changes/add-automated-documentation/design.md
@@ -46,7 +46,7 @@ Alternative considered: introduce a static-site generator. Rustdoc already provi
 
 ```bash
 RUSTDOCFLAGS="-D warnings -D missing-docs" cargo doc --manifest-path Cargo.toml --no-deps --all-features
-cargo test --manifest-path Cargo.toml --doc
+cargo test --manifest-path Cargo.toml --doc --all-features
 ```
 
 Keeping documentation separate from `inv build` makes failures locally identifiable and preserves the existing build task's purpose. Pull request CI will invoke the same task so local and hosted validation share one command definition.

--- a/openspec/changes/add-automated-documentation/design.md
+++ b/openspec/changes/add-automated-documentation/design.md
@@ -1,0 +1,115 @@
+## Context
+
+`iron-core` already enables rustdoc link lints and contains substantial crate-level narrative documentation, but strict generation with `-D warnings -D missing-docs` currently fails with 1,463 missing-documentation errors and six unresolved links. All 34 top-level public modules are considered intentional API for this change. Existing doctests report zero passing and fourteen ignored examples, while the README's installation, toolchain, dependency, release, and documentation guidance has drifted from the manifest and repository state.
+
+The strict-rustdoc baseline consists primarily of 703 undocumented struct fields, 235 variants, 212 methods, 97 associated functions, 71 structs, 57 modules, 44 enums, 20 free functions, and 24 other public items. Implementation groups these diagnostics into crate/core tools, durable/context, runtime/prompt, persisted management, MCP/plugins, automation/scheduling, and transport/CLI domains. The baseline is documentation-only: no public visibility or signature reduction is permitted while clearing it.
+
+The desired flow mirrors the documentation pipeline established in `AgentIron/iron-providers` PR #39: a dedicated local Invoke task, pull request validation, and rustdoc publication from `main`. This repository already has GitHub Pages configured as a workflow deployment at the `core.agentiron.ai` custom domain.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Give every currently public module and item meaningful inline rustdoc.
+- Provide compiling examples for primary public usage paths rather than examples for every trivial accessor or field.
+- Compile README Rust snippets as doctests and comprehensively review the README's factual claims.
+- Make documentation warnings, broken links, missing public docs, and example drift fail locally and in pull request CI.
+- Publish current `main` rustdoc through the existing GitHub Pages configuration with least-privilege workflow permissions.
+- Keep generated documentation conventional and compatible with future docs.rs publication.
+
+**Non-Goals:**
+
+- Do not reduce module or item visibility, change public signatures, or otherwise redesign the public API.
+- Do not change runtime behavior or dependencies solely for documentation convenience.
+- Do not add missing-documentation exceptions for existing public surfaces.
+- Do not add a static-site generator, custom documentation theme, or pull request preview deployments.
+- Do not require an independent example for every field, variant, or trivial accessor.
+- Do not manage the custom domain, DNS, certificate, or HTTPS-enforcement setting in repository code.
+
+## Decisions
+
+### Treat Rust visibility as the documentation boundary
+
+Every item reachable as public API during an all-features documentation build will be documented. Public modules that appear implementation-oriented remain public and documented in this change so the generated site can support a later API review.
+
+Alternative considered: narrow visibility or allow missing docs on legacy modules. This would reduce the immediate workload, but it would combine an API compatibility change with documentation work and prevent a complete review of the currently exposed surface.
+
+### Use rustdoc as the publication artifact
+
+The Pages build will publish `target/doc` from `cargo doc --manifest-path Cargo.toml --no-deps --all-features`. A generated root `index.html` will redirect to `iron_core/index.html`, making the custom domain useful without a separate landing site.
+
+Alternative considered: introduce a static-site generator. Rustdoc already provides item navigation, search, links, and examples, while a second documentation stack would create avoidable maintenance and drift.
+
+### Enforce documentation through a dedicated Invoke task
+
+`inv docs` will run these two checks as a separate documentation group:
+
+```bash
+RUSTDOCFLAGS="-D warnings -D missing-docs" cargo doc --manifest-path Cargo.toml --no-deps --all-features
+cargo test --manifest-path Cargo.toml --doc
+```
+
+Keeping documentation separate from `inv build` makes failures locally identifiable and preserves the existing build task's purpose. Pull request CI will invoke the same task so local and hosted validation share one command definition.
+
+Alternative considered: duplicate raw Cargo commands in CI or fold them into `inv build`. Duplication invites command drift, while combining the tasks obscures whether a failure comes from compilation, linting, rustdoc, or doctests.
+
+### Prefer useful rustdoc over lint-silencing text
+
+Documentation will describe semantics, invariants, side effects, ownership, errors, and lifecycle constraints where relevant. Module docs will explain purpose and relationship to neighboring modules. Repetitive fields and variants may use concise descriptions, but placeholder wording that merely restates an identifier is not sufficient.
+
+Usage-path examples will focus on recommended integrations: facade sessions and streaming, configuration, tool registration, providers and credentials, context management, profiles and stored prompts, management APIs, transports, MCP, plugins, skills, headless automation, scheduled tasks, and debugging. Existing ignored examples will be converted to compiling examples where practical.
+
+### Treat README review and README doctests as complementary checks
+
+The README will be included from `src/lib.rs` through `#[doc = include_str!("../README.md")]` on a `#[cfg(doctest)]` item. Rust snippets will compile normally or use `no_run` when executing them would require credentials, network access, filesystem state, platform services, or a long-running process. Hidden scaffolding will keep rendered examples readable. `ignore` will be reserved for examples that cannot reasonably compile in the documentation environment.
+
+Doctests cannot validate prose, TOML, shell commands, links, or operational claims, so the README will also receive a manual claim-by-claim review against `Cargo.toml`, current public APIs, workflows, releases, crates.io, and files in the repository. Installation guidance will reflect that `iron-core` is published, the minimum Rust version will match the manifest, release guidance will match current workflows, and broken documentation links will be removed or repaired.
+
+Alternative considered: only make the existing Rust snippet compile. That would leave known false statements in the primary project entry point and fail the stated goal of current consumer documentation.
+
+### Separate pull request validation from Pages publication
+
+Pull requests to `main` will run `inv docs` in the existing Rust checks job and will not publish. A dedicated Pages workflow will build on pushes to `main` and manual dispatch, upload `target/doc`, and deploy it in a separate job.
+
+The workflow will set only `contents: read` globally. The build checkout will use `persist-credentials: false`. Only the deploy job will receive `pages: write` and `id-token: write`, and deployment concurrency will cancel superseded Pages runs.
+
+Alternative considered: deploy previews for pull requests. Preview lifecycle and permission complexity are unnecessary for the initial capability.
+
+## Risks / Trade-offs
+
+- [The documentation sweep is large and may produce superficial comments] -> Review by domain, require semantic descriptions, and validate the rendered output rather than treating lint success as completion.
+- [Documenting currently public internals may appear to strengthen their compatibility promise] -> State that all current public surfaces are documented for review while deferring any visibility decision to a separate breaking-change assessment.
+- [All-features documentation increases build time and exercises optional embedded-Python dependencies] -> Cache Rust artifacts in CI and retain all-features coverage because published docs must represent the complete public surface.
+- [Doctest examples can accidentally perform external side effects] -> Use `no_run` and minimal hidden setup while still requiring compilation.
+- [README facts can drift even when doctests pass] -> Include a structured manual README audit in the implementation and review tasks.
+- [Pages deployment depends on repository-level settings] -> Use the already configured workflow-based Pages environment and document the custom-domain setup; keep validation independent so docs remain buildable if deployment is temporarily disabled.
+- [The custom domain currently does not enforce HTTPS] -> Record HTTPS enforcement as an operational follow-up rather than expanding this repository change into DNS or Pages administration.
+
+## Migration Plan
+
+1. Add the local documentation task so progress can be measured consistently.
+2. Repair existing rustdoc link failures and document public modules and items by domain until strict generation succeeds.
+3. Add and convert usage-path examples, then enable README doctest inclusion.
+4. Audit and update README content against current repository and release state.
+5. Add pull request validation and the Pages deployment workflow.
+6. Run all existing build, test, documentation, security, and package-consumer checks.
+7. Review the generated site locally before merging; after merge, verify the Pages deployment and custom-domain redirect.
+
+Rollback of publication consists of disabling or removing the Pages workflow. Local and pull request documentation validation can remain active independently. Rustdoc comments and README corrections require no data migration.
+
+## Open Questions
+
+- Should HTTPS enforcement for `core.agentiron.ai` be enabled immediately as a repository-settings follow-up, or tracked separately after the first successful deployment?
+- Which currently public modules should become candidates for a later visibility and stability review once the complete generated API can be inspected?
+
+## Follow-up Work
+
+- After the first successful Pages deployment, enable HTTPS enforcement for
+  `core.agentiron.ai` in repository settings and verify HTTP redirects to HTTPS.
+- Review the published API before the next breaking release. Initial visibility
+  candidates include orchestration internals (`prompt_runner`,
+  `prompt_lifecycle`, and `request_builder`), low-level persistence modules
+  (`config::crypto`, `config::migrations`, and `config::records`), built-in tool
+  helpers/renderers, MCP protocol/client internals, and plugin lifecycle and
+  effective-tool internals. Any visibility reduction requires a separate
+  compatibility assessment and change proposal.

--- a/openspec/changes/add-automated-documentation/proposal.md
+++ b/openspec/changes/add-automated-documentation/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+`iron-core` exposes a large public Rust API, but strict rustdoc currently reports more than one thousand undocumented public items, its examples are ignored rather than compiled, and its README contains stale installation, version, release, and documentation guidance. Current API documentation should be complete, validated on every pull request, and published from `main` so consumers can rely on it before and after releases.
+
+## What Changes
+
+- Document every currently public module and public API item without narrowing visibility or exempting existing public surfaces from missing-documentation enforcement.
+- Add compiling rustdoc examples for primary usage paths and compile README Rust snippets as doctests, using hidden scaffolding or `no_run` only where execution would cause external side effects.
+- Repair broken rustdoc links and fail documentation validation on rustdoc warnings or missing public documentation.
+- Add a local `inv docs` task and run it in pull request CI without deploying documentation.
+- Publish rustdoc output for the current `main` branch through the repository's existing GitHub Pages configuration and custom domain.
+- Perform a detailed README review covering installation, supported Rust and dependency versions, public API positioning, examples, feature claims, development commands, release behavior, documentation links, and GitHub Pages usage.
+- Preserve the existing public API; public-surface reduction remains a possible follow-up after the generated documentation can be reviewed.
+
+## Capabilities
+
+### New Capabilities
+
+- `automated-documentation`: Complete and strictly validated public API documentation, compiling examples and README guidance, pull request documentation checks, and GitHub Pages publication from `main`.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Rustdoc comments and examples throughout `src/` for all currently public modules and items.
+- Crate-level documentation and README doctest inclusion in `src/lib.rs`.
+- README installation, development, release, feature, and documentation guidance.
+- Local Invoke tasks in `tasks.py`.
+- Pull request CI and a new GitHub Pages deployment workflow under `.github/workflows/`.
+- GitHub Pages output at the existing `core.agentiron.ai` custom domain.
+- No intended runtime behavior, public signature, dependency, or visibility changes.

--- a/openspec/changes/add-automated-documentation/specs/automated-documentation/spec.md
+++ b/openspec/changes/add-automated-documentation/specs/automated-documentation/spec.md
@@ -1,0 +1,133 @@
+## ADDED Requirements
+
+### Requirement: Complete public API documentation
+The crate SHALL provide meaningful inline rustdoc for every module and API item that is public in an all-features documentation build, including public structs, enums, traits, variants, fields, constructors, builders, methods, functions, constants, and macros. This change SHALL NOT narrow existing public visibility or exempt existing public surfaces from missing-documentation validation.
+
+#### Scenario: Strict public documentation coverage
+- **WHEN** rustdoc builds the crate with all features and missing documentation denied
+- **THEN** every currently public module and item has sufficient inline documentation
+- **AND** the build completes without a missing-documentation diagnostic
+
+#### Scenario: Existing public surface is preserved
+- **WHEN** documentation is added to an implementation-oriented public module or item
+- **THEN** its visibility and public signature remain unchanged
+
+### Requirement: Strict local documentation validation
+The repository SHALL provide an `inv docs` task that runs strict rustdoc generation and documentation tests using the root manifest.
+
+#### Scenario: Local documentation task succeeds
+- **WHEN** a contributor runs `inv docs`
+- **THEN** it runs `RUSTDOCFLAGS="-D warnings -D missing-docs" cargo doc --manifest-path Cargo.toml --no-deps --all-features`
+- **AND** it runs `cargo test --manifest-path Cargo.toml --doc`
+- **AND** it reports success only when both commands succeed
+
+#### Scenario: Rustdoc warning fails validation
+- **WHEN** public documentation contains a broken link, another rustdoc warning, or an undocumented public item
+- **THEN** `inv docs` exits unsuccessfully
+
+#### Scenario: Doctest drift fails validation
+- **WHEN** a compiled documentation example no longer matches the public API
+- **THEN** `inv docs` exits unsuccessfully
+
+### Requirement: Compiling public usage examples
+Primary public usage paths SHALL have compiling rustdoc examples. Examples SHALL compile without performing network, credential, filesystem, platform-service, or long-running side effects during documentation tests.
+
+#### Scenario: Side-effect-free example
+- **WHEN** an example can execute deterministically without external state
+- **THEN** it is compiled and run as a normal doctest
+
+#### Scenario: Side-effecting example
+- **WHEN** an example requires external credentials, network access, filesystem state, platform services, or a long-running process
+- **THEN** it uses `no_run` and any minimal hidden scaffolding needed to verify compilation without executing the side effect
+
+#### Scenario: Existing ignored examples are reviewed
+- **WHEN** an existing public example is marked `ignore`
+- **THEN** it is converted to a compiling normal or `no_run` doctest where practical
+- **AND** any remaining ignored example has a concrete reason that prevents compilation in the documentation environment
+
+### Requirement: README examples participate in doctests
+The crate SHALL include README content in rustdoc tests through `#[doc = include_str!("../README.md")]` on an item gated by `#[cfg(doctest)]`. README Rust examples SHALL compile against the current public API unless they have a documented reason not to.
+
+#### Scenario: README API drift
+- **WHEN** a README Rust snippet references a removed or changed API
+- **THEN** `cargo test --manifest-path Cargo.toml --doc` fails
+
+#### Scenario: README example has runtime side effects
+- **WHEN** a README example would contact a provider or otherwise depend on external state
+- **THEN** the rendered example remains useful to readers
+- **AND** the example uses `no_run` or hidden scaffolding so its code is still compiled
+
+### Requirement: README factual accuracy
+The README SHALL be reviewed and updated against the current manifest, public API, repository files, workflows, GitHub release state, crates.io publication state, and GitHub Pages configuration. The review SHALL cover installation, minimum Rust version, dependency guidance, public API positioning, examples, feature descriptions, development commands, release and publication behavior, documentation links, and API documentation access.
+
+#### Scenario: Published crate installation guidance
+- **WHEN** a reader follows the primary installation instructions
+- **THEN** the instructions identify the currently supported crates.io dependency approach
+- **AND** dependency and feature examples are compatible with the current manifest
+
+#### Scenario: Toolchain and workflow guidance
+- **WHEN** a reader follows the development instructions
+- **THEN** the documented minimum Rust version agrees with `Cargo.toml`
+- **AND** descriptions of CI, releases, and publication agree with the repository workflows and current release process
+
+#### Scenario: README documentation links
+- **WHEN** a reader follows a repository documentation link
+- **THEN** the target exists and is relevant
+
+#### Scenario: Public API positioning
+- **WHEN** the README recommends the facade and runtime APIs as primary entry points
+- **THEN** it does not incorrectly state that other currently public modules are unsupported or outside the public API
+
+### Requirement: Pull request documentation gate
+Pull requests targeting `main` SHALL run `inv docs` as a required documentation validation step and SHALL NOT deploy documentation.
+
+#### Scenario: Pull request documentation succeeds
+- **WHEN** a pull request has complete public docs, warning-free rustdoc, and passing doctests
+- **THEN** its documentation validation step succeeds
+
+#### Scenario: Pull request documentation fails
+- **WHEN** a pull request introduces an undocumented public item, rustdoc warning, broken documentation link, or failing doctest
+- **THEN** its documentation validation step fails
+- **AND** no Pages deployment is attempted
+
+### Requirement: Main-branch GitHub Pages publication
+Pushes to `main` and manually dispatched documentation workflows SHALL build all-features rustdoc without dependencies, publish `target/doc` through GitHub Pages, and make the crate documentation reachable through the repository's existing custom domain.
+
+#### Scenario: Main branch documentation deployment
+- **WHEN** a commit is pushed to `main` and strict rustdoc generation succeeds
+- **THEN** `target/doc` is uploaded as a Pages artifact
+- **AND** a separate deploy job publishes the artifact
+
+#### Scenario: Documentation root navigation
+- **WHEN** a reader opens the documentation site's root URL
+- **THEN** the site redirects to `iron_core/index.html`
+
+#### Scenario: Failed documentation build
+- **WHEN** strict rustdoc generation fails on `main`
+- **THEN** the deploy job does not publish a new Pages artifact
+
+### Requirement: Least-privilege Pages workflow
+The Pages workflow SHALL use least-privilege permissions and SHALL prevent checkout credentials from persisting in the documentation build job.
+
+#### Scenario: Build job permissions
+- **WHEN** the documentation build job checks out the repository
+- **THEN** workflow-level permissions grant only `contents: read`
+- **AND** checkout uses `persist-credentials: false`
+
+#### Scenario: Deploy job permissions
+- **WHEN** the Pages deploy job runs
+- **THEN** `pages: write` and `id-token: write` are scoped to that job
+- **AND** those write permissions are not granted to the build job
+
+### Requirement: Generated documentation review
+Completion SHALL include a review of the rendered rustdoc site for navigation, module descriptions, terminology, examples, and cross-links, in addition to automated validation.
+
+#### Scenario: Pre-merge generated-site review
+- **WHEN** strict documentation checks pass
+- **THEN** a reviewer can navigate the generated `iron_core` documentation locally
+- **AND** primary public domains have understandable module-level descriptions and discoverable usage examples
+
+#### Scenario: Post-merge publication verification
+- **WHEN** the change merges to `main`
+- **THEN** the Pages workflow succeeds
+- **AND** the custom-domain root and crate documentation page are reachable

--- a/openspec/changes/add-automated-documentation/specs/automated-documentation/spec.md
+++ b/openspec/changes/add-automated-documentation/specs/automated-documentation/spec.md
@@ -18,7 +18,7 @@ The repository SHALL provide an `inv docs` task that runs strict rustdoc generat
 #### Scenario: Local documentation task succeeds
 - **WHEN** a contributor runs `inv docs`
 - **THEN** it runs `RUSTDOCFLAGS="-D warnings -D missing-docs" cargo doc --manifest-path Cargo.toml --no-deps --all-features`
-- **AND** it runs `cargo test --manifest-path Cargo.toml --doc`
+- **AND** it runs `cargo test --manifest-path Cargo.toml --doc --all-features`
 - **AND** it reports success only when both commands succeed
 
 #### Scenario: Rustdoc warning fails validation
@@ -50,7 +50,7 @@ The crate SHALL include README content in rustdoc tests through `#[doc = include
 
 #### Scenario: README API drift
 - **WHEN** a README Rust snippet references a removed or changed API
-- **THEN** `cargo test --manifest-path Cargo.toml --doc` fails
+- **THEN** `cargo test --manifest-path Cargo.toml --doc --all-features` fails
 
 #### Scenario: README example has runtime side effects
 - **WHEN** a README example would contact a provider or otherwise depend on external state

--- a/openspec/changes/add-automated-documentation/tasks.md
+++ b/openspec/changes/add-automated-documentation/tasks.md
@@ -1,0 +1,54 @@
+## 1. Documentation Validation Foundation
+
+- [x] 1.1 Add and register an `inv docs` task that runs strict all-features rustdoc generation and crate doctests using the commands required by the specification
+- [x] 1.2 Repair the existing unresolved rustdoc links so link warnings no longer obscure missing-documentation progress
+- [x] 1.3 Record a domain-grouped baseline of strict rustdoc diagnostics to guide the documentation sweep and confirm that no public visibility is reduced during cleanup
+
+## 2. Core Public API Rustdoc
+
+- [x] 2.1 Document crate-level modules, public re-exports, the prelude, and public binary-facing items with purpose and navigation context
+- [x] 2.2 Document configuration, errors, schema validation, capabilities, tools, and built-in-tool public APIs, including fields, variants, invariants, and failure behavior
+- [x] 2.3 Document durable and ephemeral session state, messages, timeline records, tool-call records, and their lifecycle semantics
+- [x] 2.4 Document context accounting, compaction, handoff, model switching, and context-policy public APIs
+- [x] 2.5 Document the facade, connections, runtime, prompt turns, prompt lifecycle, prompt runner, prompt composition, and request-building public APIs
+- [x] 2.6 Document profile, provider-profile, provider-credential, stored-prompt, management, and config-store public APIs
+- [x] 2.7 Document MCP and integration-plugin public APIs, including lifecycle, authentication, availability, execution, network, and rich-output contracts
+- [x] 2.8 Document automation-task, scheduled-task, headless execution, delegation, skills, and execution-resolution public APIs
+- [x] 2.9 Document transport, CLI support, embedded Python, and debug-observation public APIs
+- [x] 2.10 Run strict rustdoc after each domain pass and resolve every remaining missing module, type, field, variant, trait item, method, function, constant, macro, and warning without adding missing-docs exceptions
+
+## 3. Compiling Usage Examples
+
+- [x] 3.1 Add compiling examples for the recommended `IronAgent` connection, session, streaming prompt, approval, cancellation, and tool-registration paths
+- [x] 3.2 Add compiling examples for configuration, providers and credentials, profiles and stored prompts, context management, and management APIs
+- [x] 3.3 Add compiling examples for MCP, plugins, skills, transports, headless automation, scheduled tasks, and debug observation where they improve discovery of primary usage paths
+- [x] 3.4 Review all existing ignored rustdoc examples and convert each practical example to a normal or `no_run` doctest with minimal hidden scaffolding
+- [x] 3.5 Document a concrete reason for any example that must remain ignored and verify that no example performs external side effects during doctests
+
+## 4. README Review And Doctests
+
+- [x] 4.1 Audit every README factual claim against `Cargo.toml`, current public APIs, repository files, workflows, GitHub releases, crates.io, and the configured Pages custom domain
+- [x] 4.2 Update installation, dependency, feature, minimum-Rust-version, and public-API-positioning guidance for the published crate and current supported API
+- [x] 4.3 Update the quick-start example to current APIs and dependencies, preserve reader-friendly rendering, and make it compile as a normal or `no_run` doctest
+- [x] 4.4 Update built-in tool, MCP, plugin, and other feature descriptions to match current implementation and avoid unsupported completeness or stability claims
+- [x] 4.5 Update development, CI, release, and crates.io publication guidance so documented commands and behavior match the current workflows
+- [x] 4.6 Repair or remove stale documentation links and add the published API documentation URL and existing GitHub Pages setup details
+- [x] 4.7 Include README content from `src/lib.rs` with `#[doc = include_str!("../README.md")]` on a `#[cfg(doctest)]` item and verify README API drift fails doctests
+
+## 5. CI And GitHub Pages
+
+- [x] 5.1 Add `inv docs` to the pull request Rust checks so documentation failures block pull requests without deploying artifacts
+- [x] 5.2 Add a Pages workflow triggered by pushes to `main` and manual dispatch that builds strict all-features rustdoc and writes a root redirect to `iron_core/index.html`
+- [x] 5.3 Upload `target/doc` with the official Pages artifact action and deploy it from a separate job using the `github-pages` environment
+- [x] 5.4 Scope workflow-level permissions to `contents: read`, disable checkout credential persistence in the build job, and grant `pages: write` plus `id-token: write` only to the deploy job
+- [x] 5.5 Configure Pages workflow concurrency to cancel superseded deployments and confirm a failed build cannot reach the deploy job
+
+## 6. End-To-End Verification And Review
+
+- [x] 6.1 Run `inv docs` and confirm strict rustdoc succeeds with no missing public documentation, warnings, broken links, or failing doctests
+- [x] 6.2 Run `inv build`, `inv test`, `inv security`, and the fresh package-consumer check to confirm documentation changes do not alter runtime or package behavior
+- [x] 6.3 Inspect the locally generated rustdoc site for navigation, module descriptions, terminology, cross-links, and discoverable examples across every public domain
+- [x] 6.4 Perform a separate rendered README review covering prose, TOML, shell commands, links, installation, releases, and Pages guidance beyond what doctests validate
+- [x] 6.5 Review the final diff for accidental public visibility, signature, behavior, dependency, or generated-file changes
+- [ ] 6.6 After merge, verify the Pages workflow succeeds and both `core.agentiron.ai` and the `iron_core` crate page resolve correctly
+- [x] 6.7 Record HTTPS enforcement for `core.agentiron.ai` and any public-surface reduction candidates as explicit operational or API-review follow-ups

--- a/src/builtin/config.rs
+++ b/src/builtin/config.rs
@@ -1,3 +1,5 @@
+//! Configuration, limits, and shared state for built-in tools.
+
 use parking_lot::Mutex;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
@@ -7,18 +9,34 @@ use std::time::Duration;
 use super::policy::{BuiltinToolPolicy, ShellAvailability};
 
 #[derive(Debug, Clone)]
+/// Runtime configuration shared by all built-in tool instances.
+///
+/// Clones share read-tracking state, which enforces the read-before-edit
+/// invariant across tools created from the same configuration.
 pub struct BuiltinToolConfig {
+    /// Workspace roots within which filesystem operations are permitted.
     pub allowed_roots: Vec<PathBuf>,
+    /// Security and approval policy applied by built-in tools.
     pub policy: BuiltinToolPolicy,
+    /// Shell backend that may be registered and instantiated.
     pub shell_availability: ShellAvailability,
+    /// Maximum bytes retained independently from shell stdout and stderr.
     pub max_output_bytes: usize,
+    /// Default maximum number of bytes returned by the read tool.
     pub max_read_bytes: usize,
+    /// Default timeout available to built-in operations.
     pub default_timeout: Duration,
+    /// Default maximum duration of a shell command.
     pub shell_timeout: Duration,
+    /// Maximum number of paths collected by a glob search.
     pub max_glob_results: usize,
+    /// Maximum number of content matches collected by a grep search.
     pub max_grep_results: usize,
+    /// Maximum response-body bytes returned by web fetch.
     pub max_fetch_bytes: usize,
+    /// Tool names excluded from registration and instantiation.
     pub disabled_tools: Vec<String>,
+    /// Canonical paths successfully read and therefore eligible for editing.
     pub read_tracking: Arc<Mutex<HashSet<PathBuf>>>,
 }
 
@@ -42,6 +60,7 @@ impl Default for BuiltinToolConfig {
 }
 
 impl BuiltinToolConfig {
+    /// Create a configuration with the given allowed roots and default limits.
     pub fn new(allowed_roots: Vec<PathBuf>) -> Self {
         Self {
             allowed_roots,
@@ -49,45 +68,59 @@ impl BuiltinToolConfig {
         }
     }
 
+    /// Select the shell backend exposed by this configuration.
     pub fn with_shell_availability(mut self, avail: ShellAvailability) -> Self {
         self.shell_availability = avail;
         self
     }
 
+    /// Disable the tools whose exact names occur in `tools`.
     pub fn with_disabled_tools(mut self, tools: Vec<String>) -> Self {
         self.disabled_tools = tools;
         self
     }
 
+    /// Replace the security and approval policy.
     pub fn with_policy(mut self, policy: BuiltinToolPolicy) -> Self {
         self.policy = policy;
         self
     }
 
+    /// Set the maximum retained bytes for each shell output stream.
     pub fn with_max_output_bytes(mut self, bytes: usize) -> Self {
         self.max_output_bytes = bytes;
         self
     }
 
+    /// Set the read tool's default byte limit.
     pub fn with_max_read_bytes(mut self, bytes: usize) -> Self {
         self.max_read_bytes = bytes;
         self
     }
 
+    /// Set the default shell-command timeout.
     pub fn with_shell_timeout(mut self, timeout: Duration) -> Self {
         self.shell_timeout = timeout;
         self
     }
 
+    /// Set the general default operation timeout.
     pub fn with_default_timeout(mut self, timeout: Duration) -> Self {
         self.default_timeout = timeout;
         self
     }
 
+    /// Return whether a tool name is absent from [`Self::disabled_tools`].
     pub fn is_tool_enabled(&self, tool_name: &str) -> bool {
         !self.disabled_tools.iter().any(|d| d == tool_name)
     }
 
+    /// Validate invariants required before using this configuration.
+    ///
+    /// # Errors
+    ///
+    /// Returns a configuration error when no roots are configured or any root
+    /// is relative.
     pub fn validate(&self) -> Result<(), super::error::BuiltinToolError> {
         if self.allowed_roots.is_empty() {
             return Err(super::error::BuiltinToolError::config(
@@ -105,10 +138,18 @@ impl BuiltinToolConfig {
         Ok(())
     }
 
+    /// Record that `path` has been read for subsequent edit authorization.
+    ///
+    /// Callers must provide the canonical path used by the corresponding edit
+    /// operation because tracking stores paths verbatim.
     pub fn record_read(&self, path: &Path) {
         self.read_tracking.lock().insert(path.to_path_buf());
     }
 
+    /// Return whether `path` has previously been recorded as read.
+    ///
+    /// Callers must provide the same canonical path that was passed to
+    /// [`Self::record_read`].
     pub fn has_read(&self, path: &Path) -> bool {
         self.read_tracking.lock().contains(path)
     }

--- a/src/builtin/error.rs
+++ b/src/builtin/error.rs
@@ -1,30 +1,51 @@
+//! Stable error codes and messages returned by built-in tools.
+
 use std::fmt;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Error produced while validating or executing a built-in tool operation.
 pub struct BuiltinToolError {
+    /// Machine-readable category for the failure.
     pub code: BuiltinErrorCode,
+    /// Human-readable details about the failure.
     pub message: String,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Stable machine-readable categories for built-in tool failures.
 pub enum BuiltinErrorCode {
+    /// A requested path falls outside every configured root.
     PathOutOfScope,
+    /// A path component conflicts with the requested operation.
     PathConflict,
+    /// A requested filesystem path does not exist.
     PathNotFound,
+    /// An operation requiring text encountered binary content.
     BinaryContent,
+    /// Text selected for replacement was not found.
     EditMismatch,
+    /// A single replacement matched more than one location.
     EditAmbiguous,
+    /// Tool arguments are missing, malformed, or inconsistent.
     InvalidInput,
+    /// A URL is malformed or uses an unsupported scheme.
     InvalidUrl,
+    /// Network policy denied the request or resolved address.
     NetworkDenied,
+    /// An HTTP request or response operation failed.
     FetchFailed,
+    /// An operation exceeded its configured deadline.
     Timeout,
+    /// No supported command shell is available.
     ShellNotAvailable,
+    /// A filesystem or process I/O operation failed.
     IoError,
+    /// Built-in tool configuration violates a required invariant.
     ConfigError,
 }
 
 impl BuiltinErrorCode {
+    /// Return the stable snake-case representation used in JSON responses.
     pub fn as_str(&self) -> &'static str {
         match self {
             Self::PathOutOfScope => "path_out_of_scope",
@@ -52,6 +73,7 @@ impl fmt::Display for BuiltinErrorCode {
 }
 
 impl BuiltinToolError {
+    /// Construct an error from its stable `code` and descriptive `message`.
     pub fn new(code: BuiltinErrorCode, message: impl Into<String>) -> Self {
         Self {
             code,
@@ -59,50 +81,62 @@ impl BuiltinToolError {
         }
     }
 
+    /// Construct a [`BuiltinErrorCode::PathOutOfScope`] error.
     pub fn out_of_scope(msg: impl Into<String>) -> Self {
         Self::new(BuiltinErrorCode::PathOutOfScope, msg)
     }
 
+    /// Construct a [`BuiltinErrorCode::PathConflict`] error.
     pub fn path_conflict(msg: impl Into<String>) -> Self {
         Self::new(BuiltinErrorCode::PathConflict, msg)
     }
 
+    /// Construct a [`BuiltinErrorCode::PathNotFound`] error.
     pub fn path_not_found(msg: impl Into<String>) -> Self {
         Self::new(BuiltinErrorCode::PathNotFound, msg)
     }
 
+    /// Construct a [`BuiltinErrorCode::BinaryContent`] error.
     pub fn binary_content(msg: impl Into<String>) -> Self {
         Self::new(BuiltinErrorCode::BinaryContent, msg)
     }
 
+    /// Construct a [`BuiltinErrorCode::EditMismatch`] error.
     pub fn edit_mismatch(msg: impl Into<String>) -> Self {
         Self::new(BuiltinErrorCode::EditMismatch, msg)
     }
 
+    /// Construct a [`BuiltinErrorCode::EditAmbiguous`] error.
     pub fn edit_ambiguous(msg: impl Into<String>) -> Self {
         Self::new(BuiltinErrorCode::EditAmbiguous, msg)
     }
 
+    /// Construct a [`BuiltinErrorCode::InvalidInput`] error.
     pub fn invalid_input(msg: impl Into<String>) -> Self {
         Self::new(BuiltinErrorCode::InvalidInput, msg)
     }
 
+    /// Construct a [`BuiltinErrorCode::InvalidUrl`] error.
     pub fn invalid_url(msg: impl Into<String>) -> Self {
         Self::new(BuiltinErrorCode::InvalidUrl, msg)
     }
 
+    /// Construct a [`BuiltinErrorCode::NetworkDenied`] error.
     pub fn network_denied(msg: impl Into<String>) -> Self {
         Self::new(BuiltinErrorCode::NetworkDenied, msg)
     }
 
+    /// Construct a [`BuiltinErrorCode::FetchFailed`] error.
     pub fn fetch_failed(msg: impl Into<String>) -> Self {
         Self::new(BuiltinErrorCode::FetchFailed, msg)
     }
 
+    /// Construct a [`BuiltinErrorCode::Timeout`] error.
     pub fn timeout(msg: impl Into<String>) -> Self {
         Self::new(BuiltinErrorCode::Timeout, msg)
     }
 
+    /// Construct the standard error for an unavailable shell backend.
     pub fn shell_not_available() -> Self {
         Self::new(
             BuiltinErrorCode::ShellNotAvailable,
@@ -110,14 +144,17 @@ impl BuiltinToolError {
         )
     }
 
+    /// Construct a [`BuiltinErrorCode::IoError`] error.
     pub fn io(msg: impl Into<String>) -> Self {
         Self::new(BuiltinErrorCode::IoError, msg)
     }
 
+    /// Construct a [`BuiltinErrorCode::ConfigError`] error.
     pub fn config(msg: impl Into<String>) -> Self {
         Self::new(BuiltinErrorCode::ConfigError, msg)
     }
 
+    /// Serialize this error as an object containing `error.code` and `error.message`.
     pub fn to_json(&self) -> serde_json::Value {
         serde_json::json!({
             "error": {

--- a/src/builtin/file_ops.rs
+++ b/src/builtin/file_ops.rs
@@ -1,3 +1,8 @@
+//! Built-in tools for reading, writing, and exact-match file editing.
+//!
+//! All paths are constrained to configured roots. Editing requires a prior
+//! successful read recorded by the shared [`BuiltinToolConfig`].
+
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -11,11 +16,13 @@ use crate::error::RuntimeResult;
 use crate::tool::{Tool, ToolDefinition, ToolFuture};
 use serde_json::Value;
 
+/// Read files or list directories within configured workspace roots.
 pub struct ReadTool {
     config: Arc<BuiltinToolConfig>,
 }
 
 impl ReadTool {
+    /// Create a read tool using `config` for path checks and output limits.
     pub fn new(config: BuiltinToolConfig) -> Self {
         Self {
             config: Arc::new(config),
@@ -197,11 +204,13 @@ fn is_binary(bytes: &[u8]) -> bool {
     null_count > 0 && (null_count as f64 / check_len as f64) > 0.01
 }
 
+/// Create or overwrite text files within configured workspace roots.
 pub struct WriteTool {
     config: Arc<BuiltinToolConfig>,
 }
 
 impl WriteTool {
+    /// Create a write tool using `config` for path checks and approval metadata.
     pub fn new(config: BuiltinToolConfig) -> Self {
         Self {
             config: Arc::new(config),
@@ -348,11 +357,13 @@ fn validate_no_path_conflict(
     Ok(())
 }
 
+/// Replace exact text in a previously read file.
 pub struct EditTool {
     config: Arc<BuiltinToolConfig>,
 }
 
 impl EditTool {
+    /// Create an edit tool sharing `config`'s read-tracking state.
     pub fn new(config: BuiltinToolConfig) -> Self {
         Self {
             config: Arc::new(config),
@@ -360,11 +371,16 @@ impl EditTool {
     }
 }
 
+/// Apply a sequence of exact replacements to one previously read file.
+///
+/// All replacements are validated against an in-memory buffer before the file
+/// is written, so a validation failure leaves the file unchanged.
 pub struct MultieditTool {
     config: Arc<BuiltinToolConfig>,
 }
 
 impl MultieditTool {
+    /// Create a multi-edit tool sharing `config`'s read-tracking state.
     pub fn new(config: BuiltinToolConfig) -> Self {
         Self {
             config: Arc::new(config),
@@ -676,7 +692,8 @@ fn execute_multiedit(config: &BuiltinToolConfig, args: Value) -> RuntimeResult<V
             return Err(crate::error::RuntimeError::from(
                 BuiltinToolError::edit_ambiguous(format!(
                     "edit {}: old_string matched {} locations; provide more context or use replace_all; no changes were applied",
-                    i + 1, match_count
+                    i + 1,
+                    match_count
                 )),
             ));
         }

--- a/src/builtin/helpers.rs
+++ b/src/builtin/helpers.rs
@@ -1,17 +1,25 @@
+//! JSON metadata and result helpers shared by built-in tools.
+
 use serde_json::Value;
 
 #[derive(Debug, Clone, Default)]
+/// Typed representation of truncation and continuation metadata.
 pub struct BuiltinMeta {
+    /// Whether the corresponding output omits remaining content.
     pub truncated: bool,
+    /// Total untruncated content size in bytes, when known.
     pub total_bytes: Option<usize>,
+    /// Offset from which a caller can request the next segment.
     pub continuation_offset: Option<usize>,
 }
 
 impl BuiltinMeta {
+    /// Return an empty JSON metadata object.
     pub fn empty() -> Value {
         serde_json::json!({})
     }
 
+    /// Return JSON metadata for truncated content of `total_bytes` bytes.
     pub fn with_truncation(total_bytes: usize) -> Value {
         serde_json::json!({
             "truncated": true,
@@ -19,6 +27,7 @@ impl BuiltinMeta {
         })
     }
 
+    /// Return truncation metadata with the next continuation `offset`.
     pub fn with_continuation(offset: usize, total_bytes: usize) -> Value {
         serde_json::json!({
             "truncated": true,
@@ -28,8 +37,10 @@ impl BuiltinMeta {
     }
 }
 
+/// Result type used by built-in tool implementation helpers.
 pub type BuiltinResult<T = Value> = Result<T, super::error::BuiltinToolError>;
 
+/// Attach `meta` to object-shaped `data`, or wrap non-object data with it.
 pub fn success_result(data: Value, meta: Value) -> Value {
     let mut result = data;
     if let Some(obj) = result.as_object_mut() {
@@ -43,6 +54,7 @@ pub fn success_result(data: Value, meta: Value) -> Value {
     result
 }
 
+/// Build a JSON error object from a stable code and human-readable message.
 pub fn error_result(code: super::error::BuiltinErrorCode, message: impl Into<String>) -> Value {
     serde_json::json!({
         "error": {

--- a/src/builtin/mod.rs
+++ b/src/builtin/mod.rs
@@ -1,12 +1,27 @@
+//! Built-in filesystem, search, shell, and web tools.
+//!
+//! Tools are configured through [`BuiltinToolConfig`] and enforce its path,
+//! network, approval, size, and timeout policies when executed.
+
+/// Configuration and limits shared by built-in tools.
 pub mod config;
+/// Structured errors produced by built-in tools.
 pub mod error;
+/// Built-in file reading, writing, and editing tools.
 pub mod file_ops;
+/// Shared result metadata and JSON response helpers.
 pub mod helpers;
+/// Approval, network, shell, and path-access policies.
 pub mod policy;
+/// Registration of enabled built-in tools in a tool registry.
 pub mod registration;
+/// Compact rendering helpers for model-facing tool output.
 pub mod render;
+/// Built-in file-name and content search tools.
 pub mod search;
+/// Built-in Bash and PowerShell execution tools.
 pub mod shell;
+/// Built-in HTTP content retrieval.
 pub mod web;
 
 pub use config::BuiltinToolConfig;
@@ -37,9 +52,10 @@ pub fn is_builtin_name(name: &str) -> bool {
     )
 }
 
-/// Instantiate a builtin tool by name with the given configuration.
+/// Instantiate an enabled built-in tool by name with the given configuration.
 ///
-/// Returns `None` if the name does not correspond to a builtin tool.
+/// Returns `None` if the name is unknown, disabled, or names a shell that is
+/// unavailable according to [`BuiltinToolConfig::shell_availability`].
 pub fn instantiate_builtin(name: &str, config: &BuiltinToolConfig) -> Option<Box<dyn Tool>> {
     match name {
         "read" => config

--- a/src/builtin/policy.rs
+++ b/src/builtin/policy.rs
@@ -1,15 +1,39 @@
+//! Security and approval policies enforced by built-in tools.
+
 use std::path::{Component, Path, PathBuf};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Resource scope to which a user approval applies.
 pub enum ApprovalScope {
-    Command(String),
-    FilePath(PathBuf),
-    DirectoryPath(PathBuf),
-    Domain(String),
+    /// Exactly one command string.
+    Command(
+        /// Exact command text.
+        String,
+    ),
+    /// Exactly one filesystem path.
+    FilePath(
+        /// Exact file path.
+        PathBuf,
+    ),
+    /// A directory and paths beneath it.
+    DirectoryPath(
+        /// Directory path that anchors the scope.
+        PathBuf,
+    ),
+    /// A domain and all of its subdomains.
+    Domain(
+        /// Domain suffix without a leading wildcard.
+        String,
+    ),
+    /// Every approval context.
     All,
 }
 
 impl ApprovalScope {
+    /// Return whether this scope covers `context`.
+    ///
+    /// Directory-to-directory matching is symmetric for ancestor and
+    /// descendant contexts; domain matching includes exact and subdomains.
     pub fn matches(&self, context: &ApprovalScopeMatch) -> bool {
         match (self, context) {
             (ApprovalScope::All, _) => true,
@@ -32,34 +56,64 @@ impl ApprovalScope {
 }
 
 #[derive(Debug, Clone)]
+/// Concrete resource context tested against an [`ApprovalScope`].
 pub enum ApprovalScopeMatch {
-    Command(String),
-    FilePath(PathBuf),
-    DirectoryPath(PathBuf),
-    Domain(String),
+    /// Command being considered for approval.
+    Command(
+        /// Command text being checked.
+        String,
+    ),
+    /// File path being considered for approval.
+    FilePath(
+        /// File path being checked.
+        PathBuf,
+    ),
+    /// Directory path being considered for approval.
+    DirectoryPath(
+        /// Directory path being checked.
+        PathBuf,
+    ),
+    /// Domain being considered for approval.
+    Domain(
+        /// Domain name being checked.
+        String,
+    ),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Lifetime of a granted approval.
 pub enum ApprovalDuration {
+    /// Consume the approval for one operation.
     Once,
+    /// Retain the approval for the current session.
     Session,
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+/// Coarse network-access policy for built-in tools.
 pub enum NetworkPolicy {
+    /// Permit network operations, subject to private-address restrictions.
     #[default]
     AllowAll,
+    /// Deny all network operations.
     DenyAll,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Command shell available for built-in shell execution.
 pub enum ShellAvailability {
+    /// Bash is available.
     Bash,
+    /// PowerShell or PowerShell Core is available.
     PowerShell,
+    /// No supported shell was detected.
     None,
 }
 
 impl ShellAvailability {
+    /// Detect the first supported shell available on the process search path.
+    ///
+    /// Bash is preferred over PowerShell when both are present.
     pub fn detect() -> Self {
         if which_exists("bash") {
             Self::Bash
@@ -70,6 +124,7 @@ impl ShellAvailability {
         }
     }
 
+    /// Return the built-in tool name corresponding to this availability.
     pub fn tool_name(&self) -> Option<&'static str> {
         match self {
             Self::Bash => Some("bash"),
@@ -91,9 +146,13 @@ fn which_exists(cmd: &str) -> bool {
 }
 
 #[derive(Debug, Clone)]
+/// Security and approval settings applied to built-in tool operations.
 pub struct BuiltinToolPolicy {
+    /// How long a granted tool approval remains valid.
     pub approval_duration: ApprovalDuration,
+    /// Whether built-in network access is permitted.
     pub network: NetworkPolicy,
+    /// Whether file reads identify and summarize likely binary content.
     pub binary_detection_enabled: bool,
     /// When `false` (default), `webfetch` refuses requests that resolve to
     /// loopback, link-local, or private IP ranges. Opt in to reach internal
@@ -113,6 +172,16 @@ impl Default for BuiltinToolPolicy {
 }
 
 impl BuiltinToolPolicy {
+    /// Resolve `path` and verify that it lies within an allowed root.
+    ///
+    /// Relative paths are resolved against the first root. Existing ancestors
+    /// are canonicalized so symlinks cannot escape a root, while nonexistent
+    /// final components remain usable for file creation.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error when canonicalization fails, or an out-of-scope
+    /// error when the resolved path is outside all roots or retains `..`.
     pub fn validate_path(
         &self,
         path: &Path,

--- a/src/builtin/registration.rs
+++ b/src/builtin/registration.rs
@@ -1,7 +1,13 @@
+//! Registration of enabled and available built-in tools.
+
 use super::config::BuiltinToolConfig;
 use super::policy::ShellAvailability;
 use crate::tool::ToolRegistry;
 
+/// Register each enabled built-in tool in `registry`.
+///
+/// At most one shell tool is registered, as selected by the configuration's
+/// shell availability. Existing tools with the same names are replaced.
 pub fn register_builtin_tools(registry: &mut ToolRegistry, config: &BuiltinToolConfig) {
     if config.is_tool_enabled("read") {
         registry.register(super::file_ops::ReadTool::new(config.clone()));

--- a/src/builtin/render.rs
+++ b/src/builtin/render.rs
@@ -50,6 +50,10 @@ pub fn render_skip_warning(count: usize) -> String {
     )
 }
 
+/// Render a one-line summary for a filesystem mutation.
+///
+/// The path is made relative to the most specific matching root. Non-empty
+/// detail is appended in parentheses.
 pub fn render_mutation_summary(
     operation: &str,
     path: &Path,
@@ -65,6 +69,7 @@ pub fn render_mutation_summary(
     }
 }
 
+/// Join already-rendered directory entries with newline separators.
 pub fn render_directory_entries(entries: &[String]) -> String {
     entries.join("\n")
 }

--- a/src/builtin/search.rs
+++ b/src/builtin/search.rs
@@ -11,11 +11,13 @@ use crate::error::RuntimeResult;
 use crate::tool::{Tool, ToolDefinition, ToolFuture};
 use serde_json::Value;
 
+/// Find filesystem entries matching a glob pattern within allowed roots.
 pub struct GlobTool {
     config: Arc<BuiltinToolConfig>,
 }
 
 impl GlobTool {
+    /// Create a glob tool using `config` for root and result-limit enforcement.
     pub fn new(config: BuiltinToolConfig) -> Self {
         Self {
             config: Arc::new(config),
@@ -65,11 +67,16 @@ impl Tool for GlobTool {
     }
 }
 
+/// Search text files with regular expressions within allowed roots.
+///
+/// Binary files are skipped, and traversal respects ignore rules unless an
+/// explicit path, include pattern, or hidden-targeting pattern is supplied.
 pub struct GrepTool {
     config: Arc<BuiltinToolConfig>,
 }
 
 impl GrepTool {
+    /// Create a grep tool using `config` for root and result-limit enforcement.
     pub fn new(config: BuiltinToolConfig) -> Self {
         Self {
             config: Arc::new(config),

--- a/src/builtin/shell.rs
+++ b/src/builtin/shell.rs
@@ -1,13 +1,20 @@
+//! Built-in Bash and PowerShell command-execution tools.
+//!
+//! Commands require approval, run only in validated working directories, and
+//! return captured output subject to configured time and size limits.
+
 use crate::builtin::config::BuiltinToolConfig;
 use crate::error::RuntimeResult;
 use crate::tool::{Tool, ToolDefinition, ToolFuture};
 use serde_json::Value;
 
+/// Execute commands through Bash.
 pub struct BashTool {
     config: BuiltinToolConfig,
 }
 
 impl BashTool {
+    /// Create a Bash tool with the supplied execution policy and limits.
     pub fn new(config: BuiltinToolConfig) -> Self {
         Self { config }
     }
@@ -163,11 +170,13 @@ fn truncate_output(output: &str, max_bytes: usize) -> (bool, String) {
     )
 }
 
+/// Execute commands through PowerShell Core or Windows PowerShell.
 pub struct PowerShellTool {
     config: BuiltinToolConfig,
 }
 
 impl PowerShellTool {
+    /// Create a PowerShell tool with the supplied execution policy and limits.
     pub fn new(config: BuiltinToolConfig) -> Self {
         Self { config }
     }

--- a/src/builtin/web.rs
+++ b/src/builtin/web.rs
@@ -1,3 +1,8 @@
+//! Built-in HTTP and HTTPS content retrieval.
+//!
+//! Requests enforce network policy, reject private and special-use addresses
+//! by default, limit redirects, and truncate returned bodies at a UTF-8 boundary.
+
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::sync::Arc;
 
@@ -9,11 +14,13 @@ use crate::error::RuntimeResult;
 use crate::tool::{Tool, ToolDefinition, ToolFuture};
 use serde_json::Value;
 
+/// Fetch textual HTTP content subject to built-in network policy.
 pub struct WebFetchTool {
     config: Arc<BuiltinToolConfig>,
 }
 
 impl WebFetchTool {
+    /// Create a web-fetch tool with the supplied network and size policy.
     pub fn new(config: BuiltinToolConfig) -> Self {
         Self {
             config: Arc::new(config),

--- a/src/capability.rs
+++ b/src/capability.rs
@@ -4,7 +4,10 @@ use std::collections::HashMap;
 
 /// Stable identifier for a capability family.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct CapabilityId(pub &'static str);
+pub struct CapabilityId(
+    /// Namespaced identifier text; callers should treat this value as stable.
+    pub &'static str,
+);
 
 impl CapabilityId {
     /// Filesystem capability identifier.
@@ -178,6 +181,8 @@ impl CapabilityRegistry {
     }
 
     /// Return whether a capability requires permission.
+    ///
+    /// Unknown capabilities return `false`.
     pub fn requires_permission(&self, id: CapabilityId) -> bool {
         self.capabilities
             .get(&id)
@@ -186,6 +191,8 @@ impl CapabilityRegistry {
     }
 
     /// Return whether a capability is serviced by an ACP override.
+    ///
+    /// Unknown capabilities return `false`.
     pub fn is_acp_overridden(&self, id: CapabilityId) -> bool {
         self.backend_for(id) == Some(CapabilityBackend::AcpOverride)
     }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -36,13 +36,21 @@ use tokio_util::sync::CancellationToken;
 // Exit codes
 // ============================================================================
 
+/// Exit code for a successfully completed automation run.
 pub const EXIT_COMPLETED: i32 = 0;
+/// Exit code for invalid command-line arguments or a missing timeout.
 pub const EXIT_USAGE: i32 = 2;
+/// Exit code for configuration and stored-reference failures.
 pub const EXIT_CONFIG: i32 = 3;
+/// Exit code for an unsafe policy or unavailable required tool.
 pub const EXIT_UNSAFE_POLICY: i32 = 4;
+/// Exit code for provider initialization, credentials, or interactive authentication failures.
 pub const EXIT_PROVIDER_INIT: i32 = 5;
+/// Exit code for an automation execution failure without a more specific category.
 pub const EXIT_EXECUTION: i32 = 6;
+/// Exit code for a cancelled automation run.
 pub const EXIT_CANCELLED: i32 = 7;
+/// Exit code for an automation run that exceeded its timeout.
 pub const EXIT_TIMED_OUT: i32 = 8;
 
 // ============================================================================
@@ -52,7 +60,9 @@ pub const EXIT_TIMED_OUT: i32 = 8;
 /// Output format selection.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OutputFormat {
+    /// Human-readable final assistant text.
     Text,
+    /// A versioned JSON representation of the complete run result.
     Json,
 }
 
@@ -63,17 +73,24 @@ pub enum OutputFormat {
 /// Parsed CLI arguments.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CliArgs {
+    /// Identifier of the stored automation task to run.
     pub task_id: String,
+    /// Optional ConfigStore database path supplied by `--config`.
     pub config: Option<String>,
+    /// Optional workspace path supplied by `--workspace`.
     pub workspace: Option<String>,
+    /// Optional duration string supplied by `--timeout`.
     pub timeout: Option<String>,
+    /// Optional output format supplied by `--format`.
     pub format: Option<String>,
+    /// Whether progress output on standard error is suppressed.
     pub quiet: bool,
 }
 
 /// Usage error from argument parsing.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UsageError {
+    /// Human-readable error text, including usage help when appropriate.
     pub message: String,
 }
 
@@ -96,7 +113,13 @@ Options:
   -q, --quiet             Suppress progress output on stderr
   -h, --help              Show this help message";
 
-/// Parse command-line arguments (everything after the program name).
+/// Parses command-line arguments following the program name.
+///
+/// # Errors
+///
+/// Returns [`UsageError`] when the `run` subcommand, task ID, or an option
+/// value is missing, or when an unknown or extra argument is present. Help is
+/// also represented as a usage error containing the usage text.
 pub fn parse_args(args: &[String]) -> Result<CliArgs, UsageError> {
     if args.is_empty() {
         return Err(UsageError {
@@ -230,7 +253,12 @@ fn raw_args_request_json(args: &[String]) -> bool {
 
 /// Parse a positive duration string like `30s`, `5m`, `1h`.
 ///
-/// Returns an error for zero, negative, or malformed values.
+/// A value without a suffix is interpreted as seconds.
+///
+/// # Errors
+///
+/// Returns an error for zero, negative, malformed, unsupported-unit, or
+/// overflowing values.
 pub fn parse_duration(s: &str) -> Result<Duration, String> {
     let trimmed = s.trim();
     if trimmed.is_empty() {
@@ -276,6 +304,11 @@ pub fn parse_duration(s: &str) -> Result<Duration, String> {
 /// Resolve workspace from CLI, environment, or task fallback.
 ///
 /// Canonicalizes the path and requires it to be an existing directory.
+///
+/// # Errors
+///
+/// Returns an error when no source supplies a path, the selected path is not
+/// an existing directory, or canonicalization fails.
 pub fn resolve_workspace(
     cli: Option<&str>,
     env: Option<&str>,
@@ -311,7 +344,12 @@ pub fn resolve_workspace(
     })
 }
 
-/// Resolve the ConfigStore database path from CLI, environment, or default.
+/// Resolves the ConfigStore database path from CLI, environment, or the platform default.
+///
+/// # Errors
+///
+/// Returns an error when the platform default cannot be determined and neither
+/// an explicit CLI nor environment path was supplied.
 pub fn resolve_config_path(cli: Option<&str>, env: Option<&str>) -> Result<PathBuf, String> {
     if let Some(p) = cli {
         return Ok(PathBuf::from(p));
@@ -322,7 +360,12 @@ pub fn resolve_config_path(cli: Option<&str>, env: Option<&str>) -> Result<PathB
     default_config_path().map_err(|e| format!("failed to determine default config path: {}", e))
 }
 
-/// Resolve timeout duration from CLI, environment, or task fallback.
+/// Resolves the timeout from CLI, environment, or the stored task fallback.
+///
+/// # Errors
+///
+/// Returns an error when the selected duration is invalid or no source
+/// supplies a timeout.
 pub fn resolve_timeout(
     cli: Option<&str>,
     env: Option<&str>,
@@ -339,7 +382,12 @@ pub fn resolve_timeout(
     })
 }
 
-/// Resolve output format from CLI or environment (default: text).
+/// Resolves output format from CLI or environment, defaulting to text.
+///
+/// # Errors
+///
+/// Returns an error unless the selected value is `text` or `json`, compared
+/// case-insensitively after trimming whitespace.
 pub fn resolve_format(cli: Option<&str>, env: Option<&str>) -> Result<OutputFormat, String> {
     let raw = cli.or(env).unwrap_or("text");
     match raw.trim().to_lowercase().as_str() {
@@ -352,7 +400,10 @@ pub fn resolve_format(cli: Option<&str>, env: Option<&str>) -> Result<OutputForm
     }
 }
 
-/// Resolve quiet flag from CLI flag or environment.
+/// Resolves quiet mode from the CLI flag or environment.
+///
+/// A set CLI flag always wins. Otherwise, environment values `1`, `true`, and
+/// `yes` enable quiet mode, compared case-insensitively after trimming.
 pub fn resolve_quiet(quiet_flag: bool, env: Option<&str>) -> bool {
     if quiet_flag {
         return true;
@@ -439,7 +490,10 @@ pub fn format_text_output(result: &AutomationRunResult) -> String {
     result.output.clone()
 }
 
-/// Format a run result as a single versioned JSON object.
+/// Formats a run result as one pretty-printed, versioned JSON object.
+///
+/// If serialization unexpectedly fails, returns a minimal versioned execution
+/// failure object instead.
 pub fn format_json_output(result: &AutomationRunResult) -> String {
     serde_json::to_string_pretty(result).unwrap_or_else(|e| {
         format!(
@@ -485,7 +539,8 @@ async fn wait_for_signal() {
 ///
 /// Returns the process exit code. This function is intended to be called
 /// from the binary's `main` on a `current_thread` Tokio runtime inside a
-/// `LocalSet`.
+/// `LocalSet`. It reads process environment variables and writes the final
+/// result to standard output and diagnostics to standard error.
 pub async fn execute_run(args: &[String]) -> i32 {
     let env: Vec<(String, String)> = std::env::vars().collect();
     execute_run_with_streams(
@@ -499,7 +554,8 @@ pub async fn execute_run(args: &[String]) -> i32 {
 
 /// Execute a headless run using the provided environment variables.
 ///
-/// Separated from [`execute_run`] for testability.
+/// Separated from [`execute_run`] for testability. Output is still written to
+/// the process standard streams.
 pub async fn execute_run_with_env(args: &[String], env: &mut [(String, String)]) -> i32 {
     execute_run_with_streams(args, env, &mut std::io::stdout(), &mut std::io::stderr()).await
 }
@@ -507,7 +563,9 @@ pub async fn execute_run_with_env(args: &[String], env: &mut [(String, String)])
 /// Execute a headless run writing output to the provided writers.
 ///
 /// This is the core implementation. Tests pass `Vec<u8>` buffers to capture
-/// stdout and stderr.
+/// stdout and stderr. The environment slice is consulted instead of the
+/// process environment, and the returned value is one of the stable `EXIT_*`
+/// codes exposed by this module.
 pub async fn execute_run_with_streams(
     args: &[String],
     env: &mut [(String, String)],

--- a/src/config/builtin_models.rs
+++ b/src/config/builtin_models.rs
@@ -80,6 +80,10 @@ impl BuiltinModelEntry {
     ///
     /// An empty vector is rejected because reasoning support requires
     /// at least one valid effort level.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `values` is empty.
     pub fn with_reasoning(mut self, values: Vec<impl Into<String>>) -> Self {
         let effort_values: Vec<String> = values.into_iter().map(Into::into).collect();
         assert!(

--- a/src/config/crypto.rs
+++ b/src/config/crypto.rs
@@ -1,3 +1,9 @@
+//! Encryption primitives for provider credentials stored in [`super::ConfigStore`].
+//!
+//! Production ciphertext uses XChaCha20-Poly1305 with a fresh random nonce per
+//! write. Callers supply associated data, which the store derives from provider
+//! slug and credential mode so encrypted rows cannot be moved between identities.
+
 use chacha20poly1305::{
     aead::{rand_core::RngCore, Aead, KeyInit, OsRng},
     AeadCore, XChaCha20Poly1305, XNonce,
@@ -6,27 +12,39 @@ use std::sync::Arc;
 
 /// Key material for credential encryption.
 pub struct CredentialKey {
+    /// Raw 256-bit key material; callers should avoid logging or serializing it.
     pub key: [u8; 32],
 }
 
 /// Encryption result containing ciphertext and metadata.
 #[derive(Debug, Clone)]
 pub struct EncryptedPayload {
+    /// Authenticated ciphertext, including the Poly1305 authentication tag.
     pub ciphertext: Vec<u8>,
+    /// Per-encryption nonce; XChaCha20-Poly1305 payloads require 24 bytes.
     pub nonce: Vec<u8>,
+    /// Versioned algorithm identifier needed to select a compatible decoder.
     pub metadata: String,
 }
 
 /// Abstraction for credential encryption/decryption.
 pub trait CredentialCipher: Send + Sync {
-    /// Encrypt a serialized credential payload.
+    /// Encrypt a serialized credential payload and authenticate `associated_data`.
+    ///
+    /// Returns [`ConfigError::Encryption`](super::error::ConfigError::Encryption)
+    /// if authenticated encryption fails.
     fn encrypt(
         &self,
         plaintext: &[u8],
         associated_data: &[u8],
     ) -> Result<EncryptedPayload, super::error::ConfigError>;
 
-    /// Decrypt an encrypted credential payload.
+    /// Decrypt and authenticate an encrypted credential payload.
+    ///
+    /// The associated data must exactly match the value used for encryption.
+    /// Unsupported metadata, malformed nonces, authentication failures, and
+    /// mismatched associated data return
+    /// [`ConfigError::Decryption`](super::error::ConfigError::Decryption).
     fn decrypt(
         &self,
         encrypted: &EncryptedPayload,
@@ -135,4 +153,5 @@ impl CredentialCipher for PlaintextCipher {
     }
 }
 
+/// Thread-safe, type-erased credential cipher used by the configuration store.
 pub type DynCredentialCipher = Arc<dyn CredentialCipher>;

--- a/src/config/effective_catalog.rs
+++ b/src/config/effective_catalog.rs
@@ -8,6 +8,7 @@ use std::collections::HashMap;
 /// Errors that can occur when building or querying the effective model catalog.
 #[derive(Debug, thiserror::Error, Clone, PartialEq)]
 pub enum CatalogError {
+    /// A custom row attempted to shadow the identified compiled-in model.
     #[error("Custom model duplicates built-in entry: ({0}, {1})")]
     DuplicateBuiltIn(String, String),
 }

--- a/src/config/error.rs
+++ b/src/config/error.rs
@@ -1,3 +1,5 @@
+//! Errors produced by durable configuration, migration, and encryption operations.
+
 use thiserror::Error;
 
 /// Errors that can occur when interacting with the config store.

--- a/src/config/key_source.rs
+++ b/src/config/key_source.rs
@@ -13,6 +13,7 @@ pub struct OsKeyringKeySource {
 }
 
 impl OsKeyringKeySource {
+    /// Create a key source for the keyring entry identified by service and account.
     pub fn new(service: impl Into<String>, account: impl Into<String>) -> Self {
         Self {
             service: service.into(),
@@ -83,6 +84,7 @@ pub struct EnvVarKeySource {
 }
 
 impl EnvVarKeySource {
+    /// Create a key source that reads a base64-encoded 32-byte key from `var_name`.
     pub fn new(var_name: impl Into<String>) -> Self {
         Self {
             var_name: var_name.into(),
@@ -115,6 +117,7 @@ pub struct StaticKeySource {
 }
 
 impl StaticKeySource {
+    /// Create a key source that returns the supplied key material unchanged.
     pub fn new(key: [u8; 32]) -> Self {
         Self { key }
     }

--- a/src/config/migrations.rs
+++ b/src/config/migrations.rs
@@ -1,8 +1,15 @@
-/// Embedded migration SQL for the config store schema.
-///
-/// Migrations are applied in order. Each migration is idempotent where possible.
+//! Embedded migrations for the configuration-store schema.
+//!
+//! SQL migrations are applied in ascending version order. Prompt identity
+//! canonicalization and its unique index are completed transactionally by Rust
+//! after the SQL steps.
+
 use sha2::{Digest, Sha256};
 
+/// Ordered `(schema_version, SQL)` migrations embedded in the binary.
+///
+/// Entries cover versions 1 through 9; version 10 is finalized by the prompt
+/// identity canonicalization performed in [`apply_migrations`].
 pub const MIGRATIONS: &[(i64, &str)] = &[
     (
         1,
@@ -235,11 +242,20 @@ pub const MIGRATIONS: &[(i64, &str)] = &[
     ),
 ];
 
-/// The current schema version.
+/// Newest configuration-store schema understood by this binary.
 #[allow(dead_code)]
 pub const CURRENT_SCHEMA_VERSION: i64 = 10;
 
-/// Apply all pending migrations to the database.
+/// Apply all pending migrations and prompt-identity repairs to a database.
+///
+/// A database created by a newer binary is rejected without mutation. Each SQL
+/// migration and the final identity/index repair are committed transactionally.
+///
+/// # Errors
+///
+/// Returns [`ConfigError::Migration`](super::error::ConfigError::Migration) if
+/// schema inspection, migration SQL, identity repair, or transaction commit
+/// fails.
 pub async fn apply_migrations(pool: &sqlx::SqlitePool) -> Result<(), super::error::ConfigError> {
     // Create schema_version table if it doesn't exist
     sqlx::query("CREATE TABLE IF NOT EXISTS schema_version (id INTEGER PRIMARY KEY CHECK (id = 1), version INTEGER NOT NULL)")

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -61,6 +61,22 @@
 //!
 //! Projection is a snapshot — later mutations to the caller's config do not
 //! affect already-constructed runtimes or agents.
+//!
+//! ## Example
+//!
+//! ```
+//! use iron_core::{ApprovalStrategy, Config, ContextWindowPolicy};
+//!
+//! let config = Config::new()
+//!     .with_model("gpt-4.1")
+//!     .with_max_iterations(6)
+//!     .with_approval_strategy(ApprovalStrategy::PerTool)
+//!     .with_context_window_policy(ContextWindowPolicy::KeepRecent(24));
+//!
+//! config.validate()?;
+//! assert_eq!(config.model, "gpt-4.1");
+//! # Ok::<(), iron_core::RuntimeError>(())
+//! ```
 
 use crate::error::RuntimeError;
 use iron_providers::{GenerationConfig, ToolPolicy};

--- a/src/config/records.rs
+++ b/src/config/records.rs
@@ -1,3 +1,9 @@
+//! Typed inputs and records for the durable configuration schema.
+//!
+//! Record types mirror values read from SQLite, including durable timestamps.
+//! Input types contain only caller-controlled columns; the store assigns and
+//! preserves timestamps when it inserts or updates rows.
+
 use chrono::{DateTime, Utc};
 use serde_json::Value;
 use std::path::PathBuf;
@@ -5,69 +11,101 @@ use std::path::PathBuf;
 /// A stored profile record.
 #[derive(Debug, Clone)]
 pub struct ProfileRecord {
+    /// Stable primary key of the profile row.
     pub id: String,
+    /// Version that determines how to decode [`Self::payload`].
     pub schema_version: i64,
+    /// Serialized profile document retained as JSON for version-aware decoding.
     pub payload: Value,
+    /// Time at which the row was first inserted.
     pub created_at: DateTime<Utc>,
+    /// Time at which the row was last replaced.
     pub updated_at: DateTime<Utc>,
 }
 
 /// Input for creating or updating a profile.
 #[derive(Debug, Clone)]
 pub struct ProfileInput {
+    /// Stable primary key to insert or replace.
     pub id: String,
+    /// Schema version of [`Self::payload`].
     pub schema_version: i64,
+    /// Profile document to serialize into the row.
     pub payload: Value,
 }
 
 /// A stored prompt record.
 #[derive(Debug, Clone)]
 pub struct PromptRecord {
+    /// Immutable primary key of the prompt row.
     pub id: String,
+    /// Version that determines how to decode [`Self::payload`].
     pub schema_version: i64,
+    /// Serialized stored-prompt document.
     pub payload: Value,
+    /// User-facing prompt name duplicated from the typed payload for identity management.
     pub display_name: String,
+    /// Canonical lookup handle protected by a unique database index.
     pub normalized_name: String,
     /// `"ready"` or `"needs_rename"`.
     pub identity_state: String,
+    /// Time at which the row was first inserted.
     pub created_at: DateTime<Utc>,
+    /// Time at which the row was last replaced or renamed.
     pub updated_at: DateTime<Utc>,
 }
 
 /// Input for creating or updating a prompt.
 #[derive(Debug, Clone)]
 pub struct PromptInput {
+    /// Immutable primary key to insert or replace.
     pub id: String,
+    /// Schema version of [`Self::payload`].
     pub schema_version: i64,
+    /// Stored-prompt document to serialize into the row.
     pub payload: Value,
+    /// User-facing name, which must agree with the typed payload for current schemas.
     pub display_name: String,
+    /// Canonical handle, which must agree with the typed payload for current schemas.
     pub normalized_name: String,
 }
 
 /// A stored schedule record.
 #[derive(Debug, Clone)]
 pub struct ScheduleRecord {
+    /// Stable primary key of the desired schedule row.
     pub id: String,
+    /// Version that determines how to decode [`Self::payload`].
     pub schema_version: i64,
+    /// Serialized desired scheduled-task state.
     pub payload: Value,
+    /// Time at which the desired schedule was first inserted.
     pub created_at: DateTime<Utc>,
+    /// Time at which the desired schedule was last replaced.
     pub updated_at: DateTime<Utc>,
 }
 
 /// Input for creating or updating a schedule entry.
 #[derive(Debug, Clone)]
 pub struct ScheduleInput {
+    /// Stable primary key to insert or replace.
     pub id: String,
+    /// Schema version of [`Self::payload`].
     pub schema_version: i64,
+    /// Desired schedule document to serialize into the row.
     pub payload: Value,
 }
 
 /// A stored provider credential record (metadata only, secrets encrypted).
 #[derive(Debug, Clone)]
 pub struct CredentialRecord {
+    /// Provider slug that uniquely owns the credential row.
     pub provider_slug: String,
+    /// Persisted mode discriminator, such as `api_key` or `oauth_bearer`.
     pub credential_mode: String,
+    /// Time at which a credential was first stored for the provider.
     pub created_at: DateTime<Utc>,
+    /// Time at which the provider's credential was last replaced or refreshed.
     pub updated_at: DateTime<Utc>,
 }
 
@@ -78,185 +116,281 @@ pub struct CredentialRecord {
 /// A stored provider runtime configuration record.
 #[derive(Debug, Clone)]
 pub struct ProviderConfigRecord {
+    /// Provider slug used as the row's primary key.
     pub provider_slug: String,
+    /// Human-readable provider name.
     pub display_name: String,
+    /// Whether the provider is enabled for runtime use.
     pub enabled: bool,
+    /// Optional API base URL override.
     pub base_url: Option<String>,
+    /// Time at which the configuration was first inserted.
     pub created_at: DateTime<Utc>,
+    /// Time at which the configuration was last replaced.
     pub updated_at: DateTime<Utc>,
 }
 
 /// Input for creating or updating a provider runtime configuration.
 #[derive(Debug, Clone)]
 pub struct ProviderConfigInput {
+    /// Provider slug to insert or replace.
     pub provider_slug: String,
+    /// Human-readable provider name.
     pub display_name: String,
+    /// Whether the provider should be enabled for runtime use.
     pub enabled: bool,
+    /// Optional API base URL override.
     pub base_url: Option<String>,
 }
 
 /// A stored custom model record.
 #[derive(Debug, Clone)]
 pub struct CustomModelRecord {
+    /// Provider that exposes the model.
     pub provider_slug: String,
+    /// Provider-specific model identifier; unique with [`Self::provider_slug`].
     pub model_id: String,
+    /// Human-readable model name.
     pub display_name: String,
+    /// Maximum input context in tokens, when known.
     pub context_window: Option<u32>,
+    /// Maximum generated output in tokens, when known.
     pub output_limit: Option<u32>,
+    /// Whether the model accepts tool definitions and calls.
     pub supports_tool_calls: bool,
+    /// Whether the model exposes reasoning controls.
     pub supports_reasoning: bool,
+    /// Whether the model accepts image input.
     pub supports_vision: bool,
+    /// Whether the model can stream responses.
     pub supports_streaming: bool,
+    /// Provider-accepted reasoning effort values.
     pub reasoning_effort_values: Vec<String>,
+    /// Input-token price per million tokens, when configured.
     pub cost_input_per_million: Option<f64>,
+    /// Output-token price per million tokens, when configured.
     pub cost_output_per_million: Option<f64>,
+    /// Time at which the custom model was first inserted.
     pub created_at: DateTime<Utc>,
+    /// Time at which the custom model was last replaced.
     pub updated_at: DateTime<Utc>,
 }
 
 /// Input for creating or updating a custom model.
 #[derive(Debug, Clone)]
 pub struct CustomModelInput {
+    /// Provider that exposes the model.
     pub provider_slug: String,
+    /// Provider-specific model identifier.
     pub model_id: String,
+    /// Human-readable model name.
     pub display_name: String,
+    /// Maximum input context in tokens, when known.
     pub context_window: Option<u32>,
+    /// Maximum generated output in tokens, when known.
     pub output_limit: Option<u32>,
+    /// Whether the model accepts tool definitions and calls.
     pub supports_tool_calls: bool,
+    /// Whether the model exposes reasoning controls.
     pub supports_reasoning: bool,
+    /// Whether the model accepts image input.
     pub supports_vision: bool,
+    /// Whether the model can stream responses.
     pub supports_streaming: bool,
+    /// Provider-accepted reasoning effort values.
     pub reasoning_effort_values: Vec<String>,
+    /// Input-token price per million tokens; must be finite and non-negative.
     pub cost_input_per_million: Option<f64>,
+    /// Output-token price per million tokens; must be finite and non-negative.
     pub cost_output_per_million: Option<f64>,
 }
 
 /// A stored default model selection record.
 #[derive(Debug, Clone)]
 pub struct DefaultModelRecord {
+    /// Provider of the selected default model.
     pub provider_slug: String,
+    /// Provider-specific identifier of the selected model.
     pub model_id: String,
+    /// Time at which the singleton selection was last changed.
     pub updated_at: DateTime<Utc>,
 }
 
 /// Input for setting the default model.
 #[derive(Debug, Clone)]
 pub struct DefaultModelInput {
+    /// Provider of the requested default model.
     pub provider_slug: String,
+    /// Provider-specific identifier of the requested model.
     pub model_id: String,
 }
 
 /// A stored MCP server configuration record.
 #[derive(Debug, Clone)]
 pub struct McpServerConfigRecord {
+    /// Stable server configuration identifier.
     pub id: String,
+    /// Human-readable server label.
     pub label: String,
+    /// Optional user-facing description.
     pub description: Option<String>,
+    /// Process or HTTP transport used to connect to the server.
     pub transport: crate::mcp::server::McpTransport,
+    /// Optional working directory for process-based transports.
     pub working_dir: Option<PathBuf>,
+    /// Whether new sessions enable this server automatically.
     pub enabled_by_default: bool,
+    /// Environment variable names inherited from the host process.
     pub inherited_env_vars: Vec<String>,
+    /// Time at which the server configuration was first inserted.
     pub created_at: DateTime<Utc>,
+    /// Time at which the server configuration was last replaced.
     pub updated_at: DateTime<Utc>,
 }
 
 /// Input for creating or updating an MCP server configuration.
 #[derive(Debug, Clone)]
 pub struct McpServerConfigInput {
+    /// Stable server configuration identifier.
     pub id: String,
+    /// Human-readable server label.
     pub label: String,
+    /// Optional user-facing description.
     pub description: Option<String>,
+    /// Process or HTTP transport used to connect to the server.
     pub transport: crate::mcp::server::McpTransport,
+    /// Optional working directory for process-based transports.
     pub working_dir: Option<PathBuf>,
+    /// Whether new sessions should enable this server automatically.
     pub enabled_by_default: bool,
+    /// Environment variable names to inherit from the host process.
     pub inherited_env_vars: Vec<String>,
 }
 
 /// A stored skill settings record.
 #[derive(Debug, Clone)]
 pub struct SkillSettingsRecord {
+    /// Whether project-local skill definitions are trusted.
     pub trust_project_skills: bool,
+    /// Additional directories included in skill discovery.
     pub additional_skill_dirs: Vec<PathBuf>,
+    /// Time at which the singleton settings row was last changed.
     pub updated_at: DateTime<Utc>,
 }
 
 /// Input for setting skill settings.
 #[derive(Debug, Clone)]
 pub struct SkillSettingsInput {
+    /// Whether project-local skill definitions should be trusted.
     pub trust_project_skills: bool,
+    /// Additional directories to include in skill discovery.
     pub additional_skill_dirs: Vec<PathBuf>,
 }
 
 /// Validated runtime settings snapshot loaded from the config store.
 #[derive(Debug, Clone)]
 pub struct RuntimeSettingsSnapshot {
+    /// Persisted provider runtime configurations.
     pub provider_configs: Vec<ProviderConfigRecord>,
+    /// Persisted custom model definitions.
     pub custom_models: Vec<CustomModelRecord>,
+    /// Selected default model, if configured.
     pub default_model: Option<DefaultModelRecord>,
+    /// Persisted MCP server configurations.
     pub mcp_servers: Vec<McpServerConfigRecord>,
+    /// Effective persisted skill settings, including defaults when no row exists.
     pub skill_settings: SkillSettingsRecord,
 }
 
 /// A stored bootstrap metadata record.
 #[derive(Debug, Clone)]
 pub struct BootstrapMetadataRecord {
+    /// Namespace that prevents unrelated bootstrap processes from colliding.
     pub domain: String,
+    /// Metadata key within [`Self::domain`].
     pub key: String,
+    /// Opaque marker or version value.
     pub value: String,
+    /// Time at which the value was last written.
     pub updated_at: DateTime<Utc>,
 }
 
 /// Input for creating or updating bootstrap metadata.
 #[derive(Debug, Clone)]
 pub struct BootstrapMetadataInput {
+    /// Namespace for the bootstrap metadata.
     pub domain: String,
+    /// Metadata key within [`Self::domain`].
     pub key: String,
+    /// Opaque marker or version value to persist.
     pub value: String,
 }
 
 /// Metadata for a saved handoff bundle.
 #[derive(Debug, Clone)]
 pub struct SavedHandoffMetadata {
+    /// Stable primary key of the saved handoff.
     pub id: String,
+    /// Human-readable handoff name.
     pub name: String,
+    /// Serialized handoff bundle format version.
     pub bundle_version: String,
+    /// Session from which the handoff originated, when recorded.
     pub source_session_id: Option<String>,
+    /// Model active when the handoff was created, when recorded.
     pub source_model: Option<String>,
+    /// Provider active when the handoff was created, when recorded.
     pub source_provider: Option<String>,
+    /// Estimated token size stored with the bundle metadata.
     pub size_estimate_tokens: usize,
+    /// Time at which the handoff was first saved.
     pub created_at: DateTime<Utc>,
+    /// Time at which the handoff was last replaced.
     pub updated_at: DateTime<Utc>,
 }
 
 /// A saved handoff record with the full bundle.
 #[derive(Debug, Clone)]
 pub struct SavedHandoffRecord {
+    /// Indexed metadata read from the handoff row.
     pub metadata: SavedHandoffMetadata,
+    /// Fully decoded durable handoff bundle.
     pub bundle: crate::context::handoff::HandoffBundle,
 }
 
 /// Input for saving a handoff bundle.
 #[derive(Debug, Clone)]
 pub struct SavedHandoffInput {
+    /// Stable primary key to insert or replace.
     pub id: String,
+    /// Human-readable handoff name.
     pub name: String,
+    /// Durable bundle whose version and metadata are validated before storage.
     pub bundle: crate::context::handoff::HandoffBundle,
 }
 
 /// A stored provider profile record (non-secret provider protocol metadata).
 #[derive(Debug, Clone)]
 pub struct ProviderProfileRecord {
+    /// Provider slug used as the row's primary key.
     pub slug: String,
+    /// Validated non-secret provider protocol metadata encoded as JSON.
     pub profile_json: String,
+    /// Optional provenance label for the imported profile.
     pub source: Option<String>,
+    /// Time at which the profile was first inserted.
     pub created_at: DateTime<Utc>,
+    /// Time at which the profile was last replaced.
     pub updated_at: DateTime<Utc>,
 }
 
 /// Input for creating or updating a stored provider profile.
 #[derive(Debug, Clone)]
 pub struct ProviderProfileInput {
+    /// Provider slug to insert or replace; must match the JSON payload's slug.
     pub slug: String,
+    /// Non-secret provider profile JSON to validate and persist.
     pub profile_json: String,
+    /// Optional provenance label for the imported profile.
     pub source: Option<String>,
 }

--- a/src/config/store.rs
+++ b/src/config/store.rs
@@ -1,3 +1,8 @@
+//! SQLite-backed implementation of the durable configuration store.
+//!
+//! Writes preserve creation timestamps on replacement, migrations run when a
+//! store opens, and credential payloads are encrypted before reaching SQLite.
+
 use super::{
     crypto::{DynCredentialCipher, XChaCha20Poly1305Cipher},
     db,
@@ -14,6 +19,15 @@ use std::sync::Arc;
 use std::time::Duration;
 
 /// Durable configuration store for AgentIron.
+///
+/// Clones share the same SQLite pool and credential cipher. Non-secret APIs
+/// remain usable when no cipher can be resolved; secret reads and writes then
+/// return [`ConfigError::KeyUnavailable`].
+///
+/// Unless a method documents a narrower condition, fallible operations can
+/// return [`ConfigError::Query`] for SQLite failures and serialization or
+/// deserialization variants for malformed values. Mutations return
+/// [`ConfigError::Validation`] when their documented invariants are not met.
 #[derive(Clone)]
 pub struct ConfigStore {
     pool: SqlitePool,
@@ -3125,7 +3139,7 @@ impl ConfigStore {
 
     /// Return the IDs of schedules with an unsupported schema version that
     /// reference the specified automation task. Unlike
-    /// [`schedules_referencing_task`], this inspects rows regardless of
+    /// [`Self::schedules_referencing_task`], this inspects rows regardless of
     /// schema version so it can surface unsupported-schema references that
     /// the typed `json_extract` queries miss.
     pub async fn unsupported_schedules_referencing_task(

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,3 +1,5 @@
+//! ACP connection handling and connection-scoped session ownership.
+
 use crate::durable::{DurableSession, SessionId};
 use crate::profile::{
     default_identity_prompt, managed_profile_prompt_context, AgentApproval, AgentProfile,
@@ -15,12 +17,27 @@ use std::rc::Rc;
 use std::sync::Arc;
 use tracing::{debug, info, warn};
 
+/// Client callbacks used to deliver ACP updates and request tool permission.
+///
+/// Implementations may also observe script and compaction activity. The
+/// returned futures are deliberately non-`Send` because a connection and its
+/// facade callbacks are local to one executor thread.
 pub trait ClientChannel {
+    /// Delivers one session notification to the connected client.
+    ///
+    /// # Errors
+    ///
+    /// The future reports transport or protocol delivery failures.
     fn send_notification(
         &self,
         notification: acp::SessionNotification,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = agent_client_protocol::Result<()>>>>;
 
+    /// Requests a permission decision from the connected client.
+    ///
+    /// # Errors
+    ///
+    /// The future reports transport or protocol request failures.
     fn request_permission(
         &self,
         request: acp::RequestPermissionRequest,
@@ -32,6 +49,10 @@ pub trait ClientChannel {
         >,
     >;
 
+    /// Reports embedded-script activity to clients that support it.
+    ///
+    /// The default implementation ignores the event. `detail` is an optional
+    /// activity-specific payload.
     fn emit_script_activity(
         &self,
         _script_id: &str,
@@ -43,6 +64,11 @@ pub trait ClientChannel {
         Box::pin(async {})
     }
 
+    /// Reports a compaction lifecycle transition to clients that support it.
+    ///
+    /// `event_type` is `started`, `finished`, or `failed`; token counts may be
+    /// unavailable, and `reason` is populated for failures. The default
+    /// implementation ignores the event.
     fn emit_compaction_event(
         &self,
         _event_type: &str,
@@ -88,8 +114,10 @@ impl ClientChannel for NopClientChannel {
     }
 }
 
+/// Reference-counted client callback channel shared within one local connection.
 pub(crate) type SharedClientChannel = Rc<dyn ClientChannel>;
 
+/// Connection-visible agent profiles keyed by stable profile ID.
 pub(crate) type ProfileRegistry = HashMap<AgentProfileId, AgentProfile>;
 
 fn default_connection_profile_registry() -> ProfileRegistry {
@@ -106,6 +134,11 @@ fn default_connection_profile_registry() -> ProfileRegistry {
     registry
 }
 
+/// An ACP connection with isolated client callbacks and session ownership.
+///
+/// Dropping the value unregisters the connection and closes every session it
+/// owns. The connection is local-thread oriented because its client channel is
+/// stored in [`Rc`].
 pub struct IronConnection {
     id: ConnectionId,
     runtime: IronRuntime,
@@ -114,6 +147,7 @@ pub struct IronConnection {
 }
 
 impl IronConnection {
+    /// Registers a connection backed by `runtime` with a default profile registry.
     pub fn new(runtime: IronRuntime) -> Self {
         Self::new_with_profile_registry(
             runtime,
@@ -121,6 +155,11 @@ impl IronConnection {
         )
     }
 
+    /// Registers a connection backed by a shared profile registry.
+    ///
+    /// Profile changes made through the shared registry are visible when a
+    /// session selects a profile, while selected profile policy is snapshotted
+    /// into the session at prompt time.
     pub fn new_with_profile_registry(
         runtime: IronRuntime,
         profile_registry: Arc<RwLock<ProfileRegistry>>,
@@ -135,18 +174,22 @@ impl IronConnection {
         }
     }
 
+    /// Returns this connection's stable runtime identifier.
     pub fn id(&self) -> ConnectionId {
         self.id
     }
 
+    /// Returns the shared runtime backing this connection.
     pub fn runtime(&self) -> &IronRuntime {
         &self.runtime
     }
 
+    /// Replaces the client callback channel used by subsequent operations.
     pub fn set_client(&self, client: SharedClientChannel) {
         *self.client.borrow_mut() = Some(client);
     }
 
+    /// Returns the shared profile registry used for profile selection.
     pub fn profile_registry(&self) -> &Arc<RwLock<ProfileRegistry>> {
         &self.profile_registry
     }
@@ -235,6 +278,10 @@ impl IronConnection {
 }
 
 impl IronConnection {
+    /// Negotiates ACP protocol version and agent capabilities.
+    ///
+    /// The current implementation accepts initialization without inspecting
+    /// request fields and advertises ACP V1 with default capabilities.
     pub async fn handle_initialize(
         &self,
         _args: acp::InitializeRequest,
@@ -248,6 +295,10 @@ impl IronConnection {
         )
     }
 
+    /// Handles ACP authentication negotiation.
+    ///
+    /// Core authentication is currently a no-op; provider authentication is
+    /// resolved separately when managed prompts run.
     pub async fn handle_authenticate(
         &self,
         _args: acp::AuthenticateRequest,
@@ -255,6 +306,12 @@ impl IronConnection {
         Ok(acp::AuthenticateResponse::new())
     }
 
+    /// Creates a new durable session owned by this connection.
+    ///
+    /// # Errors
+    ///
+    /// Returns an internal ACP error if the runtime is shut down or session
+    /// allocation otherwise fails.
     pub async fn handle_new_session(
         &self,
         _args: acp::NewSessionRequest,
@@ -271,6 +328,21 @@ impl IronConnection {
         )))
     }
 
+    /// Runs one prompt against the profile-selected or runtime-default provider.
+    ///
+    /// The user message is persisted before active-turn admission. A successful
+    /// turn finishes the active prompt, applies deferred workspace roots and
+    /// model switches in that order, then performs optional post-turn
+    /// compaction. Provider failures are recorded in the session and normally
+    /// return an `EndTurn` response rather than an ACP transport error.
+    ///
+    /// # Errors
+    ///
+    /// Returns an invalid-parameters ACP error for malformed, missing, foreign,
+    /// or already-active sessions, and when an explicitly selected profile does
+    /// not exist. The user message is already durable when active-turn admission
+    /// or profile selection fails; a profile-selection failure also leaves the
+    /// admitted prompt active until it is explicitly finished or closed.
     pub async fn handle_prompt(
         &self,
         args: acp::PromptRequest,
@@ -470,6 +542,20 @@ impl IronConnection {
         Ok(acp::PromptResponse::new(stop_reason))
     }
 
+    /// Runs one prompt using an explicit managed-provider context.
+    ///
+    /// Lifecycle ordering matches [`Self::handle_prompt`]. If provider
+    /// resolution fails, the error is persisted as agent text, the prompt is
+    /// finished, deferred turn-boundary changes are applied, and `EndTurn` is
+    /// returned.
+    ///
+    /// # Errors
+    ///
+    /// Returns an invalid-parameters ACP error for malformed, missing, foreign,
+    /// or already-active sessions, and when an explicitly selected profile does
+    /// not exist. The user message is already durable when active-turn admission
+    /// or profile selection fails; a profile-selection failure also leaves the
+    /// admitted prompt active until it is explicitly finished or closed.
     pub async fn handle_prompt_managed(
         &self,
         args: acp::PromptRequest,
@@ -647,6 +733,14 @@ impl IronConnection {
         Ok(acp::PromptResponse::new(stop_reason))
     }
 
+    /// Requests cancellation of the active prompt owned by this connection.
+    ///
+    /// Cancellation is cooperative and propagates to registered child sessions.
+    ///
+    /// # Errors
+    ///
+    /// Returns an invalid-parameters ACP error when the session ID is malformed,
+    /// missing, or owned by another connection.
     pub async fn handle_cancel(
         &self,
         args: acp::CancelNotification,
@@ -661,6 +755,14 @@ impl IronConnection {
         Ok(())
     }
 
+    /// Finishes and removes a session owned by this connection.
+    ///
+    /// Registered descendants are cancelled and removed with the session.
+    ///
+    /// # Errors
+    ///
+    /// Returns an invalid-parameters ACP error when the session ID is malformed,
+    /// missing, or owned by another connection.
     pub async fn handle_close_session(
         &self,
         args: acp::CloseSessionRequest,
@@ -675,6 +777,7 @@ impl IronConnection {
     }
 }
 
+/// Constructs a session notification for `session_id` and `update`.
 pub(crate) fn notification(
     session_id: &acp::SessionId,
     update: acp::SessionUpdate,

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -419,7 +419,10 @@ impl IronConnection {
                 .map(|slug| ProviderPromptContext {
                     provider_slug: crate::provider_credential::domain::ProviderSlug::new(slug),
                     model: session.current_model.clone().unwrap_or_default(),
-                    api_key: session.current_provider_api_key.clone(),
+                    api_key: session
+                        .current_provider_api_key
+                        .as_ref()
+                        .map(|k| k.reveal().to_string()),
                 })
         };
 

--- a/src/context/accounting.rs
+++ b/src/context/accounting.rs
@@ -1,3 +1,10 @@
+//! Estimates the context that will be visible to an inference provider.
+//!
+//! Category totals use a four-characters-per-token heuristic. When a session
+//! tracker has a provider-reported input baseline, that baseline plus local
+//! post-response deltas replaces the heuristic total while the heuristic
+//! category breakdown remains available.
+
 use crate::context::models::CompressedBlock;
 use crate::tool::ToolRegistry;
 use iron_providers::Message;
@@ -6,36 +13,57 @@ fn estimate_tokens(text: &str) -> usize {
     (text.len() as f64 * 0.25).ceil() as usize
 }
 
+/// Confidence level attached to a context token count.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ContextQuality {
+    /// The count is an unchanged provider-reported baseline.
     Exact,
+    /// At least part of the count was estimated locally.
     Estimated,
+    /// No countable context was available.
     Unknown,
 }
 
+/// Provider-visible source of context tokens.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ContextCategory {
+    /// System, identity, and session instructions.
     Instructions,
+    /// Durable summaries replacing compacted history.
     CompressedBlocks,
+    /// Uncompacted recent transcript messages.
     RecentTail,
+    /// Tool schemas supplied to the provider.
     ToolDefinitions,
+    /// User prompt about to be sent.
     CurrentPrompt,
 }
 
+/// Severity derived from the fraction of a model context window in use.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ContextPressure {
+    /// Usage is below the soft threshold.
     None,
+    /// Usage has reached the soft threshold.
     Soft,
+    /// Usage has reached the medium threshold.
     Medium,
+    /// Usage has reached the strong threshold.
     Strong,
+    /// Usage has reached the critical threshold.
     Critical,
 }
 
 impl ContextPressure {
+    /// Classifies `fullness` using the default 50%, 70%, 85%, and 95% thresholds.
     pub fn from_fullness(fullness: f64) -> Self {
         Self::from_fullness_with_thresholds(fullness, 0.50, 0.70, 0.85, 0.95)
     }
 
+    /// Classifies a context-window fraction using caller-supplied thresholds.
+    ///
+    /// Thresholds are tested from `critical` down to `soft`; this method does
+    /// not validate their ordering.
     pub fn from_fullness_with_thresholds(
         fullness: f64,
         soft: f64,
@@ -52,6 +80,7 @@ impl ContextPressure {
         }
     }
 
+    /// Returns the stable lowercase label for this pressure level.
     pub fn as_str(&self) -> &'static str {
         match self {
             ContextPressure::None => "none",
@@ -62,6 +91,7 @@ impl ContextPressure {
         }
     }
 
+    /// Returns operational guidance associated with this pressure level.
     pub fn guidance(&self) -> &'static str {
         match self {
             ContextPressure::None => "Context usage is healthy. No action needed.",
@@ -73,20 +103,29 @@ impl ContextPressure {
     }
 }
 
+/// Token usage attributed to one provider-visible context category.
 #[derive(Debug, Clone)]
 pub struct ContextCategoryUsage {
+    /// Source category represented by this entry.
     pub category: ContextCategory,
+    /// Token count for the category.
     pub tokens: usize,
+    /// Confidence in the category count.
     pub quality: ContextQuality,
 }
 
+/// Point-in-time estimate of the next provider request's context footprint.
 #[derive(Debug, Clone)]
 pub struct ActiveContextSnapshot {
+    /// Best available total token count.
     pub total_tokens: usize,
+    /// Active model's context-window limit, when known.
     pub context_window_limit: Option<usize>,
     /// Token threshold at which automatic context compaction is requested.
     pub compact_threshold_tokens: Option<usize>,
+    /// Confidence in [`Self::total_tokens`].
     pub quality: ContextQuality,
+    /// Heuristic breakdown by context source.
     pub categories: Vec<ContextCategoryUsage>,
     /// Current model identifier for this session
     pub current_model: Option<String>,
@@ -97,16 +136,23 @@ pub struct ActiveContextSnapshot {
 }
 
 impl ActiveContextSnapshot {
+    /// Returns the fraction of the known context window currently occupied.
+    ///
+    /// Returns `None` when the limit is absent or zero. Values may exceed `1.0`.
     pub fn fullness(&self) -> Option<f64> {
         self.context_window_limit
             .filter(|limit| *limit > 0)
             .map(|limit| self.total_tokens as f64 / limit as f64)
     }
 
+    /// Classifies fullness using the default pressure thresholds.
     pub fn pressure(&self) -> ContextPressure {
         self.pressure_with_thresholds(0.50, 0.70, 0.85, 0.95)
     }
 
+    /// Classifies fullness using caller-supplied pressure thresholds.
+    ///
+    /// An unknown context-window limit produces [`ContextPressure::None`].
     pub fn pressure_with_thresholds(
         &self,
         soft: f64,
@@ -122,14 +168,23 @@ impl ActiveContextSnapshot {
     }
 }
 
+/// Model identity and switch history supplied to an accounting snapshot.
 pub struct SessionModelInfo<'a> {
+    /// Current model identifier, when one has been selected.
     pub current_model: Option<&'a str>,
+    /// Number of completed model switches in the session.
     pub model_switch_count: usize,
 }
 
+/// Stateless calculator for provider-visible context estimates.
 pub struct ActiveContextAccountant;
 
 impl ActiveContextAccountant {
+    /// Estimates a context snapshot from rendered request components.
+    ///
+    /// A valid `tracker` baseline supplies the total, with `current_prompt`
+    /// added because it has not yet appeared in provider usage. Without a
+    /// baseline, all components use the local text-length heuristic.
     #[allow(clippy::too_many_arguments)]
     pub fn estimate_snapshot(
         instructions: Option<&str>,
@@ -255,6 +310,9 @@ impl ActiveContextAccountant {
         }
     }
 
+    /// Estimates tokens for transcript messages using text length.
+    ///
+    /// Tool names and their JSON arguments or results are included.
     pub fn estimate_messages_tokens(messages: &[Message]) -> usize {
         let text: String = messages
             .iter()
@@ -276,9 +334,11 @@ impl ActiveContextAccountant {
     }
 }
 
+/// Stateless facade for producing session context telemetry.
 pub struct ContextTelemetry;
 
 impl ContextTelemetry {
+    /// Produces the same snapshot as [`ActiveContextAccountant::estimate_snapshot`].
     #[allow(clippy::too_many_arguments)]
     pub fn for_session(
         instructions: Option<&str>,

--- a/src/context/compaction.rs
+++ b/src/context/compaction.rs
@@ -1,10 +1,19 @@
+//! Model-directed compaction of resolved durable context.
+//!
+//! Compaction validates every requested inclusive range before mutation, then
+//! permanently removes the selected timeline entries or older compressed
+//! blocks and replaces each range with a durable summary. Active context and
+//! either half of a tool-call/result pair are protected from removal.
+
 use crate::context::models::CompressedBlock;
 use crate::durable::{DurableSession, TimelineEntry};
 use crate::tool::ToolDefinition;
 use serde_json::Value;
 use std::collections::BTreeSet;
 
+/// Provider-facing name of the runtime-owned compaction tool.
 pub const COMPRESS_TOOL_NAME: &str = "compress";
+/// Method label recorded for summaries created by the model.
 pub const COMPRESS_METHOD_MODEL_SUMMARY: &str = "model_summary";
 
 /// Runtime-owned compress tool: validates ranges, applies compression, and
@@ -12,6 +21,7 @@ pub const COMPRESS_METHOD_MODEL_SUMMARY: &str = "model_summary";
 pub struct CompressTool;
 
 impl CompressTool {
+    /// Returns the provider-facing definition of the `compress` tool.
     pub fn definition() -> ToolDefinition {
         ToolDefinition::new(
             COMPRESS_TOOL_NAME,
@@ -51,6 +61,15 @@ impl CompressTool {
         )
     }
 
+    /// Parses and validates the shape of provider-supplied compaction arguments.
+    ///
+    /// Both canonical `start_message_id`/`end_message_id` keys and the legacy
+    /// `start_id`/`end_id` aliases are accepted.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the topic, content array, IDs, or summary is
+    /// absent or empty.
     pub fn parse_arguments(arguments: &Value) -> Result<(String, Vec<CompressRange>), String> {
         let topic = arguments
             .get("topic")
@@ -102,7 +121,14 @@ impl CompressTool {
     /// Execute a compress request from the model.
     ///
     /// The model provides a topic and one or more source ranges with summaries.
-    /// The runtime validates all ranges before mutating state.
+    /// The runtime validates all ranges before mutating state. Successful
+    /// execution invalidates provider token accounting because the visible
+    /// transcript has been rewritten.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for unknown, reversed, overlapping, protected, or
+    /// improperly paired tool-call ranges. The session is unchanged on error.
     pub fn execute(
         session: &mut DurableSession,
         topic: String,
@@ -369,18 +395,28 @@ impl ResolvedRange {
     }
 }
 
+/// Inclusive visible-ID range and its durable replacement summary.
 #[derive(Debug, Clone)]
 pub struct CompressRange {
+    /// First compressed block or timeline visible ID in the range.
     pub start_id: String,
+    /// Last compressed block or timeline visible ID in the range.
     pub end_id: String,
+    /// Model-produced text that permanently replaces the range.
     pub summary: String,
 }
 
+/// Outcome and telemetry from a successful compaction.
 #[derive(Debug, Clone)]
 pub struct CompressResult {
+    /// Durable summaries added to the session.
     pub blocks_created: Vec<CompressedBlock>,
+    /// Best available estimate before the rewrite.
     pub tokens_before: Option<usize>,
+    /// Sum of available replacement-summary estimates.
     pub tokens_after: Option<usize>,
+    /// Compaction method label.
     pub method: String,
+    /// Pressure label recalculated after compaction.
     pub pressure_state: String,
 }

--- a/src/context/config.rs
+++ b/src/context/config.rs
@@ -1,3 +1,5 @@
+//! Configuration for context pressure, retention, handoff, and model switches.
+
 use serde::{Deserialize, Serialize};
 
 const DEFAULT_MAINTENANCE_THRESHOLD: usize = 50_000;
@@ -7,18 +9,28 @@ const DEFAULT_MEDIUM_THRESHOLD: f64 = 0.70;
 const DEFAULT_STRONG_THRESHOLD: f64 = 0.85;
 const DEFAULT_CRITICAL_THRESHOLD: f64 = 0.95;
 
+/// Context-management policy applied to a session.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ContextManagementConfig {
+    /// Whether automatic context management is enabled.
     pub enabled: bool,
+    /// Uncompacted token count that requests maintenance.
     pub maintenance_threshold: usize,
+    /// Policy for preserving recent uncompacted conversation context.
     pub tail_retention: TailRetentionRule,
+    /// Policy for exporting portable handoff bundles.
     pub handoff_export: HandoffExportConfig,
+    /// Fallback model context-window size when provider metadata is unavailable.
     pub context_window_hint: Option<usize>,
+    /// Fullness fraction at which soft pressure begins.
     pub soft_threshold: f64,
+    /// Fullness fraction at which medium pressure begins.
     pub medium_threshold: f64,
+    /// Fullness fraction at which strong pressure begins.
     pub strong_threshold: f64,
+    /// Fullness fraction at which critical pressure begins.
     pub critical_threshold: f64,
-    /// Configuration for model switching context adaptation
+    /// Configuration for model-switch context adaptation.
     #[serde(default)]
     pub model_switch: ModelSwitchConfig,
 }
@@ -41,55 +53,73 @@ impl Default for ContextManagementConfig {
 }
 
 impl ContextManagementConfig {
+    /// Creates the disabled default configuration.
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Enables automatic context management.
     pub fn enabled(mut self) -> Self {
         self.enabled = true;
         self
     }
 
+    /// Sets the uncompacted token count that requests maintenance.
     pub fn with_maintenance_threshold(mut self, threshold: usize) -> Self {
         self.maintenance_threshold = threshold;
         self
     }
 
+    /// Sets the recent-tail retention policy.
     pub fn with_tail_retention(mut self, rule: TailRetentionRule) -> Self {
         self.tail_retention = rule;
         self
     }
 
+    /// Sets handoff export policy.
     pub fn with_handoff_export(mut self, config: HandoffExportConfig) -> Self {
         self.handoff_export = config;
         self
     }
 
+    /// Sets a fallback context-window size in tokens.
     pub fn with_context_window_hint(mut self, hint: usize) -> Self {
         self.context_window_hint = Some(hint);
         self
     }
 
+    /// Sets the soft pressure fraction.
     pub fn with_soft_threshold(mut self, threshold: f64) -> Self {
         self.soft_threshold = threshold;
         self
     }
 
+    /// Sets the medium pressure fraction.
     pub fn with_medium_threshold(mut self, threshold: f64) -> Self {
         self.medium_threshold = threshold;
         self
     }
 
+    /// Sets the strong pressure fraction.
     pub fn with_strong_threshold(mut self, threshold: f64) -> Self {
         self.strong_threshold = threshold;
         self
     }
 
+    /// Sets the critical pressure fraction.
     pub fn with_critical_threshold(mut self, threshold: f64) -> Self {
         self.critical_threshold = threshold;
         self
     }
 
+    /// Validates enabled context-management configuration.
+    ///
+    /// Disabled configuration is accepted without validating dormant values.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for zero token/count limits, fractions outside
+    /// `0.0..=1.0`, unordered pressure thresholds, or invalid nested policy.
     pub fn validate(&self) -> Result<(), String> {
         if !self.enabled {
             return Ok(());
@@ -128,15 +158,19 @@ impl ContextManagementConfig {
         self.model_switch.validate()
     }
 
+    /// Sets model-switch adaptation policy.
     pub fn with_model_switch_config(mut self, config: ModelSwitchConfig) -> Self {
         self.model_switch = config;
         self
     }
 }
 
+/// Size and portability policy for handoff exports.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct HandoffExportConfig {
+    /// Approximate target size of an exported bundle in tokens.
     pub default_target_tokens: usize,
+    /// Whether local-resource portability warnings are appended to the note.
     pub include_portability_notes: bool,
 }
 
@@ -150,11 +184,17 @@ impl Default for HandoffExportConfig {
 }
 
 impl HandoffExportConfig {
+    /// Sets the approximate exported-bundle target in tokens.
     pub fn with_target_tokens(mut self, tokens: usize) -> Self {
         self.default_target_tokens = tokens;
         self
     }
 
+    /// Validates that the target token count is nonzero.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when `default_target_tokens` is zero.
     pub fn validate(&self) -> Result<(), String> {
         if self.default_target_tokens == 0 {
             return Err("handoff default_target_tokens must be greater than 0".into());
@@ -163,10 +203,14 @@ impl HandoffExportConfig {
     }
 }
 
+/// Rule for choosing the recent context tail retained by maintenance.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum TailRetentionRule {
+    /// Retain a fixed number of recent messages.
     Messages(usize),
+    /// Retain recent messages up to an approximate token budget.
     Tokens(usize),
+    /// Apply combined minimum-message and optional token constraints.
     Policy(TailRetentionPolicy),
 }
 
@@ -177,6 +221,11 @@ impl Default for TailRetentionRule {
 }
 
 impl TailRetentionRule {
+    /// Validates that configured retention counts are nonzero.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for a zero count or invalid nested policy.
     pub fn validate(&self) -> Result<(), String> {
         match self {
             Self::Messages(n) | Self::Tokens(n) => {
@@ -190,9 +239,12 @@ impl TailRetentionRule {
     }
 }
 
+/// Combined constraints for retaining an uncompacted recent tail.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TailRetentionPolicy {
+    /// Minimum number of recent messages to retain.
     pub min_messages: usize,
+    /// Optional approximate token ceiling for retained messages.
     pub max_tokens: Option<usize>,
 }
 
@@ -206,16 +258,23 @@ impl Default for TailRetentionPolicy {
 }
 
 impl TailRetentionPolicy {
+    /// Sets the minimum retained message count.
     pub fn with_min_messages(mut self, n: usize) -> Self {
         self.min_messages = n;
         self
     }
 
+    /// Sets the approximate retained-tail token ceiling.
     pub fn with_max_tokens(mut self, tokens: usize) -> Self {
         self.max_tokens = Some(tokens);
         self
     }
 
+    /// Validates that configured message and token counts are nonzero.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when `min_messages` or a present `max_tokens` is zero.
     pub fn validate(&self) -> Result<(), String> {
         if self.min_messages == 0 {
             return Err("min_messages must be greater than 0".into());
@@ -229,16 +288,16 @@ impl TailRetentionPolicy {
     }
 }
 
-/// Configuration for model switching context adaptation
+/// Configuration for context adaptation at a model-switch boundary.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ModelSwitchConfig {
-    /// Whether to compact context before switching to a smaller window
+    /// Whether to compact context before switching to a smaller window.
     pub compact_on_window_shrink: bool,
-    /// Default number of messages to retain in tail after compaction
+    /// Default number of messages to retain in the tail after compaction.
     pub default_tail_messages: usize,
-    /// Minimum context window before erroring (in tokens)
+    /// Smallest target context window accepted, in tokens.
     pub minimum_window_tokens: usize,
-    /// Whether to generate a session briefing on provider change
+    /// Whether to generate a session briefing when the provider changes.
     pub briefing_on_provider_change: bool,
 }
 
@@ -254,6 +313,12 @@ impl Default for ModelSwitchConfig {
 }
 
 impl ModelSwitchConfig {
+    /// Validates model-switch count and token limits.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when `default_tail_messages` or
+    /// `minimum_window_tokens` is zero.
     pub fn validate(&self) -> Result<(), String> {
         if self.default_tail_messages == 0 {
             return Err("default_tail_messages must be greater than 0".into());
@@ -264,21 +329,25 @@ impl ModelSwitchConfig {
         Ok(())
     }
 
+    /// Sets whether window shrinkage may trigger compaction.
     pub fn with_compact_on_window_shrink(mut self, enabled: bool) -> Self {
         self.compact_on_window_shrink = enabled;
         self
     }
 
+    /// Sets the default number of recent messages retained after adaptation.
     pub fn with_default_tail_messages(mut self, messages: usize) -> Self {
         self.default_tail_messages = messages;
         self
     }
 
+    /// Sets the smallest accepted target context window.
     pub fn with_minimum_window_tokens(mut self, tokens: usize) -> Self {
         self.minimum_window_tokens = tokens;
         self
     }
 
+    /// Sets whether provider changes generate a session briefing.
     pub fn with_briefing_on_provider_change(mut self, enabled: bool) -> Self {
         self.briefing_on_provider_change = enabled;
         self

--- a/src/context/handoff.rs
+++ b/src/context/handoff.rs
@@ -65,7 +65,11 @@ pub struct HandoffBundle {
     /// Current managed-provider slug, if any.
     pub current_provider_slug: Option<String>,
     /// Current managed-provider API key, if any.
-    pub current_provider_api_key: Option<String>,
+    ///
+    /// Wrapped in a [`crate::secret::SecretString`] so the credential is redacted
+    /// from debug output. It still serializes transparently because serialized
+    /// bundles must remain usable as portable secrets.
+    pub current_provider_api_key: Option<crate::secret::SecretString>,
     /// Profile identity prompt selected for this session, if any.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub profile_identity: Option<String>,

--- a/src/context/handoff.rs
+++ b/src/context/handoff.rs
@@ -18,38 +18,58 @@ use crate::durable::{DurableSession, SessionId, StructuredMessage};
 use crate::skill::SessionSkillState;
 use serde::{Deserialize, Serialize};
 
+/// Current serialized handoff bundle format version.
 pub const HANDOFF_BUNDLE_VERSION: &str = "1";
 
+/// Provenance and approximate size of a handoff bundle.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct HandoffBundleMetadata {
+    /// Metadata schema version.
     pub version: String,
+    /// Model reported by the exporter.
     pub source_model: String,
+    /// Source provider name, when known.
     pub source_provider: Option<String>,
+    /// Display form of the source session identifier.
     pub source_session_id: String,
+    /// Heuristic size of instructions, summaries, tail, and active skills.
     pub size_estimate_tokens: usize,
 }
 
+/// Portable continuity state transferred between durable sessions.
+///
+/// The bundle owns cloned instructions, summaries, recent messages, skill
+/// state, profile snapshots, and model-switch state. Runtime-local MCP and
+/// plugin enablement are intentionally absent. Managed provider credentials
+/// are included when present, so serialized bundles must be handled as secrets.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct HandoffBundle {
+    /// Bundle schema version.
     pub version: String,
+    /// Explicit source-session instructions.
     pub instructions: Option<String>,
+    /// Human-readable continuity and portability note.
     pub handoff_note: String,
+    /// Durable summaries selected for transfer.
     pub compressed_blocks: Vec<CompressedBlock>,
+    /// Recent structured messages selected for transfer.
     pub recent_tail: Vec<StructuredMessage>,
+    /// Activated skill state preserved across runtimes.
     pub skill_state: SessionSkillState,
+    /// Bundle provenance and size estimate.
     pub metadata: HandoffBundleMetadata,
-    /// Model switch history preserved across handoffs
+    /// Model-switch history preserved across handoffs.
     pub model_switch_history: Vec<ModelSwitchRecord>,
-    /// Current model after the most recent switch
+    /// Current model after the most recent switch.
     pub current_model: Option<String>,
-    /// Current provider slug (if managed)
+    /// Current managed-provider slug, if any.
     pub current_provider_slug: Option<String>,
-    /// Current provider API key (if managed)
+    /// Current managed-provider API key, if any.
     pub current_provider_api_key: Option<String>,
     /// Profile identity prompt selected for this session, if any.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub profile_identity: Option<String>,
-    /// Tools hidden due to model capability differences
+    /// Tools hidden due to model capability differences.
     #[serde(default)]
     pub hidden_tools: Vec<String>,
     /// The profile id last used for this session, if any.
@@ -73,9 +93,13 @@ pub struct HandoffBundle {
         Option<crate::provider_credential::domain::ProviderPromptContext>,
 }
 
+/// Validator and builder for portable handoff bundles.
 pub struct HandoffExporter;
 
 impl HandoffExporter {
+    /// Returns whether the session has no pending or running tool calls.
+    ///
+    /// Handoff export is restricted to this idle tool lifecycle boundary.
     pub fn can_export(session: &DurableSession) -> bool {
         !session.tool_records.iter().any(|r| {
             matches!(
@@ -86,6 +110,15 @@ impl HandoffExporter {
         })
     }
 
+    /// Clones selected continuity state into a portable bundle.
+    ///
+    /// `compressed_blocks` and `tail` are caller-selected views; they need not
+    /// equal all context currently owned by `session`. Runtime-local tool and
+    /// plugin enablement are not exported.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error while a tool call is pending approval or running.
     pub fn export(
         session: &DurableSession,
         model: &str,
@@ -178,9 +211,22 @@ impl HandoffExporter {
     }
 }
 
+/// Hydrates durable sessions from owned handoff bundles.
 pub struct HandoffImporter;
 
 impl HandoffImporter {
+    /// Merges an owned bundle into an existing durable session.
+    ///
+    /// Imported summaries are rendered as an agent message, recent tail items
+    /// are appended directly to message storage, and model-switch timeline
+    /// metadata is recreated. Existing runtime-local MCP and plugin enablement
+    /// remains owned by the target and is not replaced. The target retains its
+    /// session identity.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the target identifier equals the newly allocated
+    /// identity used by the method's mismatch guard.
     pub fn hydrate(target: &mut DurableSession, bundle: HandoffBundle) -> Result<(), String> {
         if target.id == SessionId::new() {
             return Err(
@@ -254,6 +300,10 @@ impl HandoffImporter {
         Ok(())
     }
 
+    /// Creates a fresh durable session and hydrates it from an owned bundle.
+    ///
+    /// The destination receives a new [`SessionId`]. Runtime-local MCP and
+    /// plugin enablement starts empty rather than crossing the handoff boundary.
     pub fn hydrate_into_new(bundle: HandoffBundle) -> DurableSession {
         let mut session = DurableSession::new(SessionId::new());
 

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -1,10 +1,25 @@
-//! Context management: compression, telemetry, and handoff
+//! Context management: accounting, compression, model switching, and handoff.
 //!
 //! This module implements context management:
 //!
 //! - **`active_context`**: the provider-visible footprint of the next request
 //! - **`compressed_blocks`**: freeform compressed context summaries
 //! - **`handoff_bundle`**: portable continuity payload for cross-session transfer
+//!
+//! ```
+//! use iron_core::{Config, ContextManagementConfig, TailRetentionRule};
+//!
+//! let context = ContextManagementConfig::new()
+//!     .enabled()
+//!     .with_maintenance_threshold(32_000)
+//!     .with_context_window_hint(128_000)
+//!     .with_tail_retention(TailRetentionRule::Messages(16));
+//! context.validate()?;
+//!
+//! let config = Config::default().with_context_management(context);
+//! assert!(config.context_management.enabled);
+//! # Ok::<(), String>(())
+//! ```
 
 pub mod accounting;
 pub mod compaction;

--- a/src/context/model_switch.rs
+++ b/src/context/model_switch.rs
@@ -1,60 +1,64 @@
-//! Model switching: turn-boundary model changes with context adaptation
+//! Model switching: turn-boundary model changes with context adaptation.
 //!
 //! This module implements model switching as a first-class operation that
 //! preserves session identity while adapting context and reconciling capabilities.
 
 use serde::{Deserialize, Serialize};
 
-/// Plan for adapting a session to a new model
+/// Plan for adapting a session before changing its active model.
+///
+/// Planning does not mutate a session or provider. The runtime applies the
+/// plan at an idle turn boundary so session identity and durable history remain
+/// continuous across the switch.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ModelSwitchPlan {
-    /// Source model identifier
+    /// Source model identifier.
     pub source_model: String,
-    /// Target model identifier
+    /// Target model identifier.
     pub target_model: String,
-    /// Source provider slug (if managed)
+    /// Source managed-provider slug, if any.
     pub source_provider: Option<String>,
-    /// Target provider slug (if managed)
+    /// Target managed-provider slug, if any.
     pub target_provider: Option<String>,
-    /// Context adaptation required
+    /// Context adaptation required before the target can be used.
     pub context_adaptation: ContextAdaptationPlan,
-    /// Capability differences between source and target
+    /// Capability differences between source and target.
     pub capability_diff: CapabilityDiff,
-    /// Whether compaction was triggered
+    /// Whether planning determined that compaction is required.
     pub compaction_triggered: bool,
-    /// Estimated tokens after adaptation
+    /// Estimated retained token count after adaptation.
     pub estimated_tokens_after: usize,
-    /// Target context window (if known)
+    /// Target context-window size, if known.
     pub target_window: Option<usize>,
 }
 
-/// Plan for adapting context to fit target constraints
+/// Planned retention needed to fit context into target constraints.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ContextAdaptationPlan {
-    /// Whether context needs to be compacted
+    /// Whether context needs to be compacted.
     pub needs_compaction: bool,
-    /// Number of messages to retain in tail
+    /// Number of recent messages to retain.
     pub tail_messages: usize,
-    /// Whether the tail fits within target window
+    /// Whether the estimated retained tail fits the target window.
     pub tail_fits: bool,
-    /// Estimated tokens of retained context
+    /// Estimated tokens in retained context.
     pub retained_tokens: usize,
 }
 
-/// Differences in capabilities between source and target models
+/// Capabilities lost or restricted when moving to a target model.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CapabilityDiff {
-    /// Tools that are unavailable in the target model
+    /// Tools unavailable in the target model.
     pub hidden_tools: Vec<String>,
-    /// Modalities unsupported by target (e.g., "image", "pdf")
+    /// Source modalities unsupported by the target, such as `image` or `pdf`.
     pub unsupported_modalities: Vec<String>,
-    /// Context window shrink in tokens (if smaller)
+    /// Number of tokens by which the target window is smaller.
     pub window_shrink: Option<usize>,
-    /// Features unsupported by target
+    /// Source features unsupported by the target.
     pub unsupported_features: Vec<String>,
-    /// Whether the target supports tool calling
+    /// Whether the target supports tool calling.
     pub tools_supported: bool,
-    /// Whether the target supports streaming
+    /// Whether the target supports streaming.
     pub streaming_supported: bool,
 }
 
@@ -71,38 +75,43 @@ impl Default for CapabilityDiff {
     }
 }
 
-/// Request to switch models
+/// Owned provider selection queued for a model switch.
 #[derive(Debug, Clone, PartialEq)]
 pub enum ModelSwitchRequest {
-    /// Switch to a managed provider (resolved via credential store)
+    /// Switch to a managed provider resolved through configured credentials.
     Managed {
+        /// Managed-provider slug.
         provider_slug: String,
+        /// Target model identifier.
         model: String,
+        /// Explicit provider API key, when supplied.
         api_key: Option<String>,
     },
-    /// Switch to an unmanaged provider (direct Provider instance)
+    /// Switch to an unmanaged provider instance.
     Unmanaged {
+        /// Target model identifier.
         model: String,
+        /// Display name of the provider instance.
         provider_name: String,
     },
 }
 
-/// Record of a model switch for timeline/history
+/// Durable history record of an applied model switch.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ModelSwitchRecord {
-    /// Source model
+    /// Source model.
     pub from_model: String,
-    /// Target model
+    /// Target model.
     pub to_model: String,
-    /// Source provider
+    /// Source provider, if recorded.
     pub from_provider: Option<String>,
-    /// Target provider
+    /// Target provider, if recorded.
     pub to_provider: Option<String>,
-    /// Whether context was adapted
+    /// Whether context or capabilities required adaptation.
     pub adapted: bool,
-    /// Capability differences
+    /// Capability restrictions discovered for the target.
     pub capability_diff: CapabilityDiff,
-    /// Timestamp of the switch
+    /// UTC timestamp at which the switch was recorded.
     pub timestamp: chrono::DateTime<chrono::Utc>,
 }
 
@@ -117,17 +126,17 @@ pub struct CompactionInfo {
     pub method: String,
 }
 
-/// Pending model switch queued for turn boundary
+/// Model switch request waiting for an idle turn boundary.
 #[derive(Debug, Clone)]
 pub struct PendingModelSwitch {
-    /// The switch request
+    /// Owned provider and model selection to apply.
     pub request: ModelSwitchRequest,
-    /// When the switch was requested
+    /// UTC timestamp at which the request was queued.
     pub requested_at: chrono::DateTime<chrono::Utc>,
 }
 
 impl ModelSwitchPlan {
-    /// Create a new plan with default adaptation
+    /// Creates a plan with no adaptation and a default 20-message tail.
     pub fn new(source_model: impl Into<String>, target_model: impl Into<String>) -> Self {
         Self {
             source_model: source_model.into(),
@@ -147,7 +156,7 @@ impl ModelSwitchPlan {
         }
     }
 
-    /// Whether the switch requires any adaptation
+    /// Returns whether compaction or any capability restriction is required.
     pub fn requires_adaptation(&self) -> bool {
         self.context_adaptation.needs_compaction
             || !self.capability_diff.hidden_tools.is_empty()
@@ -157,17 +166,17 @@ impl ModelSwitchPlan {
 }
 
 impl ContextAdaptationPlan {
-    /// Whether the context fits within the target window
+    /// Returns whether no compaction is required and the retained tail fits.
     pub fn fits(&self) -> bool {
         self.tail_fits && !self.needs_compaction
     }
 }
 
-/// Planner for model switches that estimates context and creates adaptation plans
+/// Stateless planner for model-switch context and capability adaptation.
 pub struct ModelSwitchPlanner;
 
 impl ModelSwitchPlanner {
-    /// Create a plan for switching from source to target model
+    /// Creates a plan for switching from a source model to a target model.
     ///
     /// Estimates current context size and determines if compaction is needed
     /// based on the target model's context window.
@@ -187,7 +196,11 @@ impl ModelSwitchPlanner {
         )
     }
 
-    /// Create a plan with capability comparison
+    /// Creates a plan and compares capabilities when both metadata records exist.
+    ///
+    /// When `target_window` is unknown, the full current estimate is assumed to
+    /// fit. When it is exceeded, retained tail size uses a coarse 20-message
+    /// average and never plans fewer than five messages before the 20-message cap.
     pub fn create_plan_with_capabilities(
         source_model: &str,
         target_model: &str,
@@ -254,9 +267,9 @@ impl ModelSwitchPlanner {
         (total_tokens as f64 * 0.6) as usize
     }
 
-    /// Estimate total context size from a session
+    /// Estimates total context from uncompacted tokens and block summary length.
     ///
-    /// Sums uncompacted tokens plus an estimate for compressed blocks.
+    /// Compressed summaries use a four-characters-per-token heuristic.
     pub fn estimate_session_tokens(
         uncompacted_tokens: usize,
         compressed_blocks: &[crate::context::models::CompressedBlock],
@@ -270,23 +283,35 @@ impl ModelSwitchPlanner {
     }
 }
 
-/// Simple model capability metadata
+/// Capability metadata used to compare two model/provider pairs.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ModelCapabilityMetadata {
+    /// Model identifier.
     pub model: String,
+    /// Provider identifier.
     pub provider: String,
+    /// Maximum context-window size in tokens.
     pub context_window: usize,
+    /// Whether tool calling is supported.
     pub supports_tools: bool,
+    /// Whether streamed responses are supported.
     pub supports_streaming: bool,
+    /// Whether reasoning-effort selection is supported.
     #[serde(default)]
     pub supports_reasoning_effort: bool,
+    /// Accepted reasoning-effort values.
     #[serde(default)]
     pub reasoning_effort_values: Vec<String>,
+    /// Input modalities supported by the model.
     pub supported_modalities: Vec<String>,
+    /// Tool names explicitly unavailable for this model.
     pub unsupported_tools: Vec<String>,
 }
 
-/// Compare capabilities between source and target models
+/// Compares source capabilities with restrictions on a target model.
+///
+/// The result records capabilities lost during the switch; it is not a full
+/// independent description of either model.
 pub fn compare_capabilities(
     source: &ModelCapabilityMetadata,
     target: &ModelCapabilityMetadata,
@@ -328,26 +353,32 @@ pub fn compare_capabilities(
     diff
 }
 
-/// Registry for model capability metadata
+/// In-memory registry keyed by provider and model identifier.
 #[derive(Debug, Clone, Default)]
 pub struct ModelCapabilityRegistry {
     models: std::collections::HashMap<(String, String), ModelCapabilityMetadata>,
 }
 
 impl ModelCapabilityRegistry {
+    /// Creates an empty capability registry.
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Inserts or replaces metadata for its provider/model pair.
     pub fn register(&mut self, metadata: ModelCapabilityMetadata) {
         let key = (metadata.provider.clone(), metadata.model.clone());
         self.models.insert(key, metadata);
     }
 
+    /// Returns metadata for an exact provider/model pair.
     pub fn get(&self, provider: &str, model: &str) -> Option<&ModelCapabilityMetadata> {
         self.models.get(&(provider.to_string(), model.to_string()))
     }
 
+    /// Compares two registered provider/model pairs.
+    ///
+    /// Returns `None` if either pair is absent.
     pub fn compare(
         &self,
         source_provider: &str,

--- a/src/context/models.rs
+++ b/src/context/models.rs
@@ -1,5 +1,8 @@
+//! Persisted data produced by context compaction.
+
 use serde::{Deserialize, Serialize};
 
+/// Default approximate size target for an exported handoff bundle.
 pub const HANDOFF_DEFAULT_TARGET_TOKENS: usize = 15_000;
 
 /// A compressed block stores a freeform summary produced by model-driven
@@ -25,6 +28,9 @@ pub struct CompressedBlock {
 }
 
 impl CompressedBlock {
+    /// Creates a compressed block with the current UTC timestamp.
+    ///
+    /// Token estimates remain unset until the compaction caller supplies them.
     pub fn new(
         id: impl Into<String>,
         topic: impl Into<String>,
@@ -42,6 +48,7 @@ impl CompressedBlock {
         }
     }
 
+    /// Renders the summary and its provenance as provider-visible text.
     pub fn render_to_text(&self) -> String {
         format!(
             "[Compressed context: {}]\nID: {}\nSource range: {}\n{}\n",

--- a/src/context/telemetry.rs
+++ b/src/context/telemetry.rs
@@ -1,1 +1,3 @@
+//! Telemetry facade for provider-visible context accounting.
+
 pub use crate::context::accounting::ContextTelemetry;

--- a/src/context/token_tracker.rs
+++ b/src/context/token_tracker.rs
@@ -1,14 +1,22 @@
+//! Provider-reported token baselines and session-local delta accounting.
+
 use crate::context::ContextQuality;
 use iron_providers::TokenUsage;
 
 /// Accumulated provider-reported token usage totals.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct TokenUsageTotals {
+    /// Sum of provider-reported input tokens.
     pub input_tokens: u64,
+    /// Sum of provider-reported output tokens.
     pub output_tokens: u64,
+    /// Sum of provider-reported cached input tokens.
     pub cached_input_tokens: u64,
+    /// Sum of provider-reported cache-creation input tokens.
     pub cache_creation_input_tokens: u64,
+    /// Sum of provider-reported cache-read input tokens.
     pub cache_read_input_tokens: u64,
+    /// Sum of provider-reported reasoning output tokens.
     pub reasoning_output_tokens: u64,
 }
 
@@ -117,32 +125,37 @@ impl SessionTokenTracker {
         }
     }
 
-    // ── accumulated usage telemetry ──
-
+    /// Returns accumulated provider-reported input tokens.
     pub fn accumulated_input_tokens(&self) -> u64 {
         self.accumulated_input_tokens
     }
 
+    /// Returns accumulated provider-reported output tokens.
     pub fn accumulated_output_tokens(&self) -> u64 {
         self.accumulated_output_tokens
     }
 
+    /// Returns accumulated provider-reported cached input tokens.
     pub fn accumulated_cached_input_tokens(&self) -> u64 {
         self.accumulated_cached_input_tokens
     }
 
+    /// Returns accumulated provider-reported cache-creation input tokens.
     pub fn accumulated_cache_creation_input_tokens(&self) -> u64 {
         self.accumulated_cache_creation_input_tokens
     }
 
+    /// Returns accumulated provider-reported cache-read input tokens.
     pub fn accumulated_cache_read_input_tokens(&self) -> u64 {
         self.accumulated_cache_read_input_tokens
     }
 
+    /// Returns accumulated provider-reported reasoning output tokens.
     pub fn accumulated_reasoning_output_tokens(&self) -> u64 {
         self.accumulated_reasoning_output_tokens
     }
 
+    /// Returns all accumulated provider-reported usage categories.
     pub fn accumulated_totals(&self) -> TokenUsageTotals {
         TokenUsageTotals {
             input_tokens: self.accumulated_input_tokens,

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -13,9 +13,25 @@
 //!
 //! ## Usage
 //!
-//! ```rust,ignore
-//! let runtime = IronRuntime::new(config, provider);
-//! runtime.set_debug_sink(Some(Arc::new(MyDebugSink)));
+//! ```no_run
+//! use iron_core::{Config, DebugEvent, DebugSink, IronAgent};
+//! use iron_providers::{ApiFamily, ProviderConnection, ProviderProfile, RuntimeConfig};
+//! use std::sync::Arc;
+//!
+//! struct MyDebugSink;
+//! impl DebugSink for MyDebugSink {
+//!     fn emit(&self, event: DebugEvent) {
+//!         eprintln!("debug event {}: {:?}", event.sequence, event.payload);
+//!     }
+//! }
+//!
+//! let provider = ProviderConnection::from_profile(
+//!     ProviderProfile::new("openai", ApiFamily::Responses, "https://api.openai.com/v1"),
+//!     RuntimeConfig::new("sk-example"),
+//! )?;
+//! let agent = IronAgent::new(Config::default(), provider);
+//! agent.set_debug_sink(Some(Arc::new(MyDebugSink)));
+//! # Ok::<(), Box<dyn std::error::Error>>(())
 //! ```
 //!
 //! ## Redaction
@@ -29,10 +45,10 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 /// A sink that receives structured debug events from the runtime.
 ///
-/// Implementations should return quickly and not block the runtime.
-/// Debug observation is best-effort: sink failures or slowness must
-/// never affect prompt execution, tool execution, model switching,
-/// or session state.
+/// Emission is synchronous and is not isolated from the caller. Implementations
+/// must return quickly, avoid blocking, and avoid panicking so observation does
+/// not disrupt prompt execution, tool execution, model switching, or session
+/// state.
 pub trait DebugSink: Send + Sync {
     /// Emit a debug event. This is synchronous and should not block.
     fn emit(&self, event: DebugEvent);
@@ -52,10 +68,15 @@ impl DebugSink for NullDebugSink {
 /// for correct behavior.
 #[derive(Clone, Debug, PartialEq)]
 pub struct DebugEvent {
+    /// UTC time at which the event envelope was created.
     pub timestamp: chrono::DateTime<chrono::Utc>,
+    /// Runtime-local monotonically increasing event sequence number.
     pub sequence: u64,
+    /// Operational importance assigned by the emitter.
     pub severity: DebugSeverity,
+    /// Correlation identifiers available at the emission site.
     pub scope: DebugScope,
+    /// Domain-specific observation carried by the event.
     pub payload: DebugPayload,
 }
 
@@ -63,8 +84,11 @@ pub struct DebugEvent {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum DebugSeverity {
+    /// Informational observation of normal runtime behavior.
     Info,
+    /// Unexpected or degraded behavior that did not necessarily stop execution.
     Warning,
+    /// A semantic operation failed.
     Error,
 }
 
@@ -77,12 +101,19 @@ pub enum DebugSeverity {
 /// turn, and tool-call scope where available.
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct DebugScope {
+    /// Identifier of the runtime instance, when assigned.
     pub runtime_id: Option<String>,
+    /// Identifier of the client connection, when the event is connection-scoped.
     pub connection_id: Option<String>,
+    /// Session associated with the event.
     pub session_id: Option<crate::SessionId>,
+    /// Prompt-turn identifier associated with the event.
     pub turn_id: Option<String>,
+    /// Tool-call identifier associated with the event.
     pub tool_call_id: Option<String>,
+    /// Provider selected for the relevant model request.
     pub provider_name: Option<String>,
+    /// Model selected for the relevant model request.
     pub model_id: Option<String>,
 }
 
@@ -94,78 +125,135 @@ pub struct DebugScope {
 #[non_exhaustive]
 pub enum DebugPayload {
     /// Prompt-related debug events.
-    Prompt(PromptDebugEvent),
+    Prompt(
+        /// Prompt observation details.
+        PromptDebugEvent,
+    ),
     /// Context-related debug events.
-    Context(ContextDebugEvent),
+    Context(
+        /// Context observation details.
+        ContextDebugEvent,
+    ),
     /// Compaction-related debug events.
-    Compaction(CompactionDebugEvent),
+    Compaction(
+        /// Compaction observation details.
+        CompactionDebugEvent,
+    ),
     /// Tool-related debug events.
-    Tool(ToolDebugEvent),
+    Tool(
+        /// Tool observation details.
+        ToolDebugEvent,
+    ),
     /// Provider/model-switch-related debug events.
-    Provider(ProviderDebugEvent),
+    Provider(
+        /// Provider or model-switch observation details.
+        ProviderDebugEvent,
+    ),
     /// Configuration-related debug events.
-    Config(ConfigDebugEvent),
+    Config(
+        /// Redacted configuration observation details.
+        ConfigDebugEvent,
+    ),
     /// Skill-related debug events.
-    Skill(SkillDebugEvent),
+    Skill(
+        /// Skill observation details.
+        SkillDebugEvent,
+    ),
 }
 
 // ── Prompt ──────────────────────────────────────────────────────
 
 #[derive(Clone, Debug, PartialEq)]
 #[non_exhaustive]
+/// Observations about prompt construction and model-input influences.
 pub enum PromptDebugEvent {
     /// A system prompt was rendered for an inference request.
     SystemPromptRendered {
+        /// Stable digest of the rendered prompt, without exposing its text.
         fingerprint: String,
+        /// Character count of the complete rendered prompt.
         total_chars: usize,
+        /// Safe metadata for each composed prompt section.
         sections: Vec<SectionSummary>,
+        /// Whether the fingerprint changed from the prior render, if known.
         changed: Option<bool>,
     },
     /// A model input influence was added, removed, changed, or suppressed.
     ModelInputInfluence {
+        /// Runtime condition or instruction that caused the influence.
         source: InfluenceSource,
+        /// Model-input component affected by the influence.
         destination: InfluenceDestination,
+        /// How the destination was altered.
         effect: InfluenceEffect,
+        /// Safe explanation of why the influence was applied.
         reason: String,
     },
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
+/// Sources that can influence model input composition.
 pub enum InfluenceSource {
+    /// Current context-window pressure.
     ContextPressure,
+    /// Whether context compaction is available.
     CompactionAvailability,
+    /// Tools currently visible to the model.
     ToolAvailability,
+    /// Activation of a reusable skill.
     SkillActivation,
+    /// Provider-specific request guidance.
     ProviderGuidance,
+    /// Explicit instruction from the connected client.
     ClientInstruction,
+    /// Instruction discovered in the active repository.
     RepoInstruction,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
+/// Model-input components that can be influenced by runtime decisions.
 pub enum InfluenceDestination {
-    SystemPromptSection(String),
+    /// Named section of the rendered system prompt.
+    SystemPromptSection(
+        /// Human-readable name of the affected section.
+        String,
+    ),
+    /// Transformation of the user-supplied prompt.
     UserPromptRewrite,
+    /// Definition of a model-visible tool.
     ToolDefinition,
+    /// Context supplied to continue a prior interaction.
     ContinuationContext,
+    /// Provider request metadata outside prompt text.
     RequestMetadata,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
+/// Kind of change made to a model-input component.
 pub enum InfluenceEffect {
+    /// New content or metadata was introduced.
     Added,
+    /// Existing content or metadata was removed.
     Removed,
+    /// Existing content or metadata was modified.
     Changed,
+    /// A candidate influence was intentionally not applied.
     Suppressed,
 }
 
+/// Safe metadata describing one rendered system-prompt section.
 #[derive(Clone, Debug, PartialEq)]
 pub struct SectionSummary {
+    /// Human-readable section title.
     pub name: String,
+    /// Component responsible for the section, when available.
     pub owner: Option<String>,
+    /// Section stability classification, when available.
     pub temperature: Option<String>,
+    /// Character count of the section, or zero when unavailable.
     pub chars: usize,
 }
 
@@ -173,21 +261,32 @@ pub struct SectionSummary {
 
 #[derive(Clone, Debug, PartialEq)]
 #[non_exhaustive]
+/// Observations about context size, quality, and pressure transitions.
 pub enum ContextDebugEvent {
     /// Active context snapshot was estimated.
     SnapshotEstimated {
+        /// Estimated tokens in active model context.
         total_tokens: usize,
+        /// Maximum model context size, when known.
         context_window_limit: Option<usize>,
+        /// Token threshold at which compaction is considered, when configured.
         compact_threshold_tokens: Option<usize>,
+        /// Confidence or completeness of the context estimate.
         quality: crate::ContextQuality,
+        /// Current context-pressure classification.
         pressure: String,
+        /// Per-category token estimates and their quality classifications.
         categories: Vec<(String, usize, crate::ContextQuality)>,
+        /// Provider-reported cumulative usage, when available.
         accumulated_usage: Option<crate::context::TokenUsageTotals>,
     },
     /// Context pressure classification changed.
     PressureChanged {
+        /// Pressure classification before the transition.
         old_pressure: String,
+        /// Pressure classification after the transition.
         new_pressure: String,
+        /// Safe explanation of the transition.
         reason: String,
     },
 }
@@ -196,22 +295,35 @@ pub enum ContextDebugEvent {
 
 #[derive(Clone, Debug, PartialEq)]
 #[non_exhaustive]
+/// Observations from the context-compaction lifecycle.
 pub enum CompactionDebugEvent {
     /// The model requested compaction.
     Requested {
+        /// Whether the request specified a compaction topic.
         topic_present: bool,
+        /// Number of transcript ranges requested for compaction.
         range_count: usize,
+        /// Safe rendering of applicable thresholds, when available.
         thresholds: Option<String>,
     },
     /// Compaction was rejected by validation.
-    Rejected { reason: String },
+    Rejected {
+        /// Validation reason for rejecting the request.
+        reason: String,
+    },
     /// Compaction was applied successfully.
     Applied {
+        /// Number of transcript blocks compacted.
         block_count: usize,
+        /// Estimated token count before compaction, when available.
         old_size_tokens: Option<usize>,
+        /// Estimated token count after compaction, when available.
         new_size_tokens: Option<usize>,
+        /// Compaction strategy or implementation, when reported.
         method: Option<String>,
+        /// Context-pressure classification after compaction.
         pressure_state: String,
+        /// Percentage token reduction, when both estimates are available.
         reduction_pct: Option<f64>,
     },
 }
@@ -220,28 +332,43 @@ pub enum CompactionDebugEvent {
 
 #[derive(Clone, Debug, PartialEq)]
 #[non_exhaustive]
+/// Observations from tool approval and execution.
 pub enum ToolDebugEvent {
     /// Tool approval was evaluated.
     ApprovalEvaluated {
+        /// Registered name of the proposed tool.
         tool_name: String,
+        /// Final approval decision.
         approved: bool,
+        /// Policy, user, or other source of the decision.
         decision_source: String,
+        /// Whether evaluation required a user-facing approval request.
         user_approval_requested: bool,
+        /// Safe explanation of the decision.
         reason: String,
     },
     /// Tool execution started.
     ExecutionStarted {
+        /// Registered name of the executing tool.
         tool_name: String,
+        /// Tool provider category, such as builtin or plugin.
         tool_source: String,
+        /// Identifier correlating this start with its completion event.
         call_id: String,
     },
     /// Tool execution finished.
     ExecutionFinished {
+        /// Registered name of the executed tool.
         tool_name: String,
+        /// Identifier correlating this completion with its start event.
         call_id: String,
+        /// Terminal execution status.
         status: String,
+        /// Elapsed execution time in milliseconds, when measured.
         duration_ms: Option<u64>,
+        /// Whether returned tool content was truncated.
         truncated: bool,
+        /// Safe failure or truncation explanation, when available.
         reason: Option<String>,
     },
 }
@@ -250,31 +377,46 @@ pub enum ToolDebugEvent {
 
 #[derive(Clone, Debug, PartialEq)]
 #[non_exhaustive]
+/// Observations from provider and model-switch decisions.
 pub enum ProviderDebugEvent {
     /// A model switch was queued for the next turn boundary.
     ModelSwitchQueued {
+        /// Model requested for the next turn.
         target_model: String,
+        /// Provider that serves the target model.
         target_provider: String,
     },
     /// A model switch plan was created.
     ModelSwitchPlanCreated {
+        /// Estimated tokens in the current context.
         current_tokens: usize,
+        /// Context-window size of the target model, when known.
         target_window: Option<usize>,
+        /// Whether context must be adapted before switching.
         adaptation_needed: bool,
+        /// Quality classification of the token estimate.
         estimate_quality: String,
     },
     /// A model switch was applied.
     ModelSwitchApplied {
+        /// Model active before the switch.
         from_model: String,
+        /// Provider active before the switch.
         from_provider: String,
+        /// Model active after the switch.
         to_model: String,
+        /// Provider active after the switch.
         to_provider: String,
+        /// Safe summary of capability changes, when available.
         capability_diff: Option<String>,
     },
     /// A model switch failed.
     ModelSwitchFailed {
+        /// Model that could not be activated.
         target_model: String,
+        /// Provider that could not serve the switch.
         target_provider: String,
+        /// Safe explanation of the failure.
         reason: String,
     },
 }
@@ -283,18 +425,29 @@ pub enum ProviderDebugEvent {
 
 #[derive(Clone, Debug, PartialEq)]
 #[non_exhaustive]
+/// Redacted observations about effective runtime configuration.
 pub enum ConfigDebugEvent {
     /// Runtime was initialized with a configuration summary.
     RuntimeConfigured {
+        /// Selected provider name.
         provider_name: String,
+        /// Selected model identifier.
         model_id: String,
+        /// Safe rendering of the default approval strategy.
         approval_strategy: String,
+        /// Whether automatic context management is enabled.
         context_management_enabled: bool,
+        /// Whether repository prompt composition is enabled.
         prompt_composition_enabled: bool,
+        /// Safe rendering of the default tool policy.
         tool_policy: String,
+        /// Whether plugin loading is enabled.
         plugin_enabled: bool,
+        /// Whether MCP integration is enabled.
         mcp_enabled: bool,
+        /// Whether skill discovery and activation are enabled.
         skill_enabled: bool,
+        /// Number of configured workspace roots.
         workspace_roots: usize,
     },
 }
@@ -303,28 +456,44 @@ pub enum ConfigDebugEvent {
 
 #[derive(Clone, Debug, PartialEq)]
 #[non_exhaustive]
+/// Observations from skill discovery, availability, and activation.
 pub enum SkillDebugEvent {
     /// Skill catalog was refreshed.
     CatalogRefreshed {
+        /// Safe names of catalog sources that were scanned.
         sources: Vec<String>,
+        /// Number of skills discovered before trust filtering.
         discovered_count: usize,
+        /// Number of discovered skills accepted as trusted.
         trusted_count: usize,
+        /// Number of discovered skills classified as untrusted.
         untrusted_count: usize,
+        /// Number of diagnostics produced during refresh.
         diagnostic_count: usize,
     },
     /// Skills were made available to a session.
     AvailableToSession {
+        /// Number of skills exposed to the session.
         count: usize,
+        /// Categories of sources contributing available skills.
         source_categories: Vec<String>,
     },
     /// Skill activation succeeded.
     ActivationSuccess {
+        /// Name of the activated skill.
         skill_name: String,
+        /// Kind of source from which the skill was loaded.
         source_kind: String,
+        /// Runtime action or request that triggered activation.
         activation_source: String,
     },
     /// Skill activation was rejected.
-    ActivationRejected { skill_name: String, reason: String },
+    ActivationRejected {
+        /// Name of the skill that was not activated.
+        skill_name: String,
+        /// Safe explanation of the rejection.
+        reason: String,
+    },
 }
 
 // ── Internal helpers ────────────────────────────────────────────
@@ -335,12 +504,14 @@ pub(crate) struct SequenceGenerator {
 }
 
 impl SequenceGenerator {
+    /// Creates a generator whose first returned sequence is one.
     pub(crate) fn new() -> Self {
         Self {
             counter: AtomicU64::new(1),
         }
     }
 
+    /// Atomically returns the next runtime-local sequence number.
     pub(crate) fn next(&self) -> u64 {
         self.counter.fetch_add(1, Ordering::Relaxed)
     }
@@ -359,6 +530,7 @@ impl Default for SequenceGenerator {
 /// through runtime → connection → session → turn → tool call.
 #[derive(Clone, Debug, Default)]
 pub struct DebugContext {
+    /// Correlation scope copied into events built from this context.
     pub scope: DebugScope,
 }
 
@@ -401,19 +573,19 @@ impl DebugContext {
         fork
     }
 
-    /// Set provider name in scope.
+    /// Sets the provider name in this context and returns it for chaining.
     pub fn with_provider(&mut self, provider: impl Into<String>) -> &mut Self {
         self.scope.provider_name = Some(provider.into());
         self
     }
 
-    /// Set model id in scope.
+    /// Sets the model identifier in this context and returns it for chaining.
     pub fn with_model(&mut self, model: impl Into<String>) -> &mut Self {
         self.scope.model_id = Some(model.into());
         self
     }
 
-    /// Build a DebugEvent from this context.
+    /// Builds a timestamped [`DebugEvent`] by cloning this context's scope.
     pub fn event(
         &self,
         sequence: u64,
@@ -500,6 +672,7 @@ pub(crate) fn emit_debug(sink: &dyn DebugSink, event: DebugEvent) {
 // ── Test utilities ──────────────────────────────────────────────
 
 #[cfg(test)]
+/// Debug sinks used by this module's tests and crate-internal test suites.
 pub(crate) mod test_helpers {
     use super::*;
     use std::sync::Mutex;
@@ -511,6 +684,7 @@ pub(crate) mod test_helpers {
     }
 
     impl RecordingDebugSink {
+        /// Creates an empty recording sink.
         pub fn new() -> Self {
             Self::default()
         }

--- a/src/delegation/mod.rs
+++ b/src/delegation/mod.rs
@@ -112,8 +112,11 @@ impl DelegationRequest {
 /// Outcome of a delegated child run.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum DelegationOutcome {
+    /// The child model completed its turn normally.
     EndTurn,
+    /// The child prompt was cancelled before normal completion.
     Cancelled,
+    /// The child exhausted the request's inference/tool iteration limit.
     MaxTurnRequests,
     /// The run stopped for a reason that is not recognized by this core version.
     Unknown,
@@ -153,24 +156,43 @@ pub struct DelegationResult {
 /// Audit/diagnostic metadata for a delegated run.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct DelegationMetadata {
+    /// Stable delegation identifier shared with the returned result.
     pub delegation_id: String,
+    /// Durable session that initiated the delegation.
     pub parent_session_id: SessionId,
+    /// Parent tool-call identifier, when delegation originated from a tool call.
     pub parent_tool_call_id: Option<String>,
+    /// Hidden durable session created for the delegated run.
     pub child_session_id: SessionId,
+    /// Requested child profile identifier, if explicitly selected.
     pub profile_id: Option<AgentProfileId>,
+    /// Approval handling applied to child tool calls.
     pub child_approval_mode: ChildApprovalMode,
+    /// Inference/tool iteration limit applied to the child prompt.
     pub max_iterations: u32,
+    /// Terminal outcome once the delegated prompt has finished.
     pub outcome: Option<DelegationOutcome>,
+    /// Deterministic digest of the model-visible child tool catalog.
     pub tool_catalog_digest: String,
+    /// Final child tools also present in the parent's effective catalog.
     pub inherited_tools: Vec<String>,
+    /// Candidate tools removed by the request's deny list.
     pub removed_tools: Vec<String>,
+    /// Final child tools not present in the parent's effective catalog.
     pub added_tools: Vec<String>,
+    /// Requested additions unavailable from runtime or session catalogs.
     pub unavailable_requested_additions: Vec<String>,
+    /// Candidate tools removed by the selected profile's tool filter.
     pub excluded_by_profile: Vec<String>,
+    /// Structured reasons requested tool-policy changes were not applied.
     pub tool_policy_diagnostics: Vec<ToolPolicyDiagnostic>,
+    /// Skill names requested for the child session.
     pub requested_skills: Vec<String>,
+    /// Requested skills loaded and activated in the child session.
     pub activated_skills: Vec<String>,
+    /// Requested skills rejected by the selected profile's skill filter.
     pub excluded_skills_by_profile: Vec<String>,
+    /// Profile-allowed skills that were absent or required elevated trust.
     pub unavailable_requested_skills: Vec<String>,
 }
 
@@ -185,49 +207,61 @@ pub enum ToolPolicyDiagnosticReason {
     /// The MCP server providing this tool is disabled for the session.
     McpServerNotEnabled {
         #[serde(rename = "server_id")]
+        /// MCP server that owns the requested tool.
         server_id: String,
     },
     /// The MCP server providing this tool is not healthy.
     McpServerNotHealthy {
         #[serde(rename = "server_id")]
+        /// MCP server that owns the requested tool.
         server_id: String,
         #[serde(rename = "health")]
+        /// Debug representation of the observed server health.
         health: String,
     },
     /// The plugin providing this tool is not enabled for the session.
     PluginNotEnabled {
         #[serde(rename = "plugin_id")]
+        /// Plugin that owns the requested tool.
         plugin_id: String,
     },
     /// The plugin providing this tool is not installed.
     PluginNotInstalled {
         #[serde(rename = "plugin_id")]
+        /// Plugin that owns the requested tool.
         plugin_id: String,
     },
     /// The plugin providing this tool has no loaded manifest.
     PluginManifestMissing {
         #[serde(rename = "plugin_id")]
+        /// Plugin that owns the requested tool.
         plugin_id: String,
     },
     /// The plugin providing this tool is not healthy.
     PluginNotHealthy {
         #[serde(rename = "plugin_id")]
+        /// Plugin that owns the requested tool.
         plugin_id: String,
         #[serde(rename = "health")]
+        /// Debug representation of the observed plugin health.
         health: String,
     },
     /// The plugin tool requires authentication that is not satisfied.
     PluginAuthRequired {
         #[serde(rename = "plugin_id")]
+        /// Plugin that owns the requested tool.
         plugin_id: String,
     },
     /// The plugin tool requires scopes that are not granted.
     PluginScopeMissing {
         #[serde(rename = "plugin_id")]
+        /// Plugin that owns the requested tool.
         plugin_id: String,
         #[serde(rename = "required")]
+        /// Complete scope set required by the tool.
         required: Vec<String>,
         #[serde(rename = "missing")]
+        /// Required scopes absent from the current grant.
         missing: Vec<String>,
     },
 }
@@ -235,7 +269,9 @@ pub enum ToolPolicyDiagnosticReason {
 /// Frontend/audit diagnostic for child tool policy derivation.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ToolPolicyDiagnostic {
+    /// Requested tool whose policy change could not be applied.
     pub tool_name: String,
+    /// Structured reason the tool was unavailable or excluded.
     pub reason: ToolPolicyDiagnosticReason,
 }
 

--- a/src/delegation/runtime.rs
+++ b/src/delegation/runtime.rs
@@ -74,7 +74,17 @@ fn map_unavailable_reason(
 }
 
 impl IronRuntime {
-    /// Derive a child tool catalog from policy, profile filter, and runtime state.
+    /// Derive the model-visible child tool catalog from policy and runtime state.
+    ///
+    /// Resolution starts from either the parent's effective catalog or a fresh
+    /// hidden session's default catalog. Requested additions are then resolved
+    /// from runtime and parent-session inventories, the child profile filter is
+    /// applied, and the explicit deny list is applied last. Unavailable or
+    /// profile-excluded additions are omitted and recorded as diagnostics.
+    ///
+    /// The returned definitions are sorted by name and include a deterministic
+    /// digest for audit records. A temporary child-default session is closed
+    /// before this method returns.
     pub fn derive_child_tool_catalog(
         &self,
         parent_session_id: SessionId,
@@ -214,10 +224,18 @@ impl IronRuntime {
         })
     }
 
-    /// Run a delegated child prompt and return the result.
+    /// Run a delegated child prompt and return its result and audit metadata.
     ///
-    /// This creates a hidden child session, sets up a delegation sink, resolves the
-    /// selected profile/provider, runs the prompt, and cleans up the relationship.
+    /// This creates a hidden child session on the parent's connection, derives
+    /// its bounded tool catalog, activates profile-allowed skills that do not
+    /// require trust, resolves the selected provider, and runs at most the
+    /// requested number of iterations. Child approvals either propagate to the
+    /// parent client or receive one-time approval according to
+    /// [`crate::delegation::ChildApprovalMode`].
+    ///
+    /// Failures before prompt execution unregister and close the child session.
+    /// On successful return, the durable child session and its parent-child
+    /// registration remain available for later inspection and lifecycle control.
     pub async fn run_delegation(
         &self,
         parent_session_id: SessionId,

--- a/src/delegation/sink.rs
+++ b/src/delegation/sink.rs
@@ -20,6 +20,10 @@ pub(crate) struct DelegationPromptSink {
 }
 
 impl DelegationPromptSink {
+    /// Create a child prompt sink bound to the parent client and ACP session.
+    ///
+    /// Approval requests are either auto-approved once or forwarded to this
+    /// parent session according to `mode`; forwarding failures deny the call.
     pub(crate) fn new(
         mode: ChildApprovalMode,
         parent_client: SharedClientChannel,

--- a/src/durable.rs
+++ b/src/durable.rs
@@ -558,8 +558,11 @@ pub struct DurableSession {
     #[serde(default)]
     pub current_provider_slug: Option<String>,
     /// Optional API key for the current managed provider.
+    ///
+    /// Stored in a [`crate::secret::SecretString`] so the value is redacted from
+    /// debug output while still serializing for durable persistence and handoff.
     #[serde(default)]
-    pub current_provider_api_key: Option<String>,
+    pub current_provider_api_key: Option<crate::secret::SecretString>,
     /// History of applied model switches for this session.
     #[serde(default)]
     pub model_switch_history: Vec<crate::context::model_switch::ModelSwitchRecord>,

--- a/src/durable.rs
+++ b/src/durable.rs
@@ -1,12 +1,29 @@
+//! Durable, serializable session state and its lifecycle transitions.
+//!
+//! A [`DurableSession`] owns conversation messages, tool and script records,
+//! timeline metadata, compacted summaries, model-switch history, and
+//! session-scoped configuration. Transient work for an active turn belongs in
+//! [`crate::ephemeral::EphemeralTurn`]. Provider usage establishes a token
+//! baseline; newly appended visible content adds local deltas, while context
+//! rewrites invalidate that baseline.
+
 use agent_client_protocol::schema::v1 as acp;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::{btree_map::Entry, BTreeMap, BTreeSet, HashMap};
 
+/// Process-local numeric identity for a durable session.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-pub struct SessionId(pub u64);
+pub struct SessionId(
+    /// Numeric session identifier.
+    pub u64,
+);
 
 impl SessionId {
+    /// Allocates the next process-local session identifier.
+    ///
+    /// Identifiers begin at one and are unique until the underlying counter
+    /// wraps. Deserializing an identifier does not advance the allocator.
     pub fn new() -> Self {
         use std::sync::atomic::{AtomicU64, Ordering};
         static COUNTER: AtomicU64 = AtomicU64::new(1);
@@ -26,26 +43,54 @@ impl std::fmt::Display for SessionId {
     }
 }
 
+/// Structured user or agent content retained by a durable session.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "role", rename_all = "snake_case")]
 pub enum StructuredMessage {
-    User { content: Vec<ContentBlock> },
-    Agent { content: Vec<ContentBlock> },
+    /// Content supplied by the user.
+    User {
+        /// Ordered content blocks in the message.
+        content: Vec<ContentBlock>,
+    },
+    /// Content produced by the agent.
+    Agent {
+        /// Ordered content blocks in the message.
+        content: Vec<ContentBlock>,
+    },
 }
 
+/// Serializable content retained in a structured message.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ContentBlock {
-    Text { text: String },
-    Image { data: String, mime_type: String },
-    Resource { uri: String, name: Option<String> },
+    /// Plain text content.
+    Text {
+        /// Text payload.
+        text: String,
+    },
+    /// Encoded image content.
+    Image {
+        /// Encoded image data.
+        data: String,
+        /// Media type describing `data`.
+        mime_type: String,
+    },
+    /// Link to an external resource.
+    Resource {
+        /// Resource URI.
+        uri: String,
+        /// Optional display name.
+        name: Option<String>,
+    },
 }
 
 impl ContentBlock {
+    /// Creates a text content block.
     pub fn text(text: impl Into<String>) -> Self {
         Self::Text { text: text.into() }
     }
 
+    /// Returns the text payload, or `None` for non-text content.
     pub fn to_text(&self) -> Option<&str> {
         match self {
             ContentBlock::Text { text } => Some(text),
@@ -53,6 +98,10 @@ impl ContentBlock {
         }
     }
 
+    /// Converts an ACP content block into durable content.
+    ///
+    /// ACP variants without a durable representation become the literal text
+    /// `[unsupported content]`.
     pub fn from_acp_content(block: &acp::ContentBlock) -> Self {
         match block {
             acp::ContentBlock::Text(tc) => ContentBlock::Text {
@@ -74,18 +123,21 @@ impl ContentBlock {
 }
 
 impl StructuredMessage {
+    /// Creates a user message containing one text block.
     pub fn user_text(text: impl Into<String>) -> Self {
         Self::User {
             content: vec![ContentBlock::text(text)],
         }
     }
 
+    /// Creates an agent message containing one text block.
     pub fn agent_text(text: impl Into<String>) -> Self {
         Self::Agent {
             content: vec![ContentBlock::text(text)],
         }
     }
 
+    /// Concatenates all text blocks, omitting images and resources.
     pub fn text_content(&self) -> String {
         let blocks = match self {
             Self::User { content } => content,
@@ -98,14 +150,17 @@ impl StructuredMessage {
             .join("")
     }
 
+    /// Returns whether this is a user message.
     pub fn is_user(&self) -> bool {
         matches!(self, Self::User { .. })
     }
 
+    /// Returns whether this is an agent message.
     pub fn is_agent(&self) -> bool {
         matches!(self, Self::Agent { .. })
     }
 
+    /// Borrows the ordered content blocks regardless of message role.
     pub fn content_blocks(&self) -> &[ContentBlock] {
         match self {
             Self::User { content } => content,
@@ -113,6 +168,9 @@ impl StructuredMessage {
         }
     }
 
+    /// Estimates text tokens at one token per four UTF-8 bytes, rounded up.
+    ///
+    /// Non-text blocks do not contribute to this estimate.
     pub fn estimated_tokens(&self) -> usize {
         estimate_text_tokens(&self.text_content())
     }
@@ -122,6 +180,7 @@ fn estimate_text_tokens(text: &str) -> usize {
     (text.len() as f64 * 0.25).ceil() as usize
 }
 
+/// Estimates tokens for a serialized tool name and argument payload.
 pub fn estimate_tool_call_tokens(tool_name: &str, arguments: &Value) -> usize {
     estimate_text_tokens(&format!("{}: {}", tool_name, arguments))
 }
@@ -130,57 +189,95 @@ fn estimate_tool_result_tokens(tool_name: &str, result: &Value) -> usize {
     estimate_text_tokens(&format!("{}: {}", tool_name, result))
 }
 
+/// Ordered metadata linking durable messages, tools, and model switches.
+///
+/// `index` values are positions in the current timeline and may be rewritten
+/// by compaction. `visible_id` values are stable user-facing range selectors.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum TimelineEntry {
+    /// A user message retained in the session.
     UserMessage {
+        /// Current zero-based timeline position.
         index: u64,
+        /// Index into [`DurableSession::messages`].
         message_index: usize,
+        /// Stable user-facing identifier used by compaction ranges.
         #[serde(skip_serializing_if = "Option::is_none")]
         visible_id: Option<String>,
+        /// Model active when the message was recorded.
         #[serde(skip_serializing_if = "Option::is_none")]
         model: Option<String>,
     },
+    /// An agent message retained in the session.
     AgentMessage {
+        /// Current zero-based timeline position.
         index: u64,
+        /// Index into [`DurableSession::messages`].
         message_index: usize,
+        /// Stable user-facing identifier used by compaction ranges.
         #[serde(skip_serializing_if = "Option::is_none")]
         visible_id: Option<String>,
+        /// Model active when the message was recorded.
         #[serde(skip_serializing_if = "Option::is_none")]
         model: Option<String>,
     },
+    /// Start boundary of a tool-call lifecycle.
     ToolCallStarted {
+        /// Current zero-based timeline position.
         index: u64,
+        /// Provider-assigned tool-call identifier.
         call_id: String,
+        /// Requested tool name.
         tool_name: String,
+        /// Index into [`DurableSession::tool_records`].
         tool_record_index: usize,
+        /// Stable user-facing identifier used by compaction ranges.
         #[serde(skip_serializing_if = "Option::is_none")]
         visible_id: Option<String>,
     },
+    /// Terminal boundary of a tool-call lifecycle.
     ToolCallTerminal {
+        /// Current zero-based timeline position.
         index: u64,
+        /// Provider-assigned tool-call identifier.
         call_id: String,
+        /// Requested tool name.
         tool_name: String,
+        /// Terminal outcome represented by this boundary.
         outcome: ToolTerminalOutcome,
+        /// Index into [`DurableSession::tool_records`].
         tool_record_index: usize,
+        /// Stable user-facing identifier used by compaction ranges.
         #[serde(skip_serializing_if = "Option::is_none")]
         visible_id: Option<String>,
     },
+    /// Metadata boundary recording an applied model switch.
+    ///
+    /// This entry is excluded from provider transcripts.
     ModelSwitched {
+        /// Current zero-based timeline position.
         index: u64,
+        /// Model active before the switch.
         from_model: String,
+        /// Model active after the switch.
         to_model: String,
+        /// Provider active before the switch, if known.
         #[serde(skip_serializing_if = "Option::is_none")]
         from_provider: Option<String>,
+        /// Provider active after the switch, if known.
         #[serde(skip_serializing_if = "Option::is_none")]
         to_provider: Option<String>,
+        /// Whether context or capabilities were adapted for the target.
         adapted: bool,
+        /// Optional stable user-facing identifier.
         #[serde(skip_serializing_if = "Option::is_none")]
         visible_id: Option<String>,
     },
 }
 
 impl TimelineEntry {
+    /// Returns the entry's current timeline position.
     pub fn index(&self) -> u64 {
         match self {
             Self::UserMessage { index, .. }
@@ -191,6 +288,7 @@ impl TimelineEntry {
         }
     }
 
+    /// Borrows the stable user-facing identifier, when assigned.
     pub fn visible_id(&self) -> Option<&str> {
         match self {
             Self::UserMessage { visible_id, .. }
@@ -201,6 +299,7 @@ impl TimelineEntry {
         }
     }
 
+    /// Assigns or replaces the stable user-facing identifier.
     pub fn set_visible_id(&mut self, id: String) {
         match self {
             Self::UserMessage { visible_id, .. }
@@ -213,6 +312,7 @@ impl TimelineEntry {
         }
     }
 
+    /// Returns the linked tool-record index for tool lifecycle entries.
     pub fn tool_record_index(&self) -> Option<usize> {
         match self {
             Self::ToolCallStarted {
@@ -225,55 +325,86 @@ impl TimelineEntry {
         }
     }
 
+    /// Returns whether this entry records a model switch.
     pub fn is_model_switched(&self) -> bool {
         matches!(self, Self::ModelSwitched { .. })
     }
 }
 
+/// Terminal state represented by a tool timeline boundary.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "outcome", rename_all = "snake_case")]
 pub enum ToolTerminalOutcome {
+    /// The tool returned successfully.
     Completed,
+    /// Tool execution failed.
     Failed,
+    /// Permission to run the tool was denied.
     Denied,
+    /// The tool call was cancelled.
     Cancelled,
 }
 
+/// Durable state and timeline links for one tool call.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DurableToolRecord {
+    /// Provider-assigned call identifier.
     pub call_id: String,
+    /// Requested tool name.
     pub tool_name: String,
+    /// Arguments supplied to the tool.
     pub arguments: Value,
+    /// Current lifecycle state.
     pub status: ToolRecordStatus,
+    /// Terminal result or error payload, when available.
     pub result: Option<Value>,
+    /// Timeline index at which the call was proposed or started.
     pub timeline_started_index: Option<u64>,
+    /// Timeline index at which the call became terminal.
     pub timeline_terminal_index: Option<u64>,
+    /// Script record that owns this child call, when linked.
     pub parent_script_id: Option<String>,
 }
 
+/// Durable state for a script that may own multiple child tool calls.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DurableScriptRecord {
+    /// Stable script execution identifier.
     pub script_id: String,
+    /// Tool call that launched the script.
     pub parent_call_id: String,
+    /// Source text executed by the script tool.
     pub script_source: String,
+    /// Optional script input payload.
     pub input: Option<Value>,
+    /// Current script lifecycle state.
     pub status: ScriptRecordStatus,
+    /// Successful or partial result payload.
     pub result: Option<Value>,
+    /// Failure payload.
     pub error: Option<Value>,
+    /// Tool-call identifiers launched by the script.
     pub child_call_ids: Vec<String>,
 }
 
+/// Lifecycle state of a durable script execution.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "status", rename_all = "snake_case")]
 pub enum ScriptRecordStatus {
+    /// Script execution is active.
     Running,
+    /// Script and all relevant children completed successfully.
     Completed,
+    /// Script produced a result while one or more children failed.
     CompletedWithFailures,
+    /// Script execution failed.
     Failed,
+    /// Script execution was cancelled.
     Cancelled,
 }
 
 impl DurableScriptRecord {
+    /// Creates a running script record with no result, error, or children.
     pub fn new(
         script_id: impl Into<String>,
         parent_call_id: impl Into<String>,
@@ -292,28 +423,33 @@ impl DurableScriptRecord {
         }
     }
 
+    /// Marks the script completed and replaces its result and child list.
     pub fn complete(&mut self, result: Value, child_call_ids: Vec<String>) {
         self.status = ScriptRecordStatus::Completed;
         self.result = Some(result);
         self.child_call_ids = child_call_ids;
     }
 
+    /// Marks the script completed with child failures and stores its result.
     pub fn complete_with_failures(&mut self, result: Value, child_call_ids: Vec<String>) {
         self.status = ScriptRecordStatus::CompletedWithFailures;
         self.result = Some(result);
         self.child_call_ids = child_call_ids;
     }
 
+    /// Marks the script failed and stores its error and child list.
     pub fn fail(&mut self, error: Value, child_call_ids: Vec<String>) {
         self.status = ScriptRecordStatus::Failed;
         self.error = Some(error);
         self.child_call_ids = child_call_ids;
     }
 
+    /// Marks the script cancelled without clearing prior result fields.
     pub fn cancel(&mut self) {
         self.status = ScriptRecordStatus::Cancelled;
     }
 
+    /// Returns whether the script has reached any terminal state.
     pub fn is_terminal(&self) -> bool {
         matches!(
             self.status,
@@ -325,18 +461,26 @@ impl DurableScriptRecord {
     }
 }
 
+/// Lifecycle state of a durable tool call.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "status", rename_all = "snake_case")]
 pub enum ToolRecordStatus {
+    /// The call is recorded but awaits a permission decision.
     PendingApproval,
+    /// Tool execution is active.
     Running,
+    /// Tool execution returned successfully.
     Completed,
+    /// Tool execution failed.
     Failed,
+    /// Permission to execute was denied.
     Denied,
+    /// The call was cancelled before normal completion.
     Cancelled,
 }
 
 impl ToolRecordStatus {
+    /// Returns whether no further lifecycle transition is expected.
     pub fn is_terminal(&self) -> bool {
         matches!(
             self,
@@ -344,6 +488,9 @@ impl ToolRecordStatus {
         )
     }
 
+    /// Maps a terminal status to its timeline outcome.
+    ///
+    /// Returns `None` for pending and running calls.
     pub fn terminal_outcome(&self) -> Option<ToolTerminalOutcome> {
         match self {
             Self::Completed => Some(ToolTerminalOutcome::Completed),
@@ -355,19 +502,35 @@ impl ToolRecordStatus {
     }
 }
 
+/// Serializable owner of durable state for one agent session.
+///
+/// Messages and tool records are stored separately from their ordered
+/// [`TimelineEntry`] links. Compaction may remove and reindex those stores while
+/// preserving stable visible IDs for retained entries. [`Self::token_tracker`]
+/// is runtime-only and is skipped during serialization.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DurableSession {
+    /// Stable identity of this session.
     pub id: SessionId,
+    /// Structured user and agent message storage referenced by the timeline.
     pub messages: Vec<StructuredMessage>,
+    /// Tool lifecycle records referenced by tool timeline entries.
     pub tool_records: Vec<DurableToolRecord>,
+    /// Ordered provider-facing history and model-switch metadata.
     pub timeline: Vec<TimelineEntry>,
+    /// Script lifecycle records and their child tool links.
     pub script_records: Vec<DurableScriptRecord>,
+    /// Explicit session instructions, excluding rendered profile identity.
     pub instructions: Option<String>,
+    /// Optional serialized description of the session workspace scope.
     pub workspace_scope: Option<String>,
+    /// Durable summaries that replace compacted context ranges.
     #[serde(default)]
     pub compressed_blocks: Vec<crate::context::models::CompressedBlock>,
+    /// Heuristic token count added since the last compaction reset.
     #[serde(default)]
     pub uncompacted_tokens: usize,
+    /// Resolved repository instructions included in prompt construction.
     #[serde(default)]
     pub repo_instruction_payload: Option<crate::prompt::config::RepoInstructionPayload>,
     /// Session-scoped MCP server enablement state.
@@ -388,20 +551,19 @@ pub struct DurableSession {
     /// Counter for generating stable visible timeline IDs.
     #[serde(default)]
     pub next_visible_id: u64,
-    /// Current model identifier for this session
+    /// Current model identifier for this session.
     #[serde(default)]
     pub current_model: Option<String>,
-    /// Provider slug when the session is using a managed provider
-    /// (set by a managed model switch)
+    /// Provider slug when the session is using a managed provider.
     #[serde(default)]
     pub current_provider_slug: Option<String>,
-    /// Optional API key for the current managed provider
+    /// Optional API key for the current managed provider.
     #[serde(default)]
     pub current_provider_api_key: Option<String>,
-    /// History of model switches for this session
+    /// History of applied model switches for this session.
     #[serde(default)]
     pub model_switch_history: Vec<crate::context::model_switch::ModelSwitchRecord>,
-    /// Tools hidden due to model capability differences
+    /// Tools hidden due to current-model capability differences.
     #[serde(default)]
     pub hidden_tools: Vec<String>,
     /// Session-scoped active workspace roots.
@@ -436,11 +598,19 @@ pub struct DurableSession {
     /// Stored as a diagnostic; the session continues with its snapshot.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub profile_unavailable: Option<String>,
+    /// Runtime token baseline and accumulated provider usage.
+    ///
+    /// This field is not serialized; a restored session starts without a
+    /// provider baseline and must use heuristic accounting until resynchronized.
     #[serde(skip, default)]
     pub token_tracker: crate::context::SessionTokenTracker,
 }
 
 impl DurableSession {
+    /// Creates an empty durable session with the supplied identity.
+    ///
+    /// Visible timeline IDs begin at `m0001`, and token accounting starts with
+    /// no provider baseline.
     pub fn new(id: SessionId) -> Self {
         Self {
             id,
@@ -476,12 +646,14 @@ impl DurableSession {
         }
     }
 
+    /// Allocates the next stable visible timeline ID.
     pub fn next_visible_id(&mut self) -> String {
         let id = format!("m{:04}", self.next_visible_id);
         self.next_visible_id += 1;
         id
     }
 
+    /// Appends a one-block user message and records its estimated token delta.
     pub fn add_user_text(&mut self, text: impl Into<String>) {
         let msg = StructuredMessage::User {
             content: vec![ContentBlock::text(text)],
@@ -501,6 +673,7 @@ impl DurableSession {
         self.token_tracker.add_delta(tokens);
     }
 
+    /// Appends a structured user message and records its text token delta.
     pub fn add_user_message(&mut self, content: Vec<ContentBlock>) {
         let msg = StructuredMessage::User { content };
         let tokens = msg.estimated_tokens();
@@ -518,6 +691,7 @@ impl DurableSession {
         self.token_tracker.add_delta(tokens);
     }
 
+    /// Appends a one-block agent message and records its estimated token delta.
     pub fn add_agent_text(&mut self, text: impl Into<String>) {
         let msg = StructuredMessage::Agent {
             content: vec![ContentBlock::text(text)],
@@ -537,6 +711,7 @@ impl DurableSession {
         self.token_tracker.add_delta(tokens);
     }
 
+    /// Appends a structured agent message and records its text token delta.
     pub fn add_agent_message(&mut self, content: Vec<ContentBlock>) {
         let msg = StructuredMessage::Agent { content };
         let tokens = msg.estimated_tokens();
@@ -556,7 +731,7 @@ impl DurableSession {
 
     /// Create the durable record for a tool call without updating token
     /// tracking.  Callers that need the delta recorded immediately should use
-    /// [`propose_tool_call`]; stream processing defers delta until after the
+    /// [`Self::propose_tool_call`]; stream processing defers delta until after the
     /// usage event to avoid losing it when `ProviderEvent::Usage` resets the
     /// baseline.
     pub fn propose_tool_call_without_delta(
@@ -593,6 +768,11 @@ impl DurableSession {
         record_index
     }
 
+    /// Records a tool call pending approval and accounts for its arguments.
+    ///
+    /// Returns the new record's index. Use
+    /// [`Self::propose_tool_call_without_delta`] when provider usage ordering
+    /// requires the local token delta to be applied later.
     pub fn propose_tool_call(
         &mut self,
         call_id: impl Into<String>,
@@ -609,6 +789,12 @@ impl DurableSession {
         record_index
     }
 
+    /// Marks an existing call running or creates a new running call.
+    ///
+    /// An existing record is selected by `call_id`; only its status changes and
+    /// no timeline entry or token delta is added. A new call receives a start
+    /// entry and contributes its estimated arguments to token accounting.
+    /// Returns the record index in either case.
     pub fn start_tool_call(
         &mut self,
         call_id: impl Into<String>,
@@ -658,6 +844,10 @@ impl DurableSession {
         record_index
     }
 
+    /// Completes the first tool record matching `call_id`.
+    ///
+    /// The result is stored, a terminal timeline entry is appended, and its
+    /// estimated token delta is recorded. An unknown ID is a no-op.
     pub fn complete_tool_call(&mut self, call_id: &str, result: Value) {
         let idx = self.tool_records.iter().position(|r| r.call_id == call_id);
         if let Some(i) = idx {
@@ -690,6 +880,11 @@ impl DurableSession {
         }
     }
 
+    /// Fails the first tool record matching `call_id`.
+    ///
+    /// The error is stored as the record result, a terminal timeline entry is
+    /// appended, and its estimated token delta is recorded. An unknown ID is a
+    /// no-op.
     pub fn fail_tool_call(&mut self, call_id: &str, error: Value) {
         let idx = self.tool_records.iter().position(|r| r.call_id == call_id);
         if let Some(i) = idx {
@@ -722,6 +917,10 @@ impl DurableSession {
         }
     }
 
+    /// Denies the first tool record matching `call_id`.
+    ///
+    /// A synthetic denial result and terminal timeline entry are added to the
+    /// provider-visible context. An unknown ID is a no-op.
     pub fn deny_tool_call(&mut self, call_id: &str) {
         let idx = self.tool_records.iter().position(|r| r.call_id == call_id);
         if let Some(i) = idx {
@@ -754,6 +953,10 @@ impl DurableSession {
         }
     }
 
+    /// Cancels the first tool record matching `call_id` if it is non-terminal.
+    ///
+    /// Cancellation adds a synthetic result and token delta. Unknown or
+    /// already terminal records are unchanged.
     pub fn cancel_tool_call(&mut self, call_id: &str) {
         let idx = self.tool_records.iter().position(|r| r.call_id == call_id);
         if let Some(i) = idx {
@@ -761,16 +964,11 @@ impl DurableSession {
         }
     }
 
-    /// Transition every non-terminal tool record (`Running` or
-    /// `PendingApproval`) to `Cancelled` atomically under the durable mutex.
+    /// Transitions every non-terminal tool record to `Cancelled`.
     ///
-    /// Why: the cancel path previously exited without tying off records whose
-    /// tool futures were still in flight, so a subsequent resume or status
-    /// query would observe a permanently-`Running` record. Because this method
-    /// does not await, holding the durable mutex for its duration is safe and
-    /// makes the transition atomic with respect to other session writes.
-    ///
-    /// Returns the list of `call_id`s that were transitioned, for logging.
+    /// Each transition appends a terminal timeline result and token delta.
+    /// The returned IDs preserve tool-record order. Callers holding the shared
+    /// durable mutex can perform the whole operation without an await point.
     pub fn cancel_running_tool_calls(&mut self, reason: &str) -> Vec<String> {
         let indices: Vec<usize> = self
             .tool_records
@@ -835,12 +1033,23 @@ impl DurableSession {
         self.token_tracker.add_delta(result_tokens);
     }
 
+    /// Appends an externally created compressed block and resets compaction age.
+    ///
+    /// This helper does not remove source timeline entries. It resets
+    /// `uncompacted_tokens` and invalidates provider-baseline accounting because
+    /// adding the rendered block changes provider-visible context.
     pub fn apply_compression(&mut self, block: crate::context::models::CompressedBlock) {
         self.compressed_blocks.push(block);
         self.uncompacted_tokens = 0;
         self.token_tracker.invalidate_baseline();
     }
 
+    /// Removes selected timeline positions and rebuilds referenced storage.
+    ///
+    /// Retained messages and tool records are compacted into new vectors;
+    /// timeline indexes and tool boundary indexes are rewritten accordingly.
+    /// Script records are unaffected. Invalid positions are ignored, and a
+    /// nonempty request invalidates the provider token baseline.
     pub fn remove_timeline_positions(&mut self, positions: &BTreeSet<usize>) {
         if positions.is_empty() {
             return;
@@ -1010,10 +1219,14 @@ impl DurableSession {
         self.token_tracker.invalidate_baseline();
     }
 
+    /// Resets the heuristic count of tokens added since compaction.
+    ///
+    /// This does not alter provider baseline/delta accounting.
     pub fn reset_uncompacted_tokens(&mut self) {
         self.uncompacted_tokens = 0;
     }
 
+    /// Returns whether no tool call is pending approval or running.
     pub fn is_idle(&self) -> bool {
         !self.tool_records.iter().any(|r| {
             matches!(
@@ -1025,6 +1238,9 @@ impl DurableSession {
 
     // -- Skill activation helpers --
 
+    /// Activates or replaces a session skill and invalidates token baseline.
+    ///
+    /// Active skill instructions are provider-visible prompt content.
     pub fn activate_skill(
         &mut self,
         name: impl Into<String>,
@@ -1040,31 +1256,38 @@ impl DurableSession {
         self.token_tracker.invalidate_baseline();
     }
 
+    /// Deactivates a named skill and invalidates token baseline.
     pub fn deactivate_skill(&mut self, name: &str) {
         self.skill_state.deactivate(name);
         self.token_tracker.invalidate_baseline();
     }
 
+    /// Returns active skill names in session-defined order.
     pub fn list_active_skills(&self) -> Vec<&str> {
         self.skill_state.active_names()
     }
 
+    /// Renders all active skill instructions for prompt inclusion.
     pub fn active_skill_instructions(&self) -> String {
         self.skill_state.active_skill_instructions()
     }
 
+    /// Returns whether a skill with `name` is active.
     pub fn is_skill_active(&self, name: &str) -> bool {
         self.skill_state.is_active(name)
     }
 
+    /// Replaces the session snapshot of skills available for activation.
     pub fn set_available_skills(&mut self, skills: Vec<crate::skill::LoadedSkill>) {
         self.available_skills = skills;
     }
 
+    /// Borrows the session snapshot of available skills.
     pub fn list_available_skills(&self) -> &[crate::skill::LoadedSkill] {
         &self.available_skills
     }
 
+    /// Clones an available skill whose metadata ID matches `name`.
     pub fn load_available_skill(&self, name: &str) -> Option<crate::skill::LoadedSkill> {
         self.available_skills
             .iter()
@@ -1074,18 +1297,25 @@ impl DurableSession {
 
     // -- Workspace root helpers --
 
+    /// Borrows workspace roots active for the current turn.
     pub fn active_workspace_roots(&self) -> &[std::path::PathBuf] {
         &self.workspace_roots
     }
 
+    /// Stages replacement workspace roots for the next turn boundary.
     pub fn set_pending_workspace_roots(&mut self, roots: Vec<std::path::PathBuf>) {
         self.pending_workspace_roots = Some(roots);
     }
 
+    /// Discards workspace roots staged for the next turn boundary.
     pub fn clear_pending_workspace_roots(&mut self) {
         self.pending_workspace_roots = None;
     }
 
+    /// Applies staged workspace roots at a turn boundary.
+    ///
+    /// Returns whether roots were staged. Applying them invalidates provider
+    /// token accounting because workspace-derived prompt context may change.
     pub fn apply_pending_workspace_roots(&mut self) -> bool {
         if let Some(roots) = self.pending_workspace_roots.take() {
             self.workspace_roots = roots;
@@ -1096,10 +1326,18 @@ impl DurableSession {
         }
     }
 
+    /// Builds a provider transcript without stable visible-ID prefixes.
+    ///
+    /// Model-switch entries are metadata and are omitted.
     pub fn to_transcript(&self) -> iron_providers::Transcript {
         self.to_transcript_with_visible_ids(false)
     }
 
+    /// Builds a provider transcript from the ordered durable timeline.
+    ///
+    /// When `include_visible_ids` is true, text messages are prefixed with
+    /// their stable IDs. Non-text message blocks are omitted, terminal tool
+    /// records become tool messages, and model-switch metadata is excluded.
     pub fn to_transcript_with_visible_ids(
         &self,
         include_visible_ids: bool,
@@ -1177,15 +1415,24 @@ impl DurableSession {
         iron_providers::Transcript::with_messages(provider_messages)
     }
 
+    /// Returns whether the session has no messages or tool records.
+    ///
+    /// Compressed blocks, scripts, and model-switch metadata do not affect this
+    /// predicate.
     pub fn is_empty(&self) -> bool {
         self.messages.is_empty() && self.tool_records.is_empty()
     }
 
+    /// Replaces explicit session instructions and invalidates token baseline.
     pub fn set_instructions(&mut self, instructions: impl Into<String>) {
         self.instructions = Some(instructions.into());
         self.token_tracker.invalidate_baseline();
     }
 
+    /// Sets the profile identity, treating blank text as absent.
+    ///
+    /// The rendered identity is provider-visible, so this invalidates token
+    /// baseline accounting.
     pub fn set_profile_identity(&mut self, identity: impl Into<String>) {
         let value = identity.into();
         if value.trim().is_empty() {
@@ -1212,6 +1459,7 @@ impl DurableSession {
         }
     }
 
+    /// Starts a durable script record linked to its launching tool call.
     pub fn record_script_start(
         &mut self,
         script_id: impl Into<String>,
@@ -1223,6 +1471,9 @@ impl DurableSession {
             .push(DurableScriptRecord::new(script_id, call_id, source, input));
     }
 
+    /// Completes the first script record matching `script_id`.
+    ///
+    /// An unknown ID is a no-op.
     pub fn record_script_complete(
         &mut self,
         script_id: &str,
@@ -1238,6 +1489,9 @@ impl DurableSession {
         }
     }
 
+    /// Completes a matching script while recording child-call failures.
+    ///
+    /// An unknown ID is a no-op.
     pub fn record_script_complete_with_failures(
         &mut self,
         script_id: &str,
@@ -1253,6 +1507,10 @@ impl DurableSession {
         }
     }
 
+    /// Fails the first script record matching `script_id`.
+    ///
+    /// This convenience path records an empty child-call list. An unknown ID is
+    /// a no-op.
     pub fn record_script_failed(&mut self, script_id: &str, error: Value) {
         if let Some(rec) = self
             .script_records
@@ -1263,6 +1521,9 @@ impl DurableSession {
         }
     }
 
+    /// Cancels the first script record matching `script_id`.
+    ///
+    /// An unknown ID is a no-op.
     pub fn record_script_cancelled(&mut self, script_id: &str) {
         if let Some(rec) = self
             .script_records
@@ -1273,6 +1534,10 @@ impl DurableSession {
         }
     }
 
+    /// Links a child tool call to a script in both durable records.
+    ///
+    /// Either side is updated independently when present. Existing child links
+    /// are not deduplicated.
     pub fn link_child_to_script(&mut self, script_id: &str, child_call_id: &str) {
         if let Some(rec) = self
             .script_records
@@ -1290,19 +1555,21 @@ impl DurableSession {
         }
     }
 
-    /// Enable or disable an MCP server for this session.
+    /// Enables or disables an MCP server for this session.
+    ///
+    /// MCP tool definitions affect provider-visible context, so changing this
+    /// state invalidates token baseline accounting.
     pub fn set_mcp_server_enabled(&mut self, server_id: impl Into<String>, enabled: bool) {
         self.mcp_server_enablement.insert(server_id.into(), enabled);
         self.token_tracker.invalidate_baseline();
     }
 
-    /// Check if an MCP server is enabled for this session.
-    /// Returns None if not explicitly set.
+    /// Returns explicit MCP server enablement, or `None` when unset.
     pub fn is_mcp_server_enabled(&self, server_id: &str) -> Option<bool> {
         self.mcp_server_enablement.get(server_id).copied()
     }
 
-    /// Get list of MCP server IDs that are enabled for this session.
+    /// Returns IDs of MCP servers explicitly enabled for this session.
     pub fn list_enabled_mcp_servers(&self) -> Vec<String> {
         self.mcp_server_enablement
             .iter()
@@ -1311,24 +1578,24 @@ impl DurableSession {
             .collect()
     }
 
-    /// Enable or disable a plugin for this session.
+    /// Enables or disables a plugin and invalidates token baseline accounting.
     pub fn set_plugin_enabled(&mut self, plugin_id: impl Into<String>, enabled: bool) {
         self.plugin_enablement.set_enabled(plugin_id, enabled);
         self.token_tracker.invalidate_baseline();
     }
 
-    /// Check if a plugin is enabled for this session.
-    /// Returns None if not explicitly set.
+    /// Returns explicit plugin enablement, or `None` when unset.
     pub fn is_plugin_enabled(&self, plugin_id: &str) -> Option<bool> {
         self.plugin_enablement.is_enabled(plugin_id)
     }
 
-    /// Get list of plugin IDs that are enabled for this session.
+    /// Returns IDs of plugins explicitly enabled for this session.
     pub fn list_enabled_plugins(&self) -> Vec<String> {
         self.plugin_enablement.list_enabled()
     }
 }
 
+/// Shared, synchronously locked ownership of a [`DurableSession`].
 pub type SharedDurableSession = std::sync::Arc<parking_lot::Mutex<DurableSession>>;
 
 fn render_with_visible_id(

--- a/src/embedded_python/catalog.rs
+++ b/src/embedded_python/catalog.rs
@@ -1,3 +1,5 @@
+//! Internal script-visible catalog of runtime tools and safe Python aliases.
+
 use crate::tool::ToolDefinition;
 use serde_json::{json, Value};
 use std::collections::{HashMap, HashSet};
@@ -11,16 +13,19 @@ const PYTHON_KEYWORDS: &[&str] = &[
 ];
 
 #[derive(Debug, Clone)]
+/// Catalog entry containing a tool definition and optional Python-safe alias.
 pub(crate) struct ToolCatalogEntry {
     definition: ToolDefinition,
     alias: Option<String>,
 }
 
 impl ToolCatalogEntry {
+    /// Returns the registered runtime tool name.
     pub(crate) fn name(&self) -> &str {
         &self.definition.name
     }
 
+    /// Returns public catalog metadata without the input schema.
     pub(crate) fn summary_json(&self) -> Value {
         json!({
             "name": self.definition.name,
@@ -30,6 +35,7 @@ impl ToolCatalogEntry {
         })
     }
 
+    /// Returns complete script-visible metadata, including the input schema.
     pub(crate) fn describe_json(&self) -> Value {
         json!({
             "name": self.definition.name,
@@ -42,6 +48,7 @@ impl ToolCatalogEntry {
 }
 
 #[derive(Debug, Clone, Default)]
+/// Snapshot of tools available to one embedded-Python run.
 pub(crate) struct ToolCatalog {
     entries: Vec<ToolCatalogEntry>,
     by_name: HashMap<String, usize>,
@@ -49,6 +56,7 @@ pub(crate) struct ToolCatalog {
 }
 
 impl ToolCatalog {
+    /// Builds a catalog and assigns non-conflicting Python-safe aliases.
     pub(crate) fn from_definitions(definitions: Vec<ToolDefinition>) -> Self {
         let mut entries = Vec::with_capacity(definitions.len());
         let mut by_name = HashMap::with_capacity(definitions.len());
@@ -76,6 +84,7 @@ impl ToolCatalog {
         }
     }
 
+    /// Creates the frozen `IronTools` object injected as the `tools` global.
     pub(crate) fn namespace_object(&self) -> monty::MontyObject {
         monty::MontyObject::Dataclass {
             name: "IronTools".to_string(),
@@ -86,6 +95,7 @@ impl ToolCatalog {
         }
     }
 
+    /// Returns summaries for all catalog entries in registry order.
     pub(crate) fn available_json(&self) -> Value {
         Value::Array(
             self.entries
@@ -95,15 +105,18 @@ impl ToolCatalog {
         )
     }
 
+    /// Returns full metadata for a registered tool name.
     pub(crate) fn describe_json(&self, name: &str) -> Option<Value> {
         self.entry_by_name(name)
             .map(ToolCatalogEntry::describe_json)
     }
 
+    /// Looks up an entry by its registered runtime name.
     pub(crate) fn entry_by_name(&self, name: &str) -> Option<&ToolCatalogEntry> {
         self.by_name.get(name).map(|idx| &self.entries[*idx])
     }
 
+    /// Looks up an entry by its generated Python method alias.
     pub(crate) fn entry_by_alias(&self, alias: &str) -> Option<&ToolCatalogEntry> {
         self.by_alias.get(alias).map(|idx| &self.entries[*idx])
     }
@@ -143,6 +156,7 @@ fn alias_for_tool(name: &str, assigned_aliases: &HashSet<String>) -> Option<Stri
     Some(alias)
 }
 
+/// Returns whether a Monty object is the injected `IronTools` namespace.
 pub(crate) fn is_tools_namespace(obj: &monty::MontyObject) -> bool {
     matches!(obj, monty::MontyObject::Dataclass { name, .. } if name == "IronTools")
 }

--- a/src/embedded_python/convert.rs
+++ b/src/embedded_python/convert.rs
@@ -1,8 +1,13 @@
+//! Conversions between JSON values, Monty values, and script exceptions.
+
 use monty::{DictPairs, ExcType, MontyException, MontyObject};
 use num_bigint::BigInt;
 use num_traits::Zero;
 use serde_json::Value;
 
+/// Converts a JSON value into the corresponding embedded-Python value.
+///
+/// JSON arrays and objects become Python lists and dictionaries recursively.
 pub fn json_to_monty(value: &Value) -> MontyObject {
     match value {
         Value::Null => MontyObject::None,
@@ -26,6 +31,11 @@ pub fn json_to_monty(value: &Value) -> MontyObject {
     }
 }
 
+/// Converts an embedded-Python value into JSON-compatible output.
+///
+/// Tuples become arrays, dictionary keys are converted to strings, non-finite
+/// `NaN` becomes the string `"NaN"`, and integers outside the JSON `i64` range
+/// become decimal strings. Unsupported runtime objects become JSON `null`.
 pub fn monty_to_json(obj: &MontyObject) -> Value {
     match obj {
         MontyObject::None => Value::Null,
@@ -79,6 +89,11 @@ fn bigint_to_json(bi: &BigInt) -> Value {
     }
 }
 
+/// Creates the Python exception used to report a child tool-call failure.
+///
+/// Recognized timeout names map to Python `TimeoutError`; other tool failure,
+/// denial, and cancellation names map to `RuntimeError`. The supplied type name
+/// is retained as a prefix in the exception message.
 pub fn make_iron_exception(type_name: &str, message: &str) -> MontyException {
     let exc_type = match type_name {
         "ToolFailedError" | "ToolError" => ExcType::RuntimeError,

--- a/src/embedded_python/engine.rs
+++ b/src/embedded_python/engine.rs
@@ -1,3 +1,5 @@
+//! Monty-backed sandboxed script engine and per-execution state.
+
 use crate::config::EmbeddedPythonConfig;
 use crate::embedded_python::convert::{json_to_monty, make_iron_exception, monty_to_json};
 use crate::embedded_python::types::{
@@ -15,11 +17,23 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
+/// Host callback used to execute a child tool call requested by a script.
+///
+/// Arguments are the generated call ID, registered tool name, and JSON object
+/// payload. The callback returns the terminal child-call status and optional
+/// JSON result or failure detail.
 pub type ToolExecutorFn =
     dyn Fn(&str, &str, Value) -> (ChildCallStatus, Option<Value>) + Send + Sync;
 
+/// A configured, single-script execution.
+///
+/// Runs enforce source-size, serialized-result-size, wall-clock, child-call,
+/// cancellation, and host OS-access limits. The cancellation flag may be set
+/// from another thread before or during execution.
 pub struct ScriptRun {
+    /// Source and structured input for this run.
     pub input: ScriptInput,
+    /// Resource limits and feature settings captured when the run was created.
     pub config: EmbeddedPythonConfig,
     cancel_token: Arc<AtomicBool>,
     child_outcomes: Arc<Mutex<Vec<ChildCallOutcome>>>,
@@ -28,6 +42,7 @@ pub struct ScriptRun {
 }
 
 impl ScriptRun {
+    /// Creates a run using a snapshot of `config` and a shared cancellation flag.
     pub fn new(
         input: ScriptInput,
         config: &EmbeddedPythonConfig,
@@ -43,21 +58,36 @@ impl ScriptRun {
         }
     }
 
+    /// Installs the host callback for child tool calls.
+    ///
+    /// Without an executor, attempted child calls are recorded as failed.
     pub fn with_tool_executor(mut self, executor: Arc<ToolExecutorFn>) -> Self {
         self.tool_executor = Some(executor);
         self
     }
 
+    /// Replaces the tools namespace catalog used by this run.
     pub(crate) fn with_tool_catalog(mut self, catalog: ToolCatalog) -> Self {
         self.tool_catalog = catalog;
         self
     }
 
+    /// Populates the script-visible tools namespace from a runtime registry.
+    ///
+    /// Tool definitions are snapshotted when this method is called. Calls are
+    /// still dispatched through the separately configured [`ToolExecutorFn`].
     pub fn with_tool_catalog_from_registry(mut self, registry: &ToolRegistry) -> Self {
         self.tool_catalog = ToolCatalog::from_definitions(registry.definitions());
         self
     }
 
+    /// Executes the script synchronously to a terminal output.
+    ///
+    /// The script receives `input` and `tools` globals. It may call cataloged
+    /// tools through `tools.<alias>(payload)`, `tools.call(name, payload)`, or
+    /// the low-level `iron_call(name, payload)`. Direct host OS operations are
+    /// rejected. The configured timeout is enforced by the interpreter; source
+    /// and serialized result byte limits are checked before and after execution.
     pub fn execute(&self) -> ScriptOutput {
         if self.cancel_token.load(Ordering::SeqCst) {
             return ScriptOutput::cancelled();
@@ -506,21 +536,28 @@ enum ResolvedFunctionCall {
     Error(MontyException),
 }
 
+/// Factory for embedded-Python runs sharing one configuration snapshot.
 pub struct ScriptEngine {
+    /// Configuration copied into each run created by this engine.
     pub config: EmbeddedPythonConfig,
 }
 
 impl ScriptEngine {
+    /// Creates an engine by cloning the supplied embedded-Python configuration.
     pub fn new(config: &EmbeddedPythonConfig) -> Self {
         Self {
             config: config.clone(),
         }
     }
 
+    /// Returns whether embedded-Python execution is enabled by configuration.
     pub fn is_enabled(&self) -> bool {
         self.config.enabled
     }
 
+    /// Creates a run with a new, initially unset cancellation flag.
+    ///
+    /// No child tool executor or tool catalog is installed automatically.
     pub fn create_run(&self, input: ScriptInput) -> ScriptRun {
         let cancel_token = Arc::new(AtomicBool::new(false));
         ScriptRun::new(input, &self.config, cancel_token)

--- a/src/embedded_python/mod.rs
+++ b/src/embedded_python/mod.rs
@@ -1,4 +1,13 @@
+//! Sandboxed embedded-Python execution and its `python_exec` tool.
+//!
+//! The always-available types describe script inputs and outputs. Enabling the
+//! `embedded-python` feature also exposes JSON conversion helpers and the
+//! Monty-backed execution engine. Scripts are constrained by configured source
+//! size, result size, duration, and child-tool-call limits and have no direct
+//! host OS access.
+
 #[cfg(feature = "embedded-python")]
+/// Internal catalog used to expose registered tools to scripts.
 pub(crate) mod catalog;
 #[cfg(feature = "embedded-python")]
 pub mod convert;

--- a/src/embedded_python/python_exec_tool.rs
+++ b/src/embedded_python/python_exec_tool.rs
@@ -1,3 +1,5 @@
+//! Runtime tool adapter for sandboxed embedded-Python execution.
+
 use crate::error::RuntimeResult;
 use crate::tool::{Tool, ToolDefinition, ToolFuture};
 use serde_json::{json, Value};
@@ -11,6 +13,12 @@ use crate::embedded_python::{ScriptRun, ToolExecutorFn};
 #[cfg(feature = "embedded-python")]
 use std::sync::Arc;
 
+/// Tool implementation that executes Python source in the embedded sandbox.
+///
+/// The tool always requires approval. With the `embedded-python` feature it
+/// enforces the default [`crate::config::EmbeddedPythonConfig`] limits and can
+/// delegate script child calls to a configured executor. Without that feature,
+/// execution returns a tool error explaining how to enable it.
 pub struct PythonExecTool {
     definition: ToolDefinition,
     #[cfg(feature = "embedded-python")]
@@ -24,6 +32,7 @@ impl Default for PythonExecTool {
 }
 
 impl PythonExecTool {
+    /// Creates a `python_exec` tool without a child tool-call executor.
     pub fn new() -> Self {
         let definition = ToolDefinition::new(
             "python_exec",
@@ -51,6 +60,7 @@ impl PythonExecTool {
     }
 
     #[cfg(feature = "embedded-python")]
+    /// Installs the host callback used for tool calls made by Python scripts.
     pub fn with_tool_executor(mut self, executor: Arc<ToolExecutorFn>) -> Self {
         self.tool_executor = Some(executor);
         self
@@ -87,6 +97,10 @@ impl PythonExecTool {
 }
 
 #[cfg(feature = "embedded-python")]
+/// Converts structured script output to the JSON returned by `python_exec`.
+///
+/// Optional `result`, `error`, and `child_outcomes` members are omitted when
+/// absent. Status and error kinds use stable snake-case strings.
 pub fn script_output_to_json(output: &ScriptOutput) -> Value {
     let status_str = match output.status {
         ScriptExecStatus::Completed => "completed",

--- a/src/embedded_python/sandbox.rs
+++ b/src/embedded_python/sandbox.rs
@@ -1,16 +1,26 @@
+//! Sandbox allowlists and resource limits for embedded-Python execution.
+
 use crate::config::EmbeddedPythonConfig;
 
+/// Builtin/module allowlists and per-run resource limits.
 #[derive(Debug, Clone)]
 pub struct SandboxConfig {
+    /// Python builtin names available to scripts.
     pub allowed_builtins: Vec<&'static str>,
+    /// Python module names scripts may import.
     pub allowed_modules: Vec<&'static str>,
+    /// Maximum accepted Python source length in bytes.
     pub max_source_bytes: usize,
+    /// Maximum serialized JSON result length in bytes.
     pub max_result_bytes: usize,
+    /// Maximum number of host tool calls initiated by one script.
     pub max_child_calls: usize,
+    /// Maximum script execution duration in seconds.
     pub timeout_secs: u64,
 }
 
 impl SandboxConfig {
+    /// Builds sandbox limits from runtime configuration and the default allowlists.
     pub fn from_config(config: &EmbeddedPythonConfig) -> Self {
         Self {
             allowed_builtins: DEFAULT_ALLOWED_BUILTINS.to_vec(),

--- a/src/embedded_python/types.rs
+++ b/src/embedded_python/types.rs
@@ -1,70 +1,116 @@
+//! Serializable request, result, status, and error types for script execution.
+
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+/// Source code and structured input supplied to an embedded-Python run.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ScriptInput {
+    /// Python source code to execute.
     pub script: String,
+    /// JSON value exposed to the script as `input`.
     pub input: Value,
 }
 
+/// Terminal output from an embedded-Python run.
+///
+/// Successful runs set `result`; failed and cancelled runs set `error`.
+/// Outcomes from child tool calls are retained when execution reaches a point
+/// where they can be reported.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ScriptOutput {
+    /// Overall terminal status of the script.
     pub status: ScriptExecStatus,
+    /// JSON-compatible value produced by the script's last expression.
     pub result: Option<Value>,
+    /// Error that terminated execution, if any.
     pub error: Option<ScriptError>,
+    /// Outcomes of host tool calls initiated by the script.
     pub child_outcomes: Vec<ChildCallOutcome>,
 }
 
+/// Terminal status of an embedded-Python run.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ScriptExecStatus {
+    /// The script and all child tool calls completed successfully.
     Completed,
+    /// The script returned a result, but at least one child tool call did not complete.
     CompletedWithFailures,
+    /// Script execution terminated with an error.
     Failed,
+    /// Execution was cancelled before producing a result.
     Cancelled,
 }
 
+/// Structured error returned by a failed or cancelled script.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ScriptError {
+    /// Machine-readable category of the failure.
     pub kind: ScriptErrorKind,
+    /// Human-readable failure description.
     pub message: String,
 }
 
+/// Categories of embedded-Python execution failure.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ScriptErrorKind {
+    /// Execution exceeded the configured wall-clock duration.
     Timeout,
+    /// Python source exceeded the configured byte limit.
     SourceTooLarge,
+    /// Serialized JSON output exceeded the configured byte limit.
     ResultTooLarge,
+    /// Parsing or executing the Python source failed.
     Runtime,
+    /// The script attempted more than the configured number of child tool calls.
     ChildCallLimitExceeded,
+    /// The run's cancellation token was set.
     Cancelled,
+    /// The script attempted unavailable host OS access.
     SandboxViolation,
 }
 
+/// Recorded outcome of one host tool call initiated by a script.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChildCallOutcome {
+    /// Runtime-generated identifier for the child call.
     pub call_id: String,
+    /// Registered tool name passed to the host executor.
     pub tool_name: String,
+    /// Terminal status reported by the host executor.
     pub status: ChildCallStatus,
+    /// Optional JSON result or structured failure detail from the tool.
     pub result: Option<Value>,
 }
 
+/// Terminal status of a child tool call.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ChildCallStatus {
+    /// The tool returned successfully.
     Completed,
+    /// The tool returned an execution failure.
     Failed,
+    /// Permission or policy denied the tool call.
     Denied,
+    /// The child call was cancelled.
     Cancelled,
 }
 
+/// JSON output wrapper for consumers that need a result-only value.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ScriptResult {
+    /// JSON-compatible script output.
     pub output: Value,
 }
 
 impl ScriptOutput {
+    /// Builds successful output and derives its status from child-call outcomes.
+    ///
+    /// Any child status other than [`ChildCallStatus::Completed`] produces
+    /// [`ScriptExecStatus::CompletedWithFailures`].
     pub fn completed(result: Value, child_outcomes: Vec<ChildCallOutcome>) -> Self {
         let has_failure = child_outcomes
             .iter()
@@ -82,6 +128,7 @@ impl ScriptOutput {
         }
     }
 
+    /// Builds failed output with no result or child-call outcomes.
     pub fn failed(error: ScriptError) -> Self {
         Self {
             status: ScriptExecStatus::Failed,
@@ -91,6 +138,7 @@ impl ScriptOutput {
         }
     }
 
+    /// Builds cancelled output with the standard cancellation error.
     pub fn cancelled() -> Self {
         Self {
             status: ScriptExecStatus::Cancelled,
@@ -105,6 +153,7 @@ impl ScriptOutput {
 }
 
 impl ScriptError {
+    /// Builds the standard execution-timeout error.
     pub fn timeout() -> Self {
         Self {
             kind: ScriptErrorKind::Timeout,
@@ -112,6 +161,7 @@ impl ScriptError {
         }
     }
 
+    /// Builds an error reporting the maximum accepted source size in bytes.
     pub fn source_too_large(max: usize) -> Self {
         Self {
             kind: ScriptErrorKind::SourceTooLarge,
@@ -119,6 +169,7 @@ impl ScriptError {
         }
     }
 
+    /// Builds an error reporting the maximum accepted serialized result size in bytes.
     pub fn result_too_large(max: usize) -> Self {
         Self {
             kind: ScriptErrorKind::ResultTooLarge,
@@ -126,6 +177,7 @@ impl ScriptError {
         }
     }
 
+    /// Builds an error reporting the maximum number of child tool calls.
     pub fn child_call_limit(max: usize) -> Self {
         Self {
             kind: ScriptErrorKind::ChildCallLimitExceeded,
@@ -133,6 +185,7 @@ impl ScriptError {
         }
     }
 
+    /// Builds a runtime error with the supplied interpreter message.
     pub fn runtime(message: impl Into<String>) -> Self {
         Self {
             kind: ScriptErrorKind::Runtime,
@@ -140,6 +193,7 @@ impl ScriptError {
         }
     }
 
+    /// Builds an error describing an attempted operation outside the sandbox.
     pub fn sandbox_violation(message: impl Into<String>) -> Self {
         Self {
             kind: ScriptErrorKind::SandboxViolation,

--- a/src/ephemeral.rs
+++ b/src/ephemeral.rs
@@ -1,32 +1,60 @@
+//! In-memory state for a single active session turn.
+//!
+//! Unlike [`crate::durable::DurableSession`], this state is not conversation
+//! history. It owns transient permission requests, streamed chunks, phase
+//! notifications, and a shareable cancellation flag for one in-flight turn.
+
 use crate::durable::SessionId;
 use serde_json::Value;
 use std::sync::Arc;
 use tokio::sync::watch;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Current lifecycle phase of an in-flight prompt turn.
 pub enum TurnPhase {
+    /// The turn exists but has not started.
     Idle,
+    /// Model or tool work is in progress.
     Running,
+    /// At least one tool call is awaiting permission.
     WaitingPermission,
+    /// Cancellation has begun but has not reached a terminal state.
     Cancelling,
+    /// The turn completed normally.
     Completed,
+    /// The turn was cancelled.
     Cancelled,
 }
 
+/// A permission decision still required by the current turn.
 #[derive(Debug, Clone)]
 pub enum PendingPermission {
+    /// A tool call waiting for approval or denial.
     Waiting {
+        /// Provider-assigned identifier of the tool call.
         call_id: String,
+        /// Name of the requested tool.
         tool_name: String,
+        /// Arguments supplied to the tool call.
         arguments: Value,
     },
 }
 
+/// Transient state owned by one in-flight turn.
+///
+/// The turn belongs to [`Self::session_id`], but it does not own the durable
+/// session. Cloned phase watchers and cancellation tokens may outlive a lock
+/// guard on this value and allow concurrent tasks to observe its lifecycle.
 pub struct EphemeralTurn {
+    /// Durable session to which this turn belongs.
     pub session_id: SessionId,
+    /// Optional client- or protocol-supplied turn identifier.
     pub turn_id: Option<String>,
+    /// Current lifecycle phase.
     pub phase: TurnPhase,
+    /// Tool calls whose permission decisions are outstanding.
     pub pending_permissions: Vec<PendingPermission>,
+    /// Response fragments buffered while the turn is active.
     pub partial_chunks: Vec<String>,
     phase_tx: watch::Sender<TurnPhase>,
     phase_rx: watch::Receiver<TurnPhase>,
@@ -34,6 +62,7 @@ pub struct EphemeralTurn {
 }
 
 impl EphemeralTurn {
+    /// Creates an idle turn associated with `session_id`.
     pub fn new(session_id: SessionId, turn_id: Option<String>) -> Self {
         let (phase_tx, phase_rx) = watch::channel(TurnPhase::Idle);
         Self {
@@ -48,11 +77,13 @@ impl EphemeralTurn {
         }
     }
 
+    /// Moves the turn to [`TurnPhase::Running`] and notifies phase watchers.
     pub fn start(&mut self) {
         self.phase = TurnPhase::Running;
         let _ = self.phase_tx.send(TurnPhase::Running);
     }
 
+    /// Records a tool permission request and enters the waiting phase.
     pub fn request_permission(&mut self, call_id: String, tool_name: String, arguments: Value) {
         self.phase = TurnPhase::WaitingPermission;
         let _ = self.phase_tx.send(TurnPhase::WaitingPermission);
@@ -63,6 +94,10 @@ impl EphemeralTurn {
         });
     }
 
+    /// Removes the pending request for `call_id`.
+    ///
+    /// Returns `true` when a request was found. The turn resumes
+    /// [`TurnPhase::Running`] only after the final pending request is removed.
     pub fn resolve_permission(&mut self, call_id: &str) -> bool {
         let idx = self.pending_permissions.iter().position(|p| match p {
             PendingPermission::Waiting { call_id: cid, .. } => cid == call_id,
@@ -79,10 +114,12 @@ impl EphemeralTurn {
         }
     }
 
+    /// Appends a streamed response fragment to the turn-local buffer.
     pub fn add_chunk(&mut self, chunk: String) {
         self.partial_chunks.push(chunk);
     }
 
+    /// Completes the turn and clears permissions and buffered chunks.
     pub fn complete(&mut self) {
         self.phase = TurnPhase::Completed;
         let _ = self.phase_tx.send(TurnPhase::Completed);
@@ -90,6 +127,9 @@ impl EphemeralTurn {
         self.partial_chunks.clear();
     }
 
+    /// Cancels the turn, publishes its terminal phase, and signals workers.
+    ///
+    /// Pending permissions are discarded, while buffered chunks are retained.
     pub fn cancel(&mut self) {
         self.phase = TurnPhase::Cancelled;
         let _ = self.phase_tx.send(TurnPhase::Cancelled);
@@ -98,19 +138,25 @@ impl EphemeralTurn {
         self.pending_permissions.clear();
     }
 
+    /// Returns whether cancellation has been requested through this turn.
     pub fn is_cancel_requested(&self) -> bool {
         self.cancel_requested
             .load(std::sync::atomic::Ordering::SeqCst)
     }
 
+    /// Returns a shared cancellation flag for work spawned by this turn.
+    ///
+    /// The returned [`Arc`] observes the same atomic flag as [`Self::cancel`].
     pub fn cancel_token(&self) -> Arc<std::sync::atomic::AtomicBool> {
         self.cancel_requested.clone()
     }
 
+    /// Subscribes to subsequent phase changes.
     pub fn phase_watcher(&self) -> watch::Receiver<TurnPhase> {
         self.phase_rx.clone()
     }
 
+    /// Returns whether the turn is completed or cancelled.
     pub fn is_terminal(&self) -> bool {
         matches!(self.phase, TurnPhase::Completed | TurnPhase::Cancelled)
     }
@@ -128,4 +174,5 @@ impl std::fmt::Debug for EphemeralTurn {
     }
 }
 
+/// Shared, asynchronously locked ownership of an [`EphemeralTurn`].
 pub type SharedEphemeralTurn = Arc<tokio::sync::Mutex<EphemeralTurn>>;

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,133 +2,224 @@
 
 use thiserror::Error;
 
+/// Result type returned by fallible runtime operations.
 pub type RuntimeResult<T> = Result<T, RuntimeError>;
 
 #[derive(Error, Debug, Clone, PartialEq)]
+/// Failures produced by runtime orchestration and tool execution.
 pub enum RuntimeError {
+    /// A model provider request or response failed.
     #[error("Provider error: {0}")]
-    Provider(String),
+    Provider(
+        /// Provider failure details.
+        String,
+    ),
 
+    /// An agent turn exhausted its configured iteration limit.
     #[error("Maximum iterations ({max}) exceeded")]
-    MaxIterationsExceeded { max: u32 },
+    MaxIterationsExceeded {
+        /// Configured maximum number of iterations.
+        max: u32,
+    },
 
+    /// A tool failed while executing.
     #[error("Tool execution error: {message}")]
-    ToolExecution { message: String },
+    ToolExecution {
+        /// Tool-provided failure details.
+        message: String,
+    },
 
+    /// No registered tool has the requested name.
     #[error("Tool not found: {name}")]
-    ToolNotFound { name: String },
+    ToolNotFound {
+        /// Requested tool name.
+        name: String,
+    },
 
+    /// Runtime configuration is invalid.
     #[error("Invalid configuration: {message}")]
-    InvalidConfig { message: String },
+    InvalidConfig {
+        /// Description of the violated configuration invariant.
+        message: String,
+    },
 
+    /// A session operation failed.
     #[error("Session error: {message}")]
-    Session { message: String },
+    Session {
+        /// Session failure details.
+        message: String,
+    },
 
+    /// A tool call cannot proceed without approval.
     #[error("Approval required for tool: {tool_name}")]
-    ApprovalRequired { tool_name: String },
+    ApprovalRequired {
+        /// Name of the tool awaiting approval.
+        tool_name: String,
+    },
 
+    /// A turn was started while another turn remained active.
     #[error("Turn already active (turn_id: {turn_id})")]
-    TurnAlreadyActive { turn_id: u64 },
+    TurnAlreadyActive {
+        /// Identifier of the currently active turn.
+        turn_id: u64,
+    },
 
+    /// An operation targeted a turn that has already completed.
     #[error("Turn has already finished")]
     TurnFinished,
 
+    /// Approval was supplied while the turn was in another state.
     #[error("Turn is not waiting for approval")]
     NotWaitingForApproval,
 
+    /// No pending approval matches the supplied call identifier.
     #[error("No pending approval for call_id: {call_id}")]
-    ApprovalNotFound { call_id: String },
+    ApprovalNotFound {
+        /// Tool call identifier that was not pending.
+        call_id: String,
+    },
 
+    /// Interaction input was supplied while the turn was in another state.
     #[error("Turn is not waiting for an interaction")]
     NotWaitingForInteraction,
 
+    /// No pending interaction matches the supplied identifier.
     #[error("No pending interaction for interaction_id: {interaction_id}")]
-    InteractionNotFound { interaction_id: String },
+    InteractionNotFound {
+        /// Interaction identifier that was not pending.
+        interaction_id: String,
+    },
 
+    /// A resolution has a different kind than its pending interaction.
     #[error("Interaction resolution kind mismatch for interaction_id: {interaction_id}")]
-    InteractionKindMismatch { interaction_id: String },
+    InteractionKindMismatch {
+        /// Identifier of the interaction with the mismatched resolution.
+        interaction_id: String,
+    },
 
+    /// An interaction resolution is malformed or semantically invalid.
     #[error("Invalid interaction resolution: {message}")]
-    InvalidInteractionResolution { message: String },
+    InvalidInteractionResolution {
+        /// Description of the invalid resolution.
+        message: String,
+    },
 
+    /// An operation targeted a closed session.
     #[error("Session has been closed")]
     SessionClosed,
 
+    /// The session's runtime executor is no longer available.
     #[error("Session runtime has been shut down")]
     RuntimeShutdown,
 
+    /// Communication with an external transport failed.
     #[error("Transport error: {0}")]
-    Transport(String),
+    Transport(
+        /// Transport failure details.
+        String,
+    ),
 
+    /// A session identifier did not resolve to a known session.
     #[error("Session not found: {0}")]
-    SessionNotFound(String),
+    SessionNotFound(
+        /// Session identifier that was not found.
+        String,
+    ),
 
+    /// Establishing or using a connection failed.
     #[error("Connection error: {0}")]
-    Connection(String),
+    Connection(
+        /// Connection failure details.
+        String,
+    ),
 
+    /// Capability negotiation or invocation failed.
     #[error("Capability error: {0}")]
-    Capability(String),
+    Capability(
+        /// Capability failure details.
+        String,
+    ),
 
+    /// A turn-level operation failed.
     #[error("Turn error: {0}")]
-    Turn(String),
+    Turn(
+        /// Turn failure details.
+        String,
+    ),
 
+    /// Loading or applying configuration failed.
     #[error("Configuration error: {0}")]
-    Config(String),
+    Config(
+        /// Configuration failure details.
+        String,
+    ),
 }
 
 impl RuntimeError {
+    /// Construct a provider failure from a message.
     pub fn provider<S: Into<String>>(message: S) -> Self {
         Self::Provider(message.into())
     }
 
+    /// Construct an iteration-limit failure for the configured maximum.
     pub fn max_iterations(max: u32) -> Self {
         Self::MaxIterationsExceeded { max }
     }
 
+    /// Construct a tool-execution failure from a message.
     pub fn tool_execution<S: Into<String>>(message: S) -> Self {
         Self::ToolExecution {
             message: message.into(),
         }
     }
 
+    /// Construct a missing-tool failure from the requested name.
     pub fn tool_not_found<S: Into<String>>(name: S) -> Self {
         Self::ToolNotFound { name: name.into() }
     }
 
+    /// Construct an invalid-configuration failure from a message.
     pub fn invalid_config<S: Into<String>>(message: S) -> Self {
         Self::InvalidConfig {
             message: message.into(),
         }
     }
 
+    /// Construct a session failure from a message.
     pub fn session<S: Into<String>>(message: S) -> Self {
         Self::Session {
             message: message.into(),
         }
     }
 
+    /// Construct an approval-required failure for a tool name.
     pub fn approval_required<S: Into<String>>(tool_name: S) -> Self {
         Self::ApprovalRequired {
             tool_name: tool_name.into(),
         }
     }
 
+    /// Construct a transport failure from a message.
     pub fn transport<S: Into<String>>(msg: S) -> Self {
         Self::Transport(msg.into())
     }
 
+    /// Construct a missing-session failure from an identifier.
     pub fn session_not_found<S: Into<String>>(id: S) -> Self {
         Self::SessionNotFound(id.into())
     }
 
+    /// Construct a connection failure from a message.
     pub fn connection<S: Into<String>>(msg: S) -> Self {
         Self::Connection(msg.into())
     }
 
+    /// Construct a capability failure from a message.
     pub fn capability<S: Into<String>>(msg: S) -> Self {
         Self::Capability(msg.into())
     }
 
+    /// Return whether this error represents exhaustion of the iteration limit.
     pub fn is_max_iterations(&self) -> bool {
         matches!(self, Self::MaxIterationsExceeded { .. })
     }

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -118,7 +118,9 @@ pub enum AutomationRunErrorCategory {
 /// Structured error carried in a failed, cancelled, or timed-out run result.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AutomationRunError {
+    /// Stable class used by callers to map the failure to an exit status.
     pub category: AutomationRunErrorCategory,
+    /// Human-readable failure detail.
     pub message: String,
 }
 
@@ -290,14 +292,19 @@ impl AutomationRunResult {
 /// Typed failure during execution-input resolution.
 #[derive(Debug, thiserror::Error)]
 pub enum ResolutionError {
+    /// The requested automation-task ID has no readable current record.
     #[error("automation task '{0}' not found")]
     TaskNotFound(String),
+    /// The task's stored-prompt reference does not exist.
     #[error("stored prompt '{0}' not found")]
     PromptNotFound(String),
+    /// The stored prompt has an unsupported schema or fails validation.
     #[error("stored prompt '{0}' has an unsupported schema version or invalid payload")]
     InvalidPrompt(String),
+    /// The explicit or default profile cannot be found in the supplied snapshot.
     #[error("profile '{}' not found", _0.as_str())]
     ProfileNotFound(AgentProfileId),
+    /// Persistent configuration access failed during resolution.
     #[error(transparent)]
     Store(#[from] ConfigError),
 }

--- a/src/facade.rs
+++ b/src/facade.rs
@@ -1,3 +1,5 @@
+//! High-level agent, connection, session, and streaming prompt APIs.
+
 use crate::plugin::rich_output::{transcript_text as plugin_transcript_text, view as plugin_view};
 use crate::{
     capability::{CapabilityBackend, CapabilityDescriptor, CapabilityId},
@@ -98,17 +100,23 @@ pub struct PermissionRequest {
 ///
 /// # Event Ordering
 ///
-/// Events are emitted in the order they occur:
-/// 1. Zero or more [`Status`](PromptEvent::Status) events
-/// 2. Zero or more [`Output`](PromptEvent::Output) events (text from the model)
-/// 3. Zero or more [`ToolCall`](PromptEvent::ToolCall) events
-/// 4. For each tool requiring approval: an [`ApprovalRequest`](PromptEvent::ApprovalRequest)
-/// 5. For each tool call: a [`ToolResult`](PromptEvent::ToolResult)
-/// 6. Finally, a [`Complete`](PromptEvent::Complete) event
+/// Events preserve runtime occurrence order and may interleave across inference
+/// iterations. For a given tool, [`ToolCall`](PromptEvent::ToolCall) precedes an
+/// optional [`ApprovalRequest`](PromptEvent::ApprovalRequest), which precedes
+/// its terminal [`ToolResult`](PromptEvent::ToolResult). Compaction start events
+/// precede their matching finish or failure event. A successful stream task
+/// emits one [`Complete`](PromptEvent::Complete) event last.
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```no_run
+/// use iron_core::{Config, IronAgent, PromptEvent};
+/// use iron_providers::{ApiFamily, ProviderConnection, ProviderProfile, RuntimeConfig};
+///
+/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// # let provider = ProviderConnection::from_profile(ProviderProfile::new("openai", ApiFamily::Responses, "https://api.openai.com/v1"), RuntimeConfig::new("sk-example"))?;
+/// # let agent = IronAgent::new(Config::default(), provider);
+/// # let session = agent.connect().create_session()?;
 /// let (handle, mut events) = session.prompt_stream("Hello");
 /// while let Some(event) = events.next().await {
 ///     match event {
@@ -121,6 +129,8 @@ pub struct PermissionRequest {
 ///         _ => {}
 ///     }
 /// }
+/// # Ok(())
+/// # }
 /// ```
 #[derive(Debug, Clone)]
 pub enum PromptEvent {
@@ -323,7 +333,14 @@ pub enum PromptStatus {
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```no_run
+/// use iron_core::{Config, IronAgent};
+/// use iron_providers::{ApiFamily, ProviderConnection, ProviderProfile, RuntimeConfig};
+///
+/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// # let provider = ProviderConnection::from_profile(ProviderProfile::new("openai", ApiFamily::Responses, "https://api.openai.com/v1"), RuntimeConfig::new("sk-example"))?;
+/// # let agent = IronAgent::new(Config::default(), provider);
+/// # let session = agent.connect().create_session()?;
 /// let (handle, mut events) = session.prompt_stream("Hello");
 ///
 /// // Later, when an approval request is received...
@@ -331,6 +348,8 @@ pub enum PromptStatus {
 ///
 /// // Or cancel the entire prompt
 /// handle.cancel().await;
+/// # Ok(())
+/// # }
 /// ```
 pub struct PromptHandle {
     approval_resolvers:
@@ -409,7 +428,7 @@ impl std::fmt::Debug for PromptHandle {
     }
 }
 
-/// A stream of prompt events.
+/// Asynchronous event receiver for one streaming prompt.
 ///
 /// Returned by [`AgentSession::prompt_stream`] and
 /// [`AgentSession::prompt_stream_with_blocks`], this struct provides
@@ -418,7 +437,14 @@ impl std::fmt::Debug for PromptHandle {
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```no_run
+/// use iron_core::{Config, IronAgent, PromptEvent};
+/// use iron_providers::{ApiFamily, ProviderConnection, ProviderProfile, RuntimeConfig};
+///
+/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// # let provider = ProviderConnection::from_profile(ProviderProfile::new("openai", ApiFamily::Responses, "https://api.openai.com/v1"), RuntimeConfig::new("sk-example"))?;
+/// # let agent = IronAgent::new(Config::default(), provider);
+/// # let session = agent.connect().create_session()?;
 /// let (handle, mut events) = session.prompt_stream("Hello");
 ///
 /// while let Some(event) = events.next().await {
@@ -428,6 +454,8 @@ impl std::fmt::Debug for PromptHandle {
 ///         _ => {}
 ///     }
 /// }
+/// # Ok(())
+/// # }
 /// ```
 pub struct PromptEvents {
     rx: tokio::sync::mpsc::UnboundedReceiver<PromptEvent>,
@@ -506,7 +534,7 @@ fn default_profile_registry() -> ProfileRegistry {
 // IronAgent
 // ---------------------------------------------------------------------------
 
-/// The main entry point for interacting with an Iron agent.
+/// Top-level owner of the runtime and its profile and stored-prompt registries.
 ///
 /// `IronAgent` is the top-level type for creating and managing agent connections.
 /// It owns the runtime, provider, and tool registry. Use [`IronAgent::connect`]
@@ -514,20 +542,22 @@ fn default_profile_registry() -> ProfileRegistry {
 ///
 /// # Example
 ///
-/// ```ignore
-/// use iron_core::{IronAgent, Config};
+/// ```no_run
+/// use iron_core::{Config, FunctionTool, IronAgent};
 /// use iron_providers::{ApiFamily, ProviderConnection, ProviderProfile, RuntimeConfig};
+/// use serde_json::json;
 ///
 /// let config = Config::default();
 /// let provider = ProviderConnection::from_profile(
 ///     ProviderProfile::new("openai", ApiFamily::Responses, "https://api.openai.com/v1"),
-///     RuntimeConfig::new("sk-..."),
+///     RuntimeConfig::new("sk-example"),
 /// )
 /// .expect("provider config should be valid");
 /// let agent = IronAgent::new(config, provider);
 ///
 /// // Register custom tools
-/// agent.register_tool(my_custom_tool);
+/// let ping = FunctionTool::simple("ping", "Return pong", |_| Ok(json!("pong")));
+/// agent.register_tool(ping);
 ///
 /// // Connect and create a session
 /// let conn = agent.connect();
@@ -1154,12 +1184,15 @@ type SyncPermissionHandler = Rc<RefCell<Option<Box<dyn Fn(&str) -> PermissionVer
 /// Inspectable metadata for a hidden runtime session.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HiddenSessionInfo {
+    /// Identifier of the hidden session.
     pub session_id: SessionId,
+    /// Connection that directly owns the hidden session.
     pub connection_id: ConnectionId,
+    /// Parent session for delegated work, when registered.
     pub parent_session_id: Option<SessionId>,
 }
 
-/// A connection to an Iron agent.
+/// Connection-scoped owner for sessions, events, and permission callbacks.
 ///
 /// Connections are the primary interface for creating and managing sessions.
 /// Each connection has its own event queue and can set up permission handlers
@@ -1174,7 +1207,12 @@ pub struct HiddenSessionInfo {
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```no_run
+/// use iron_core::{Config, IronAgent, PermissionVerdict};
+/// use iron_providers::{ApiFamily, ProviderConnection, ProviderProfile, RuntimeConfig};
+///
+/// # let provider = ProviderConnection::from_profile(ProviderProfile::new("openai", ApiFamily::Responses, "https://api.openai.com/v1"), RuntimeConfig::new("sk-example")).unwrap();
+/// # let agent = IronAgent::new(Config::default(), provider);
 /// let conn = agent.connect();
 ///
 /// // Set up a permission handler
@@ -1787,7 +1825,7 @@ fn convert_notification_to_prompt_event_with_index(
 // AgentSession
 // ---------------------------------------------------------------------------
 
-/// A session for interacting with the agent.
+/// Connection-owned handle to one durable conversation and its active prompt.
 ///
 /// Sessions maintain conversation history and context. Each session is owned
 /// by the connection that created it. Use the session to send prompts and
@@ -1809,7 +1847,14 @@ fn convert_notification_to_prompt_event_with_index(
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```no_run
+/// use iron_core::{Config, ContentBlock, IronAgent, PromptEvent};
+/// use iron_providers::{ApiFamily, ProviderConnection, ProviderProfile, RuntimeConfig};
+///
+/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// # let provider = ProviderConnection::from_profile(ProviderProfile::new("openai", ApiFamily::Responses, "https://api.openai.com/v1"), RuntimeConfig::new("sk-example"))?;
+/// # let agent = IronAgent::new(Config::default(), provider);
+/// # let conn = agent.connect();
 /// let session = conn.create_session().unwrap();
 ///
 /// // Using the streaming API (text-only convenience)
@@ -1823,10 +1868,9 @@ fn convert_notification_to_prompt_event_with_index(
 /// }
 ///
 /// // Using the streaming API (multimodal)
-/// use iron_core::ContentBlock;
 /// let blocks = vec![
 ///     ContentBlock::text("Describe this image:"),
-///     ContentBlock::Image { data: base64_data, mime_type: "image/png".into() },
+///     ContentBlock::Image { data: "base64-data".into(), mime_type: "image/png".into() },
 /// ];
 /// let (handle, mut events) = session.prompt_stream_with_blocks(&blocks);
 /// while let Some(event) = events.next().await {
@@ -1836,6 +1880,8 @@ fn convert_notification_to_prompt_event_with_index(
 ///         _ => {}
 ///     }
 /// }
+/// # Ok(())
+/// # }
 /// ```
 pub struct AgentSession {
     id: SessionId,
@@ -1942,17 +1988,23 @@ impl AgentSession {
     ///
     /// # Example
     ///
-    /// ```ignore
-    /// use iron_core::facade::{IronAgent, AgentSession};
+    /// ```no_run
+    /// use iron_core::{Config, IronAgent};
     /// use iron_core::provider_credential::domain::{ProviderPromptContext, ProviderSlug};
+    /// use iron_providers::{ApiFamily, ProviderConnection, ProviderProfile, RuntimeConfig};
     ///
-    /// let session: AgentSession = /* ... */;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let provider = ProviderConnection::from_profile(ProviderProfile::new("openai", ApiFamily::Responses, "https://api.openai.com/v1"), RuntimeConfig::new("sk-example"))?;
+    /// # let agent = IronAgent::new(Config::default(), provider);
+    /// # let session = agent.connect().create_session()?;
     /// let context = ProviderPromptContext {
     ///     provider_slug: ProviderSlug::new("kimi-code"),
     ///     model: "kimi-for-coding".into(),
     ///     api_key: None,
     /// };
     /// let outcome = session.prompt_managed("Explain closures in Rust", context).await;
+    /// # Ok(())
+    /// # }
     /// ```
     pub async fn prompt_managed(
         &self,
@@ -1981,18 +2033,24 @@ impl AgentSession {
     ///
     /// # Example
     ///
-    /// ```ignore
-    /// use iron_core::facade::{AgentSession, ContentBlock};
+    /// ```no_run
+    /// use iron_core::{Config, ContentBlock, IronAgent};
     /// use iron_core::provider_credential::domain::{ProviderPromptContext, ProviderSlug};
+    /// use iron_providers::{ApiFamily, ProviderConnection, ProviderProfile, RuntimeConfig};
     ///
-    /// let session: AgentSession = /* ... */;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let provider = ProviderConnection::from_profile(ProviderProfile::new("openai", ApiFamily::Responses, "https://api.openai.com/v1"), RuntimeConfig::new("sk-example"))?;
+    /// # let agent = IronAgent::new(Config::default(), provider);
+    /// # let session = agent.connect().create_session()?;
     /// let context = ProviderPromptContext {
     ///     provider_slug: ProviderSlug::new("kimi-code"),
     ///     model: "kimi-for-coding".into(),
     ///     api_key: Some("sk-...".into()),
     /// };
-    /// let blocks = vec![ContentBlock::Text("Describe this image".into())];
+    /// let blocks = vec![ContentBlock::text("Describe this image")];
     /// let outcome = session.prompt_with_blocks_managed(&blocks, context).await;
+    /// # Ok(())
+    /// # }
     /// ```
     pub async fn prompt_with_blocks_managed(
         &self,
@@ -2022,7 +2080,14 @@ impl AgentSession {
     ///
     /// # Example
     ///
-    /// ```ignore
+    /// ```no_run
+    /// use iron_core::{Config, IronAgent, PromptEvent};
+    /// use iron_providers::{ApiFamily, ProviderConnection, ProviderProfile, RuntimeConfig};
+    ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let provider = ProviderConnection::from_profile(ProviderProfile::new("openai", ApiFamily::Responses, "https://api.openai.com/v1"), RuntimeConfig::new("sk-example"))?;
+    /// # let agent = IronAgent::new(Config::default(), provider);
+    /// # let session = agent.connect().create_session()?;
     /// let (handle, mut events) = session.prompt_stream("Hello");
     ///
     /// while let Some(event) = events.next().await {
@@ -2035,6 +2100,8 @@ impl AgentSession {
     ///         _ => {}
     ///     }
     /// }
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn prompt_stream(&self, text: &str) -> (PromptHandle, PromptEvents) {
         let acp_blocks = vec![acp::ContentBlock::Text(acp::TextContent::new(text))];
@@ -2057,13 +2124,18 @@ impl AgentSession {
     ///
     /// # Example
     ///
-    /// ```ignore
-    /// use iron_core::ContentBlock;
+    /// ```no_run
+    /// use iron_core::{Config, ContentBlock, IronAgent, PromptEvent};
+    /// use iron_providers::{ApiFamily, ProviderConnection, ProviderProfile, RuntimeConfig};
     ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let provider = ProviderConnection::from_profile(ProviderProfile::new("openai", ApiFamily::Responses, "https://api.openai.com/v1"), RuntimeConfig::new("sk-example"))?;
+    /// # let agent = IronAgent::new(Config::default(), provider);
+    /// # let session = agent.connect().create_session()?;
     /// let blocks = vec![
     ///     ContentBlock::text("Describe this image:"),
     ///     ContentBlock::Image {
-    ///         data: base64_data,
+    ///         data: "base64-data".into(),
     ///         mime_type: "image/png".into(),
     ///     },
     /// ];
@@ -2076,6 +2148,8 @@ impl AgentSession {
     ///         _ => {}
     ///     }
     /// }
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn prompt_stream_with_blocks(
         &self,
@@ -2158,10 +2232,15 @@ impl AgentSession {
     ///
     /// # Example
     ///
-    /// ```ignore
+    /// ```no_run
+    /// use iron_core::{Config, IronAgent};
     /// use iron_core::provider_credential::domain::{ProviderPromptContext, ProviderSlug};
+    /// use iron_providers::{ApiFamily, ProviderConnection, ProviderProfile, RuntimeConfig};
     ///
-    /// let session: AgentSession = /* ... */;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let provider = ProviderConnection::from_profile(ProviderProfile::new("openai", ApiFamily::Responses, "https://api.openai.com/v1"), RuntimeConfig::new("sk-example"))?;
+    /// # let agent = IronAgent::new(Config::default(), provider);
+    /// # let session = agent.connect().create_session()?;
     /// let context = ProviderPromptContext {
     ///     provider_slug: ProviderSlug::new("kimi-code"),
     ///     model: "kimi-for-coding".into(),
@@ -2171,6 +2250,8 @@ impl AgentSession {
     /// while let Some(event) = events.next().await {
     ///     // handle PromptEvent
     /// }
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn prompt_stream_managed(
         &self,
@@ -2188,18 +2269,24 @@ impl AgentSession {
     ///
     /// # Example
     ///
-    /// ```ignore
-    /// use iron_core::facade::{AgentSession, ContentBlock};
+    /// ```no_run
+    /// use iron_core::{Config, ContentBlock, IronAgent};
     /// use iron_core::provider_credential::domain::{ProviderPromptContext, ProviderSlug};
+    /// use iron_providers::{ApiFamily, ProviderConnection, ProviderProfile, RuntimeConfig};
     ///
-    /// let session: AgentSession = /* ... */;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let provider = ProviderConnection::from_profile(ProviderProfile::new("openai", ApiFamily::Responses, "https://api.openai.com/v1"), RuntimeConfig::new("sk-example"))?;
+    /// # let agent = IronAgent::new(Config::default(), provider);
+    /// # let session = agent.connect().create_session()?;
     /// let context = ProviderPromptContext {
     ///     provider_slug: ProviderSlug::new("kimi-code"),
     ///     model: "kimi-for-coding".into(),
     ///     api_key: None,
     /// };
-    /// let blocks = vec![ContentBlock::Text("Describe this".into())];
+    /// let blocks = vec![ContentBlock::text("Describe this")];
     /// let (handle, mut events) = session.prompt_stream_with_blocks_managed(&blocks, context);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn prompt_stream_with_blocks_managed(
         &self,

--- a/src/headless/mod.rs
+++ b/src/headless/mod.rs
@@ -20,7 +20,25 @@
 //!
 //! WASM plugins are not scanned, registered, or loaded. A profile that
 //! explicitly allow-lists a plugin tool fails preflight with an
-//! [`UnavailableTool`] error.
+//! [`HeadlessBootstrapError::UnavailableTool`] error.
+//!
+//! ```no_run
+//! use iron_core::bootstrap_headless;
+//! use iron_core::config::ConfigStore;
+//! use std::{path::PathBuf, time::Duration};
+//!
+//! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! let store = ConfigStore::open().await?;
+//! let runtime = bootstrap_headless(
+//!     store,
+//!     "daily-review",
+//!     PathBuf::from("/workspace/project"),
+//!     Duration::from_secs(300),
+//! ).await?;
+//! println!("running {} with {}", runtime.resolved.task.id, runtime.model);
+//! # Ok(())
+//! # }
+//! ```
 
 use crate::builtin::BuiltinToolConfig;
 use crate::config::records::{McpServerConfigRecord, RuntimeSettingsSnapshot};
@@ -79,13 +97,28 @@ pub enum HeadlessBootstrapError {
     MissingDefaultProvider,
     /// Provider construction failed after credential resolution.
     #[error("provider initialization failed for '{provider}': {reason}")]
-    ProviderInit { provider: String, reason: String },
+    ProviderInit {
+        /// Provider slug selected by persisted runtime settings.
+        provider: String,
+        /// Provider registry construction failure.
+        reason: String,
+    },
     /// Credential is missing, unreadable, or otherwise unusable.
     #[error("credential failure for provider '{provider}': {reason}")]
-    CredentialFailure { provider: String, reason: String },
+    CredentialFailure {
+        /// Provider slug whose non-interactive credential could not be used.
+        provider: String,
+        /// Credential lookup, decoding, expiry, or storage failure.
+        reason: String,
+    },
     /// Credential exists but requires interactive re-authentication.
     #[error("interactive authentication required for provider '{provider}': {reason}")]
-    InteractiveAuthRequired { provider: String, reason: String },
+    InteractiveAuthRequired {
+        /// Provider slug requiring renewed authentication.
+        provider: String,
+        /// Reason unattended credential recovery cannot continue.
+        reason: String,
+    },
     /// Profile approval or tool policy is unsafe for headless execution.
     #[error("unsafe policy for headless execution: {0}")]
     UnsafePolicy(String),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,6 +204,7 @@ pub mod request_builder;
 pub mod runtime;
 pub mod scheduled_task;
 pub mod schema;
+pub mod secret;
 pub mod skill;
 pub mod stored_prompt;
 pub mod tool;
@@ -261,6 +262,7 @@ pub use profile::{
 };
 pub use prompt_turn::PromptTurn;
 pub use runtime::{ConnectionId, CreateSessionOptions, IronRuntime};
+pub use secret::SecretString;
 pub use stored_prompt::{
     kebab_to_title_case, load_prompts, normalize_prompt_name, IdentityState, PromptLoadDiagnostic,
     PromptLoadIssue, PromptLoadReport, StoredPrompt, StoredPromptEntry, StoredPromptRegistry,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,8 @@
 )]
 //! iron-core: Core AgentIron runtime, ACP-native session management, and tool registry
 //!
-//! This crate provides the ACP-native runtime, session management, tool registration,
-//! and configuration types as described in AGENTS.md.
+//! This crate provides an ACP-native runtime, durable session management, tool
+//! registration, provider integration, and configuration APIs for embedded agents.
 //!
 //! # Quick start
 //!
@@ -18,9 +18,18 @@
 //! `session.prompt_stream(text)` for text-only prompts. Both return the same
 //! `(PromptHandle, PromptEvents)` pair:
 //!
-//! ```ignore
-//! let agent = IronAgent::new(config, provider);
-//! agent.register_tool(my_tool);
+//! ```no_run
+//! use iron_core::{Config, ContentBlock, FunctionTool, IronAgent, PromptEvent};
+//! use iron_providers::{ApiFamily, ProviderConnection, ProviderProfile, RuntimeConfig};
+//! use serde_json::json;
+//!
+//! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! let provider = ProviderConnection::from_profile(
+//!     ProviderProfile::new("openai", ApiFamily::Responses, "https://api.openai.com/v1"),
+//!     RuntimeConfig::new("sk-example"),
+//! )?;
+//! let agent = IronAgent::new(Config::default(), provider);
+//! agent.register_tool(FunctionTool::simple("ping", "Return pong", |_| Ok(json!("pong"))));
 //! let connection = agent.connect();
 //! let session = connection.create_session()?;
 //!
@@ -31,7 +40,7 @@
 //! use iron_core::ContentBlock;
 //! let blocks = vec![
 //!     ContentBlock::text("Describe this image:"),
-//!     ContentBlock::Image { data: img_data, mime_type: "image/png".into() },
+//!     ContentBlock::Image { data: "base64-data".into(), mime_type: "image/png".into() },
 //! ];
 //! let (handle, mut events) = session.prompt_stream_with_blocks(&blocks);
 //!
@@ -45,8 +54,11 @@
 //!         PromptEvent::ToolResult { call_id, status, .. } => { /* show outcome */ }
 //!         PromptEvent::Complete { outcome } => break,
 //!         PromptEvent::Status { message } => { /* advisory */ }
+//!         _ => { /* model switches, compaction, scripts, and auth changes */ }
 //!     }
 //! }
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! `prompt_stream(&str)` is a convenience wrapper that wraps the text as a single
@@ -63,8 +75,8 @@
 //! - [`AgentConnection`] → one ACP client association (wraps [`IronConnection`])
 //! - [`AgentSession`] → session with prompt/cancel/drain_events (wraps durable state)
 //!
-//! The runtime supports in-process (primary), stdio, and TCP transports via the
-//! `transport` module.
+//! The [`transport`] module provides the operational in-process ACP adapter.
+//! Its reserved stdio and TCP entry points currently return compatibility errors.
 //!
 //! # Session Ownership
 //!
@@ -76,8 +88,8 @@
 //!
 //! `Config.context_window_policy` is applied consistently in both ACP-native and
 //! request paths via a shared request builder (`request_builder` module).
-//! Summarization lives under `context_management`; the context-window policy is
-//! limited to `KeepAll` and `KeepRecent`.
+//! Summarization lives under [`context`]; the context-window policy is limited
+//! to `KeepAll` and `KeepRecent`.
 //!
 //! # Context Management
 //!
@@ -143,9 +155,10 @@
 //!   as the corresponding runtime tool registration or substitution.
 //!
 //! - **Transport support:**
-//!   In-process (primary, for embeddings), stdio (subprocess), TCP (cross-process).
-//!   All transports enforce identical session ownership, durable history, permission
-//!   flow, and cancellation semantics.
+//!   The in-process adapter is operational for embeddings. Stdio and TCP entry
+//!   points are reserved but currently return compatibility errors. The shared
+//!   ACP RPC layer defines session ownership, durable history, permission flow,
+//!   and cancellation semantics independently of transport framing.
 //!
 //! - **Conformance testing:**
 //!   Each supported method has at least one transport-independent unit test
@@ -316,6 +329,11 @@ pub use debug::{
     ToolDebugEvent,
 };
 
+/// Commonly used runtime, provider, session, and tool types.
+///
+/// Import this module with `use iron_core::prelude::*` when building a typical
+/// embedded agent integration. Specialized management and extension APIs remain
+/// available through their named modules.
 pub mod prelude {
     pub use crate::{
         AgentConnection, AgentSession, ApprovalStrategy, Config, ConfigSource, ContentBlock,
@@ -325,3 +343,8 @@ pub mod prelude {
         RuntimeResult, SessionId, Tool, ToolDefinition, ToolPolicy, ToolRegistry, Transcript,
     };
 }
+
+#[cfg(doctest)]
+/// Compiles the README's Rust examples as crate documentation tests.
+#[doc = include_str!("../README.md")]
+pub struct ReadmeDoctests;

--- a/src/management/mod.rs
+++ b/src/management/mod.rs
@@ -18,6 +18,21 @@
 //!   `child_sessions`) are not durable scheduled-run history. Historical
 //!   run browsing requires the follow-up capability tracked in #98.
 //! - Interactive stored-prompt preview is deferred to #97.
+//!
+//! ```no_run
+//! use iron_core::ConfigManagementService;
+//! use iron_core::config::ConfigStore;
+//!
+//! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! let store = ConfigStore::open_in_memory().await?;
+//! let service = ConfigManagementService::new(store);
+//! let profiles = service.list_profiles().await?;
+//! for record in profiles {
+//!     println!("{record:?}");
+//! }
+//! # Ok(())
+//! # }
+//! ```
 
 use crate::automation_task::{AutomationTask, AutomationTaskInput};
 use crate::config::{ConfigError, ConfigStore};
@@ -46,41 +61,63 @@ use uuid::Uuid;
 /// Fatal errors from management operations.
 #[derive(Debug, Error)]
 pub enum ManagementError {
+    /// A durable configuration operation failed without a more specific mapping.
     #[error("Storage error: {0}")]
     Storage(ConfigError),
 
+    /// Caller input or a decoded record violated a management invariant.
     #[error("Validation error: {0}")]
     Validation(String),
 
+    /// An operation named a related entity that does not exist or is unusable.
     #[error("Reference error: {0}")]
     Reference(String),
 
+    /// Deletion or identity assignment was blocked by existing referrers.
     #[error("Conflict: {target} is referenced by {referrers:?}")]
     Conflict {
+        /// ID or normalized identity that could not be changed.
         target: String,
+        /// Stable IDs of records causing the conflict.
         referrers: Vec<String>,
     },
 
+    /// Malformed or unsupported rows prevented a safe dependency decision.
     #[error("Cannot verify referential integrity: {details}")]
-    IntegrityUnknown { details: String },
+    IntegrityUnknown {
+        /// Records or queries that made the integrity result indeterminate.
+        details: String,
+    },
 
+    /// Profile deletion would violate the requested valid-profile floor.
     #[error(
         "Cannot delete profile: {remaining} valid profile(s) would remain, below the requested minimum of {minimum}"
     )]
-    MinimumValidProfiles { minimum: usize, remaining: usize },
+    MinimumValidProfiles {
+        /// Minimum number of valid persisted profiles requested by the caller.
+        minimum: usize,
+        /// Number of valid profiles that the deletion would leave.
+        remaining: usize,
+    },
 
+    /// A host-scheduler operation was requested without attaching a scheduler.
     #[error("Scheduler is not attached")]
     SchedulerUnavailable,
 
+    /// The attached host scheduler rejected an operation.
     #[error("Scheduler error: {0}")]
     Scheduler(String),
 
+    /// Durable state changed successfully but a secondary synchronization step failed.
     #[error(
         "Partial operation for '{target}': durable_succeeded={durable_succeeded}, error={error}"
     )]
     Partial {
+        /// Stable ID whose operation completed only partially.
         target: String,
+        /// Whether the durable configuration mutation committed.
         durable_succeeded: bool,
+        /// Failure from registry synchronization or another secondary step.
         error: String,
     },
 }
@@ -148,20 +185,30 @@ impl From<ConfigError> for ManagementError {
 /// Diagnostic category for a single record issue.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DiagnosticCategory {
+    /// The record's schema version is not understood by this binary.
     UnsupportedSchemaVersion,
+    /// Serialized data could not be decoded or violated structural invariants.
     InvalidPayload,
+    /// A record named by an earlier listing disappeared before it was read.
     MissingRecord,
+    /// A referenced profile is absent or unusable.
     UnavailableProfile,
+    /// A referenced skill is unavailable to the selected profile.
     UnavailableSkill,
+    /// A migrated prompt is quarantined until its identity is renamed.
     NeedsRename,
+    /// A legacy approval value is not valid for user-facing profiles.
     ReadOnlyRejected,
+    /// A persisted prompt identity-state discriminator is not recognized.
     UnknownIdentityState,
 }
 
 /// A diagnostic for a single managed record.
 #[derive(Debug, Clone, PartialEq)]
 pub struct RecordDiagnostic {
+    /// Stable category suitable for programmatic handling.
     pub category: DiagnosticCategory,
+    /// Record-specific explanation suitable for display or logs.
     pub message: String,
 }
 
@@ -175,8 +222,11 @@ pub enum ManagedRecord<T> {
     Ready(T),
     /// The record exists but has one or more issues requiring attention.
     NeedsAttention {
+        /// Stable ID of the degraded record.
         id: String,
+        /// Partially usable decoded value, when safe decoding was possible.
         decoded: Option<T>,
+        /// Issues preventing the record from being considered ready.
         diagnostics: Vec<RecordDiagnostic>,
     },
 }
@@ -188,11 +238,31 @@ pub enum ManagedRecord<T> {
 /// A typed entity in the dependency graph.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum DependencyEntity {
-    ProviderCredential { slug: String },
-    Profile { id: String },
-    Prompt { id: String },
-    AutomationTask { id: String },
-    ScheduledTask { id: String },
+    /// Provider credential identified by provider slug.
+    ProviderCredential {
+        /// Provider slug used for credential resolution.
+        slug: String,
+    },
+    /// Agent profile identified by stable record ID.
+    Profile {
+        /// Stable profile ID.
+        id: String,
+    },
+    /// Stored prompt identified by immutable record ID.
+    Prompt {
+        /// Immutable prompt ID.
+        id: String,
+    },
+    /// Automation task identified by stable record ID.
+    AutomationTask {
+        /// Stable automation-task ID.
+        id: String,
+    },
+    /// Desired scheduled task identified by stable record ID.
+    ScheduledTask {
+        /// Stable schedule ID.
+        id: String,
+    },
 }
 
 /// Whether a link points in the dependency or dependent direction.
@@ -207,15 +277,20 @@ pub enum DependencyDirection {
 /// Whether a link is a direct reference or a transitive chain.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum DependencyProximity {
+    /// The target or entity names the other without an intermediate record.
     Direct,
+    /// The relationship passes through one or more intermediate records.
     Transitive,
 }
 
 /// A single link in the dependency graph.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct DependencyLink {
+    /// Entity reached from the report target.
     pub entity: DependencyEntity,
+    /// Whether the reached entity is required by or depends on the target.
     pub direction: DependencyDirection,
+    /// Whether the relationship is immediate or crosses intermediate records.
     pub proximity: DependencyProximity,
     /// Ordered path from the target to this entity.
     pub path: Vec<DependencyEntity>,
@@ -224,7 +299,9 @@ pub struct DependencyLink {
 /// Result of querying the dependency impact of a target entity.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct DependencyImpactReport {
+    /// Entity from which dependency traversal began.
     pub target: DependencyEntity,
+    /// Discovered dependencies and dependents, each with an explicit path.
     pub links: Vec<DependencyLink>,
     /// Warnings about malformed or unsupported records that may have caused
     /// the report to omit dependency paths.
@@ -242,11 +319,15 @@ pub struct DependencyImpactReport {
 /// credential material.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CredentialSummary {
+    /// Provider that owns the persisted credential.
     pub provider_slug: String,
+    /// Recognized persisted mode, or [`CredentialMode::Unsupported`].
     pub credential_mode: CredentialMode,
     /// Persisted-state auth status derived from the credential mode.
     pub auth_status: ProviderAuthStatus,
+    /// Time at which a credential was first stored for this provider.
     pub created_at: DateTime<Utc>,
+    /// Time at which the credential was last replaced or refreshed.
     pub updated_at: DateTime<Utc>,
 }
 
@@ -261,9 +342,13 @@ pub struct CredentialSummary {
 /// see the remaining desired-state drift and any host/diagnostic state.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ScheduleDeletionOutcome {
+    /// Stable ID of the schedule targeted for deletion.
     pub schedule_id: String,
+    /// Whether removal from the host scheduler succeeded.
     pub host_removed: bool,
+    /// Whether deletion of the durable desired-state row succeeded.
     pub desired_deleted: bool,
+    /// Post-failure schedule status when host and desired state diverged.
     pub drift: Option<crate::scheduled_task::ScheduleStatus>,
 }
 
@@ -273,8 +358,17 @@ pub struct ScheduleDeletionOutcome {
 /// AgentProfile>>>` shared with a runtime. The trait is object-safe so the
 /// management service can hold either implementation without generics.
 pub trait ProfileRegistry: Send + Sync {
+    /// Insert or replace a profile after its durable write commits.
+    ///
+    /// Returns a synchronization diagnostic if the registry rejects the value.
     fn insert(&self, id: AgentProfileId, profile: AgentProfile) -> Result<(), String>;
+    /// Remove a profile after its durable deletion commits.
+    ///
+    /// Returns a synchronization diagnostic if the registry cannot remove it.
     fn remove(&self, id: &AgentProfileId) -> Result<(), String>;
+    /// Find another profile that owns `name` after normalization.
+    ///
+    /// `excluding_id` is ignored so an update does not conflict with itself.
     fn find_by_normalized_name(
         &self,
         name: &str,
@@ -317,7 +411,9 @@ impl ProfileRegistry for RwLock<HashMap<AgentProfileId, AgentProfile>> {
 
 /// Fallible registry abstraction for stored-prompt synchronization.
 pub trait PromptRegistry: Send + Sync {
+    /// Validate and insert or replace a prompt after durable persistence.
     fn register(&self, id: String, prompt: StoredPrompt) -> Result<(), String>;
+    /// Remove a prompt after durable deletion.
     fn unregister(&self, id: &str) -> Result<(), String>;
 }
 
@@ -343,6 +439,11 @@ impl PromptRegistry for RwLock<StoredPromptRegistry> {
 /// Constructed from a [`ConfigStore`] with optional attached registries and
 /// scheduler dependencies. Profile, prompt, automation-task, and credential
 /// management remain available when host scheduling is not attached.
+///
+/// Methods map durable failures into [`ManagementError::Storage`] or a more
+/// specific validation, reference, conflict, or integrity variant. Registry
+/// synchronization occurs after durable commits, so a synchronization failure
+/// is reported as [`ManagementError::Partial`] rather than rolled back.
 pub struct ConfigManagementService {
     store: ConfigStore,
     profile_registry: Option<Arc<dyn ProfileRegistry>>,
@@ -383,6 +484,7 @@ impl ConfigManagementService {
     }
 
     #[cfg(test)]
+    /// Attach a type-erased profile registry for management-service tests.
     pub(crate) fn with_profile_registry_for_test(
         mut self,
         registry: Arc<dyn ProfileRegistry>,
@@ -392,6 +494,7 @@ impl ConfigManagementService {
     }
 
     #[cfg(test)]
+    /// Attach a type-erased prompt registry for management-service tests.
     pub(crate) fn with_prompt_registry_for_test(
         mut self,
         registry: Arc<dyn PromptRegistry>,
@@ -2797,9 +2900,13 @@ fn profile_record_error_to_impact_reason(error: crate::profile::ProfileRecordErr
 /// A profile entry with timestamps.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ManagedProfileEntry {
+    /// Stable profile record ID.
     pub id: AgentProfileId,
+    /// Decoded and structurally valid profile.
     pub profile: AgentProfile,
+    /// Time at which the profile row was first inserted.
     pub created_at: DateTime<Utc>,
+    /// Time at which the profile row was last replaced.
     pub updated_at: DateTime<Utc>,
 }
 
@@ -2815,9 +2922,13 @@ pub type ManagedScheduledTaskRecord = ManagedRecord<ScheduledTask>;
 /// A prompt entry with timestamps and identity state.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ManagedPromptEntry {
+    /// Decoded prompt definition.
     pub prompt: StoredPrompt,
+    /// Persisted identity state controlling handle-based availability.
     pub identity_state: IdentityState,
+    /// Time at which the prompt row was first inserted.
     pub created_at: DateTime<Utc>,
+    /// Time at which the prompt row was last replaced or renamed.
     pub updated_at: DateTime<Utc>,
 }
 

--- a/src/mcp/connection.rs
+++ b/src/mcp/connection.rs
@@ -1,3 +1,9 @@
+//! Connection lifecycle and execution routing for configured MCP servers.
+//!
+//! [`McpConnectionManager`] initializes transports, discovers tools, records
+//! health in the shared registry, and optionally retries failed connections
+//! with bounded exponential backoff until shutdown is requested.
+
 use crate::mcp::client::{create_transport_client, McpTransportClient};
 use crate::mcp::server::{McpServerHealth, McpServerRegistry, McpTransport};
 use std::collections::{HashMap, HashSet};
@@ -18,7 +24,9 @@ pub struct McpConnectionManager {
 
 /// Handle to an active MCP connection
 pub struct McpConnectionHandle {
+    /// Registry ID of the connected server.
     pub server_id: String,
+    /// Transport configuration used by this connection.
     pub transport: McpTransport,
     client: Box<dyn McpTransportClient>,
 }
@@ -41,9 +49,13 @@ impl Clone for McpConnectionHandle {
 /// Configuration for reconnection behavior
 #[derive(Debug, Clone)]
 pub struct ReconnectConfig {
+    /// Maximum consecutive automatic reconnect attempts per server.
     pub max_attempts: u32,
+    /// Initial reconnect delay in milliseconds.
     pub base_delay_ms: u64,
+    /// Upper bound for exponential reconnect delay in milliseconds.
     pub max_delay_ms: u64,
+    /// Interval between connection health scans, in seconds.
     pub health_check_interval_secs: u64,
 }
 
@@ -91,7 +103,10 @@ impl McpConnectionManager {
         self.in_flight_connections.write().await.remove(server_id);
     }
 
-    /// Start the connection manager with background health monitoring
+    /// Connects configured servers, then monitors and reconnects until shutdown.
+    ///
+    /// The method returns when the watched value becomes `true` or all shutdown
+    /// senders are dropped. Callers normally run it in a dedicated task.
     pub async fn start(&self, config: ReconnectConfig, mut shutdown_rx: watch::Receiver<bool>) {
         // Connect to all configured servers
         self.connect_all().await;
@@ -186,7 +201,7 @@ impl McpConnectionManager {
         }
     }
 
-    /// Connect to all configured MCP servers
+    /// Connects every configured server except those marked disabled.
     pub async fn connect_all(&self) {
         let servers = self.registry.list_servers();
         for server in servers {
@@ -197,7 +212,11 @@ impl McpConnectionManager {
         }
     }
 
-    /// Connect to a specific MCP server
+    /// Initializes, registers, and discovers tools for one configured server.
+    ///
+    /// Concurrent or redundant attempts for the same server are ignored.
+    /// Construction, initialization, and discovery failures are recorded in
+    /// the registry rather than returned to the caller.
     pub async fn connect_server(&self, server_id: &str) {
         let server = self.registry.get_server(server_id);
         if let Some(server) = server {
@@ -268,7 +287,7 @@ impl McpConnectionManager {
         }
     }
 
-    /// Disconnect from a specific MCP server
+    /// Closes and removes a server connection, returning its health to configured.
     pub async fn disconnect_server(&self, server_id: &str) {
         let mut connections = self.connections.write().await;
         if let Some(handle) = connections.remove(server_id) {
@@ -279,7 +298,7 @@ impl McpConnectionManager {
         }
     }
 
-    /// Check if a server is currently connected and healthy
+    /// Returns whether a live handle reports that the server is connected.
     pub async fn is_connected(&self, server_id: &str) -> bool {
         let connections = self.connections.read().await;
         if let Some(handle) = connections.get(server_id) {
@@ -289,7 +308,7 @@ impl McpConnectionManager {
         }
     }
 
-    /// Reconnect to a server (force disconnect and reconnect)
+    /// Forces a disconnect, clears automatic retry history, and reconnects.
     pub async fn reconnect_server(&self, server_id: &str) {
         info!("Forcing reconnection of MCP server: {}", server_id);
         self.disconnect_server(server_id).await;
@@ -334,7 +353,16 @@ impl McpConnectionManager {
         }
     }
 
-    /// Call a tool on an MCP server
+    /// Executes a server-local tool through an active MCP connection.
+    ///
+    /// Connection-like failures move the server to error health so the monitor
+    /// can reconnect it. Other tool failures are returned without changing
+    /// connection health.
+    ///
+    /// # Errors
+    ///
+    /// Returns an actionable error when the server is unknown, disabled,
+    /// connecting, unavailable, disconnected, or rejects the tool call.
     pub async fn call_tool(
         &self,
         server_id: &str,
@@ -458,7 +486,7 @@ impl McpConnectionManager {
         }
     }
 
-    /// Shutdown all connections
+    /// Closes all active connections and restores their registry health state.
     pub async fn shutdown(&self) {
         let server_ids: Vec<String> = {
             let connections = self.connections.read().await;
@@ -472,7 +500,7 @@ impl McpConnectionManager {
         info!("All MCP connections shutdown");
     }
 
-    /// Get the registry reference
+    /// Returns the shared server registry used by this manager.
     pub fn registry(&self) -> &McpServerRegistry {
         &self.registry
     }

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -2,6 +2,24 @@
 //!
 //! New code should use [`SessionToolCatalog`] for session-effective inspection,
 //! provider request construction, and execution.
+//!
+//! ```
+//! use iron_core::{HttpConfig, McpServerConfig, McpServerRegistry, McpTransport};
+//!
+//! let registry = McpServerRegistry::new();
+//! registry.register_server(McpServerConfig {
+//!     id: "docs".into(),
+//!     label: "Documentation".into(),
+//!     description: Some("Internal documentation search".into()),
+//!     transport: McpTransport::Http {
+//!         config: HttpConfig::new("https://mcp.example.com".into()),
+//!     },
+//!     enabled_by_default: true,
+//!     working_dir: None,
+//!     inherited_env_vars: vec![],
+//! });
+//! assert_eq!(registry.list_servers().len(), 1);
+//! ```
 
 pub mod client;
 pub mod connection;

--- a/src/mcp/protocol.rs
+++ b/src/mcp/protocol.rs
@@ -1,16 +1,27 @@
+//! JSON-RPC wire types used by the MCP transport clients.
+//!
+//! The types in [`messages`] model the initialize, paginated tool discovery,
+//! and tool execution exchanges. Conversion helpers reduce MCP content blocks
+//! to the JSON values and error strings returned by the runtime tool layer.
+
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-/// JSON-RPC 2.0 request
+/// An outbound JSON-RPC 2.0 request.
 #[derive(Debug, Clone, Serialize)]
 pub struct JsonRpcRequest {
+    /// JSON-RPC protocol version, always `"2.0"` for requests built here.
     pub jsonrpc: String,
+    /// MCP method to invoke.
     pub method: String,
+    /// Method-specific parameters.
     pub params: Value,
+    /// Request identifier used to correlate the response.
     pub id: u64,
 }
 
 impl JsonRpcRequest {
+    /// Builds a JSON-RPC 2.0 request with the supplied method, parameters, and ID.
     pub fn new(method: &str, params: Value, id: u64) -> Self {
         Self {
             jsonrpc: "2.0".to_string(),
@@ -21,129 +32,180 @@ impl JsonRpcRequest {
     }
 }
 
-/// JSON-RPC 2.0 response
+/// An inbound JSON-RPC 2.0 response.
 #[derive(Debug, Clone, Deserialize)]
 pub struct JsonRpcResponse {
+    /// JSON-RPC protocol version reported by the server.
     pub jsonrpc: String,
+    /// Successful result payload, when present.
     pub result: Option<Value>,
+    /// Structured RPC error, when the request failed.
     pub error: Option<JsonRpcError>,
+    /// Correlation ID; some servers omit it from bootstrap responses.
     #[serde(default)]
     pub id: Option<u64>,
 }
 
-/// JSON-RPC 2.0 error
+/// A JSON-RPC 2.0 error object returned by an MCP server.
 #[derive(Debug, Clone, Deserialize)]
 pub struct JsonRpcError {
+    /// Numeric JSON-RPC error code.
     pub code: i32,
+    /// Human-readable error message.
     pub message: String,
+    /// Optional server-defined diagnostic payload.
     pub data: Option<Value>,
 }
 
-/// MCP protocol messages
+/// Method-specific MCP request, response, tool, and content types.
 pub mod messages {
     use serde::{Deserialize, Serialize};
     use serde_json::Value;
 
-    /// Initialize request
+    /// Client capabilities sent during MCP connection initialization.
     #[derive(Debug, Serialize)]
     #[serde(rename_all = "camelCase")]
     pub struct InitializeRequest {
+        /// MCP protocol version requested by the client.
         pub protocol_version: String,
+        /// Client capability object.
         pub capabilities: Value,
+        /// Name and version identifying the client implementation.
         pub client_info: ClientInfo,
     }
 
+    /// Name and version identifying an MCP client.
     #[derive(Debug, Serialize)]
     #[serde(rename_all = "camelCase")]
     pub struct ClientInfo {
+        /// Client implementation name.
         pub name: String,
+        /// Client implementation version.
         pub version: String,
     }
 
-    /// Initialize response
+    /// Server capabilities returned after successful initialization.
     #[derive(Debug, Deserialize)]
     #[serde(rename_all = "camelCase")]
     pub struct InitializeResponse {
+        /// MCP protocol version selected by the server.
         pub protocol_version: String,
+        /// Server capability object.
         pub capabilities: Value,
+        /// Name and version identifying the server implementation.
         pub server_info: ServerInfo,
     }
 
+    /// Name and version identifying an MCP server.
     #[derive(Debug, Deserialize)]
     #[serde(rename_all = "camelCase")]
     pub struct ServerInfo {
+        /// Server implementation name.
         pub name: String,
+        /// Server implementation version.
         pub version: String,
     }
 
-    /// Tool list request
+    /// A request for one page of the server's tool catalog.
     #[derive(Debug, Serialize)]
     #[serde(rename_all = "camelCase")]
     pub struct ListToolsRequest {
+        /// Opaque pagination cursor returned by the previous page.
         #[serde(skip_serializing_if = "Option::is_none")]
         pub cursor: Option<String>,
     }
 
-    /// Tool list response
+    /// One page of tools discovered from an MCP server.
     #[derive(Debug, Deserialize)]
     #[serde(rename_all = "camelCase")]
     pub struct ListToolsResponse {
+        /// Tool definitions in this page.
         pub tools: Vec<Tool>,
+        /// Cursor for the next page, or `None` when discovery is complete.
         #[serde(default)]
         pub next_cursor: Option<String>,
     }
 
+    /// A tool definition advertised by an MCP server.
     #[derive(Debug, Deserialize)]
     #[serde(rename_all = "camelCase")]
     pub struct Tool {
+        /// Server-local tool name.
         pub name: String,
+        /// Description presented to the model.
         pub description: String,
+        /// JSON Schema describing accepted arguments.
         pub input_schema: Value,
     }
 
-    /// Tool call request
+    /// A request to execute a named MCP tool.
     #[derive(Debug, Serialize)]
     #[serde(rename_all = "camelCase")]
     pub struct CallToolRequest {
+        /// Server-local name of the tool to invoke.
         pub name: String,
+        /// JSON arguments supplied to the tool.
         pub arguments: Value,
     }
 
-    /// Tool call response
+    /// Content blocks returned by an MCP tool invocation.
     #[derive(Debug, Deserialize)]
     #[serde(rename_all = "camelCase")]
     pub struct CallToolResponse {
+        /// Ordered content emitted by the tool.
         pub content: Vec<ToolContent>,
+        /// Whether the content describes a tool-level failure.
         #[serde(default)]
         pub is_error: bool,
     }
 
+    /// A content block returned by an MCP tool.
     #[derive(Debug, Deserialize)]
     #[serde(tag = "type")]
     pub enum ToolContent {
+        /// Plain text content.
         #[serde(rename = "text")]
-        Text { text: String },
+        Text {
+            /// Text emitted by the tool.
+            text: String,
+        },
+        /// Base64-encoded image content.
         #[serde(rename = "image")]
         Image {
+            /// Base64-encoded image bytes.
             data: String,
+            /// Media type of the encoded image.
             #[serde(rename = "mimeType")]
             mime_type: String,
         },
+        /// Text or binary resource content.
         #[serde(rename = "resource")]
-        Resource { resource: Resource },
+        Resource {
+            /// Resource descriptor returned by the server.
+            resource: Resource,
+        },
     }
 
+    /// Resource content referenced or embedded by a tool response.
     #[derive(Debug, Deserialize)]
     #[serde(rename_all = "camelCase")]
     pub struct Resource {
+        /// URI identifying the resource.
         pub uri: String,
+        /// Optional media type of the resource.
         pub mime_type: Option<String>,
+        /// Optional inline UTF-8 text content.
         pub text: Option<String>,
+        /// Optional inline base64-encoded binary content.
         pub blob: Option<String>,
     }
 }
 
-/// Convert tool content to JSON value
+/// Converts MCP content blocks into the runtime's compact JSON result shape.
+///
+/// A single block becomes `{"result": ...}` and multiple blocks become
+/// `{"results": [...]}`. Images and non-text resources are represented by
+/// descriptive placeholders rather than exposing binary data.
 pub fn tool_content_to_value(content: Vec<messages::ToolContent>) -> Value {
     let mut texts = Vec::new();
     for item in content {
@@ -171,7 +233,10 @@ pub fn tool_content_to_value(content: Vec<messages::ToolContent>) -> Value {
     }
 }
 
-/// Convert tool error content into a useful error string.
+/// Converts MCP error content into a useful error string.
+///
+/// Text blocks are joined with newlines; if no textual representation is
+/// available, the normalized JSON value is serialized instead.
 pub fn tool_error_to_string(content: Vec<messages::ToolContent>) -> String {
     let value = tool_content_to_value(content);
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1,3 +1,9 @@
+//! MCP server configuration, discovered tool metadata, and runtime health state.
+//!
+//! [`McpServerRegistry`] is the shared state boundary between configuration,
+//! connection management, session catalogs, and diagnostics. Its mutation
+//! version lets consumers invalidate snapshots when health or tools change.
+
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -31,17 +37,22 @@ impl HttpConfig {
 pub enum McpTransport {
     /// Local stdio transport (spawns subprocess)
     Stdio {
+        /// Executable used to start the MCP server process.
         command: String,
+        /// Command-line arguments passed to the server process.
         args: Vec<String>,
+        /// Explicit environment entries applied after sanitized inheritance.
         env: HashMap<String, String>,
     },
     /// Remote HTTP transport
     Http {
+        /// Endpoint and headers for request/response HTTP transport.
         #[serde(flatten)]
         config: HttpConfig,
     },
     /// Remote HTTP with SSE transport
     HttpSse {
+        /// Endpoint and headers for HTTP POST plus server-sent events transport.
         #[serde(flatten)]
         config: HttpConfig,
     },
@@ -72,7 +83,9 @@ impl McpServerHealth {
 /// Metadata about a discovered MCP tool
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct McpToolInfo {
+    /// Server-local tool name.
     pub name: String,
+    /// Description presented to models and diagnostics.
     pub description: String,
     /// JSON schema for the tool's input
     pub input_schema: serde_json::Value,
@@ -105,7 +118,9 @@ pub struct McpServerConfig {
 /// Runtime state for a configured MCP server
 #[derive(Debug, Clone)]
 pub struct McpServerState {
+    /// Immutable connection configuration for the server.
     pub config: McpServerConfig,
+    /// Current connection lifecycle state.
     pub health: McpServerHealth,
     /// Discovered tools from this server, if connected
     pub discovered_tools: Vec<McpToolInfo>,
@@ -114,6 +129,7 @@ pub struct McpServerState {
 }
 
 impl McpServerState {
+    /// Creates configured, disconnected state with no discovered tools or error.
     pub fn new(config: McpServerConfig) -> Self {
         Self {
             config,
@@ -132,6 +148,7 @@ pub struct McpServerRegistry {
 }
 
 impl McpServerRegistry {
+    /// Creates an empty registry with mutation version zero.
     pub fn new() -> Self {
         Self {
             servers: Arc::new(RwLock::new(HashMap::new())),

--- a/src/mcp/session_catalog.rs
+++ b/src/mcp/session_catalog.rs
@@ -1,3 +1,10 @@
+//! Canonical, session-effective catalog of local, MCP, and plugin tools.
+//!
+//! Construction snapshots session enablement, runtime health, authentication,
+//! model-hidden tools, and profile filters. The same catalog supplies provider
+//! definitions, approval policy, diagnostics, and execution routing so model
+//! visibility cannot diverge from runtime availability checks.
+
 use crate::durable::DurableSession;
 use crate::mcp::server::{McpServerHealth, McpServerRegistry};
 use crate::mcp::McpConnectionManager;
@@ -55,11 +62,17 @@ pub struct SessionToolCatalog {
 /// Summary of an MCP server's status for a session.
 #[derive(Debug)]
 pub struct McpServerSummary {
+    /// Stable server ID used in namespaced tool names.
     pub id: String,
+    /// Human-readable configured server label.
     pub label: String,
+    /// Whether the server is enabled for this session.
     pub enabled: bool,
+    /// Current runtime connection health.
     pub health: McpServerHealth,
+    /// Whether session enablement and connection health both permit use.
     pub usable: bool,
+    /// Number of discovered tools usable by this session.
     pub tool_count: usize,
 }
 
@@ -148,7 +161,12 @@ impl SessionToolCatalog {
             .max_by_key(|(plugin_id, _)| plugin_id.len())
     }
 
-    /// Create a new session tool catalog for the given session.
+    /// Builds a snapshot of all tools visible and executable in a session.
+    ///
+    /// Local tools are included first, followed by tools from enabled connected
+    /// MCP servers and enabled healthy plugins whose auth requirements are met.
+    /// Model-hidden tools and the session's effective profile filter are then
+    /// applied to both definitions and execution handles.
     pub fn new(
         local_registry: Arc<ToolRegistry>,
         mcp_registry: Arc<McpServerRegistry>,
@@ -1047,9 +1065,15 @@ pub enum ToolSource {
     /// A tool registered directly in the local tool registry.
     Local,
     /// A tool provided by an MCP server.
-    Mcp { server_id: String },
+    Mcp {
+        /// Registry ID of the server that advertises the tool.
+        server_id: String,
+    },
     /// A tool provided by a WASM plugin.
-    Plugin { plugin_id: String },
+    Plugin {
+        /// Registry ID of the plugin that exports the tool.
+        plugin_id: String,
+    },
 }
 
 /// Diagnostic information about a tool's availability in the session.

--- a/src/plugin/auth.rs
+++ b/src/plugin/auth.rs
@@ -1,3 +1,9 @@
+//! Runtime-owned plugin authentication vocabulary and client interaction types.
+//!
+//! Plugins declare OAuth requirements, while the runtime owns state transitions,
+//! credential bindings, prompts, and interaction messages. Credentials are not
+//! passed directly to plugin code.
+
 use serde::{Deserialize, Serialize};
 
 /// OAuth authentication requirements declared by a plugin
@@ -21,11 +27,17 @@ pub struct OAuthRequirements {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum OAuthProvider {
+    /// Google OAuth services.
     Google,
+    /// GitHub OAuth services.
     GitHub,
+    /// Slack OAuth services.
     Slack,
+    /// Discord OAuth services.
     Discord,
+    /// Microsoft OAuth services.
     Microsoft,
+    /// A provider identified by plugin-supplied endpoint metadata.
     Custom,
 }
 

--- a/src/plugin/config.rs
+++ b/src/plugin/config.rs
@@ -1,3 +1,9 @@
+//! Plugin installation sources and artifact integrity verification.
+//!
+//! Local artifacts are read directly by the lifecycle manager. Remote artifacts
+//! carry a required cryptographic checksum that is verified before caching,
+//! manifest extraction, or WASM loading.
+
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
@@ -50,7 +56,12 @@ pub enum ChecksumAlgorithm {
 }
 
 impl Checksum {
-    /// Verify that the given bytes match this checksum
+    /// Verifies that bytes match the configured digest, ignoring hex case.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ChecksumError::Mismatch`] with both expected and computed
+    /// hex digests when verification fails.
     pub fn verify(&self, data: &[u8]) -> Result<(), ChecksumError> {
         match self.algorithm {
             ChecksumAlgorithm::Sha256 => {
@@ -87,7 +98,12 @@ impl Checksum {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ChecksumError {
     /// Checksum does not match the computed hash
-    Mismatch { expected: String, computed: String },
+    Mismatch {
+        /// Hex digest supplied by the plugin configuration.
+        expected: String,
+        /// Hex digest computed from the artifact bytes.
+        computed: String,
+    },
 }
 
 impl std::fmt::Display for ChecksumError {

--- a/src/plugin/effective_tools.rs
+++ b/src/plugin/effective_tools.rs
@@ -1,3 +1,9 @@
+//! Session-effective plugin tool availability, definitions, and execution wrappers.
+//!
+//! [`compute_tool_availability`] is the canonical health, authentication, and
+//! OAuth-scope gate. [`EffectivePluginToolView`] combines that result with
+//! session enablement, while [`PluginTool`] routes approved calls to the WASM host.
+
 use crate::durable::DurableSession;
 use crate::plugin::manifest::{ExportedTool, ToolAuthRequirements};
 use crate::plugin::registry::{PluginRegistry, PluginState};
@@ -19,6 +25,11 @@ pub struct PluginTool {
 }
 
 impl PluginTool {
+    /// Creates a namespaced plugin tool definition without an attached WASM host.
+    ///
+    /// The provider-visible name is `plugin_{plugin_id}_{tool_name}` and the
+    /// approval flag is copied from the manifest. Attach a host with
+    /// [`PluginTool::with_wasm_host`] before using the tool for execution.
     pub fn new(
         plugin_id: String,
         tool_name: String,
@@ -42,24 +53,29 @@ impl PluginTool {
         }
     }
 
+    /// Records whether this tool is gated by plugin authentication metadata.
     pub fn with_auth_requirement(mut self, requires_auth: bool) -> Self {
         self.requires_auth = requires_auth;
         self
     }
 
+    /// Attaches the WASM host used when the tool executes.
     pub fn with_wasm_host(mut self, host: Arc<WasmHost>) -> Self {
         self.wasm_host = Some(host);
         self
     }
 
+    /// Returns the registry ID of the exporting plugin.
     pub fn plugin_id(&self) -> &str {
         &self.plugin_id
     }
 
+    /// Returns the plugin-local tool name before runtime namespacing.
     pub fn original_tool_name(&self) -> &str {
         &self.tool_name
     }
 
+    /// Returns whether the manifest declares authentication for this tool.
     pub fn requires_auth(&self) -> bool {
         self.requires_auth
     }
@@ -119,7 +135,9 @@ pub enum UnavailableReason {
     AuthRequired,
     /// Tool requires specific scopes that are not covered by the granted credentials.
     ScopeMissing {
+        /// Complete set of OAuth scopes required by the tool.
         required: Vec<String>,
+        /// Required scopes absent from the current credential binding.
         missing: Vec<String>,
     },
     /// MCP server is not enabled for the current session.
@@ -135,7 +153,9 @@ pub enum UnavailableReason {
 /// Result of canonical per-tool availability computation.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ToolAvailabilityResult {
+    /// Whether health and authentication permit execution now.
     pub available: bool,
+    /// First canonical reason for unavailability, or `None` when available.
     pub reason: Option<UnavailableReason>,
 }
 
@@ -230,6 +250,7 @@ pub struct EffectivePluginToolView {
 }
 
 impl EffectivePluginToolView {
+    /// Creates a view backed by the shared plugin registry and WASM host.
     pub fn new(plugin_registry: Arc<PluginRegistry>, wasm_host: Arc<WasmHost>) -> Self {
         Self {
             plugin_registry,
@@ -402,18 +423,26 @@ impl EffectivePluginToolView {
 /// Summary of plugin tool availability for a session
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct SessionPluginToolSummary {
+    /// Status entry for every plugin registered with the runtime.
     pub plugins: Vec<PluginToolSummary>,
 }
 
 /// Summary for a single plugin
 #[derive(Debug, Serialize, Deserialize)]
 pub struct PluginToolSummary {
+    /// Stable plugin registry ID.
     pub id: String,
+    /// Whether the plugin is enabled in the session.
     pub enabled: bool,
+    /// Whether runtime health is [`PluginHealth::Healthy`].
     pub healthy: bool,
+    /// Whether enablement and health permit considering its tools.
     pub usable: bool,
+    /// Number of tools whose health, auth, and scope gates are satisfied.
     pub tool_count: usize,
+    /// Whether the plugin manifest declares OAuth requirements.
     pub requires_auth: bool,
+    /// Whether the runtime currently holds authenticated state for the plugin.
     pub authenticated: bool,
 }
 

--- a/src/plugin/lifecycle.rs
+++ b/src/plugin/lifecycle.rs
@@ -37,7 +37,12 @@ pub enum InstallResult {
     /// Plugin was installed and loaded successfully.
     Success,
     /// Remote download completed but the computed checksum did not match.
-    InvalidChecksum { expected: String, computed: String },
+    InvalidChecksum {
+        /// Hex digest declared by the plugin configuration.
+        expected: String,
+        /// Hex digest computed from the downloaded artifact.
+        computed: String,
+    },
     /// A remote source was provided without a required checksum.
     MissingChecksum,
     /// Network or filesystem failure while fetching the artifact.
@@ -51,7 +56,9 @@ pub enum InstallResult {
     LoadFailed(String),
     /// Manifest identity does not match the runtime plugin configuration.
     IdentityMismatch {
+        /// Plugin ID requested by runtime configuration.
         config_id: String,
+        /// Plugin ID embedded in the artifact manifest.
         manifest_id: String,
     },
 }
@@ -187,6 +194,9 @@ impl PluginLifecycle {
     ///
     /// Re-installs are idempotent: the old artifact is replaced and the
     /// manifest/auth state is cleared before the new artifact is processed.
+    ///
+    /// Failures leave the registered plugin in error health with loaded state
+    /// cleared and remove any newly cached artifact.
     pub async fn install_with_loader(
         &self,
         config: PluginConfig,
@@ -333,6 +343,9 @@ impl PluginLifecycle {
     }
 
     /// Uninstall a plugin, delegating the WASM-host unload to `loader`.
+    ///
+    /// Cached-file removal is best effort. The registry entry is removed even
+    /// if the artifact has already disappeared or cannot be deleted.
     pub async fn uninstall_with_loader(
         &self,
         plugin_id: &str,

--- a/src/plugin/manifest.rs
+++ b/src/plugin/manifest.rs
@@ -1,3 +1,9 @@
+//! Validated manifest model embedded in plugin WASM artifacts.
+//!
+//! Manifests identify publishers, presentation data, network policy, auth
+//! requirements, exported tools, and resource limits. The lifecycle validates
+//! this untrusted metadata before registering tools or loading executable code.
+
 use crate::plugin::auth::OAuthRequirements;
 use crate::plugin::network::NetworkPolicy;
 use serde::{Deserialize, Serialize};
@@ -101,7 +107,12 @@ pub struct ToolAuthRequirements {
 }
 
 impl PluginManifest {
-    /// Validate the manifest structure
+    /// Validates required identity and presentation fields, API version, and tool names.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`ManifestValidationError`] for an empty required field, an
+    /// API version other than `1.0`, or duplicate plugin-local tool names.
     pub fn validate(&self) -> Result<(), ManifestValidationError> {
         // Validate identity
         if self.identity.id.is_empty() {
@@ -161,8 +172,11 @@ impl PluginManifest {
 /// Errors that can occur during manifest validation
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ManifestValidationError {
+    /// A required manifest field was empty; contains its dotted field name.
     MissingField(String),
+    /// The manifest requested an unsupported plugin API version.
     UnsupportedApiVersion(String),
+    /// Two exported tools used the same plugin-local name.
     DuplicateToolName(String),
 }
 

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -11,6 +11,18 @@
 //! validation → WASM host load.  The pipeline is parameterised over a
 //! `PluginLoader` trait so the lifecycle state machine can be tested
 //! independently of Extism.
+//!
+//! ```
+//! use iron_core::{PluginSource, PluginSourceConfig};
+//! use std::path::PathBuf;
+//!
+//! let plugin = PluginSourceConfig {
+//!     id: "com.example.calendar".into(),
+//!     source: PluginSource::LocalPath { path: PathBuf::from("calendar.wasm") },
+//!     enabled_by_default: false,
+//! };
+//! assert_eq!(plugin.id, "com.example.calendar");
+//! ```
 
 pub mod auth;
 pub mod config;

--- a/src/plugin/network.rs
+++ b/src/plugin/network.rs
@@ -1,3 +1,8 @@
+//! Declarative outbound network policy for WASM plugins.
+//!
+//! Policies match exact domains and their subdomains. The default is an empty
+//! allowlist, which grants no network access; wildcard access must be explicit.
+
 use serde::{Deserialize, Serialize};
 
 /// Network access policy declared by a plugin
@@ -13,7 +18,10 @@ pub enum NetworkPolicy {
 }
 
 impl NetworkPolicy {
-    /// Check if a domain is allowed by this policy
+    /// Returns whether a domain is allowed by this policy.
+    ///
+    /// Allowlist and blocklist entries match both the exact domain and any
+    /// subdomain ending in `.{entry}`.
     pub fn allows(&self, domain: &str) -> bool {
         match self {
             Self::Allowlist(domains) => {
@@ -31,7 +39,7 @@ impl NetworkPolicy {
         }
     }
 
-    /// Get a summary description of the policy
+    /// Returns a concise human-readable summary of the policy's breadth.
     pub fn summary(&self) -> String {
         match self {
             Self::Allowlist(domains) => {

--- a/src/plugin/registry.rs
+++ b/src/plugin/registry.rs
@@ -1,3 +1,10 @@
+//! Shared runtime inventory, health, authentication, and availability for plugins.
+//!
+//! [`PluginRegistry`] stores lifecycle state independently from per-session
+//! enablement. Registry mutations increment a version for catalog invalidation;
+//! availability snapshots consistently apply plugin health, auth state, and
+//! granted OAuth scopes.
+
 use crate::plugin::auth::{
     AuthActionHint, AuthAvailability, AuthPrompt, AuthState, CredentialBinding,
 };
@@ -16,9 +23,12 @@ use std::sync::{
 };
 use tracing::{info, warn};
 
-/// Stable identifier for a plugin
+/// Stable identifier for a plugin.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct PluginId(pub String);
+pub struct PluginId(
+    /// String form used as the registry key and tool namespace component.
+    pub String,
+);
 
 impl std::fmt::Display for PluginId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -99,6 +109,7 @@ pub struct PluginState {
 }
 
 impl PluginState {
+    /// Creates configured runtime state with no loaded artifact, manifest, or credentials.
     pub fn new(config: PluginConfig) -> Self {
         // Runtime health starts as Configured regardless of session-level
         // enablement defaults.  Session enablement is a separate concern
@@ -217,6 +228,7 @@ pub struct PluginRegistry {
 }
 
 impl PluginRegistry {
+    /// Creates an empty plugin registry with mutation version zero.
     pub fn new() -> Self {
         Self {
             plugins: Arc::new(RwLock::new(HashMap::new())),
@@ -430,7 +442,12 @@ impl PluginRegistry {
         }
     }
 
-    /// Start authentication flow
+    /// Transitions an eligible plugin into the authenticating state.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the plugin is unknown, already authenticating,
+    /// or already authenticated.
     pub fn start_authentication(&self, plugin_id: &str) -> Result<(), String> {
         let mut plugins = self.plugins.write();
         if let Some(state) = plugins.get_mut(plugin_id) {

--- a/src/plugin/rich_output.rs
+++ b/src/plugin/rich_output.rs
@@ -1,96 +1,149 @@
+//! Normalized transcript and constrained rich-view output from plugin tools.
+//!
+//! Plain string results become transcript-only envelopes. JSON objects are
+//! interpreted as rich output only when they explicitly use the
+//! `plugin_tool_result` kind, preserving arbitrary legacy JSON unchanged.
+//! Rich payloads are limited to typed todo, status, and progress views; unknown
+//! fields and executable presentation content are rejected during normalization.
+
 use crate::plugin::wasm_host::{WasmError, WasmResult};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 const NORMALIZED_RESULT_KIND: &str = "plugin_tool_result";
 
+/// Canonical result shape returned by normalized plugin tool execution.
+///
+/// The transcript is suitable for model history, while the optional view is a
+/// constrained client-rendered projection. Runtime metadata identifies the
+/// source and cannot be supplied by the plugin.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct PluginToolResultEnvelope {
+    /// Envelope discriminator, always `"plugin_tool_result"` after normalization.
     pub kind: String,
+    /// Text persisted in the model-visible transcript.
     pub transcript: PluginToolTranscript,
+    /// Optional structured view for a supporting client.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub view: Option<PluginToolView>,
+    /// Runtime-injected provenance for this result.
     pub metadata: PluginToolResultMetadata,
 }
 
+/// Model-visible text associated with a plugin tool result.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct PluginToolTranscript {
+    /// Non-empty text to append to the conversation transcript.
     pub text: String,
 }
 
+/// A constrained, client-rendered projection of plugin output.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct PluginToolView {
+    /// Stable logical view ID used to correlate updates.
     pub id: String,
+    /// How the client should combine this view with prior output.
     pub mode: PluginToolViewMode,
+    /// Typed presentation payload rendered by the client.
     pub payload: PluginToolViewPayload,
 }
 
+/// Update behavior for a rich plugin view.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum PluginToolViewMode {
+    /// Replace the prior view with the same logical ID.
     Replace,
+    /// Append this view to existing output.
     Append,
+    /// Display the view temporarily rather than retaining it as durable output.
     Transient,
 }
 
+/// Supported safe presentation payloads for plugin rich output.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum PluginToolViewPayload {
+    /// A checklist-style collection of todo items.
     TodoList(TodoListView),
+    /// A textual status callout.
     Status(StatusView),
+    /// Fractional progress for an ongoing operation.
     Progress(ProgressView),
 }
 
+/// A checklist view containing one or more todo items.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct TodoListView {
+    /// Optional heading displayed above the list.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
+    /// Non-empty list of todo items.
     pub items: Vec<TodoListItem>,
 }
 
+/// One item in a [`TodoListView`].
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct TodoListItem {
+    /// Non-empty stable item ID used to correlate updates.
     pub id: String,
+    /// Non-empty user-facing item text.
     pub label: String,
+    /// Whether the item is complete.
     pub done: bool,
 }
 
+/// A textual status view with optional severity and title.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct StatusView {
+    /// Non-empty status message.
     pub text: String,
+    /// Optional semantic level used for client styling.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub level: Option<StatusLevel>,
+    /// Optional heading displayed with the status.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
 }
 
+/// Semantic level of a plugin status view.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum StatusLevel {
+    /// Neutral informational status.
     Info,
+    /// Successful completion or healthy status.
     Success,
+    /// Warning that may require attention.
     Warning,
+    /// Failed or unhealthy status.
     Error,
 }
 
+/// Fractional progress view for an ongoing operation.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProgressView {
+    /// Optional description of the operation being measured.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
+    /// Completion fraction in the inclusive range `0.0..=1.0`.
     pub value: f64,
 }
 
+/// Runtime-injected provenance for a normalized plugin tool result.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct PluginToolResultMetadata {
+    /// Registry ID of the plugin that produced the result.
     pub plugin_id: String,
+    /// Plugin-local name of the executed tool.
     pub tool_name: String,
 }
 
@@ -106,6 +159,18 @@ struct PluginToolResultInput {
     metadata: Option<Value>,
 }
 
+/// Normalizes and validates a raw result from a plugin tool.
+///
+/// String values become transcript-only envelopes. Objects explicitly tagged
+/// `plugin_tool_result` are parsed with unknown fields denied, validated, and
+/// rewritten with runtime-owned metadata. Other JSON values pass through
+/// unchanged.
+///
+/// # Errors
+///
+/// Returns [`WasmError::ExecutionFailed`] when a declared rich envelope is
+/// malformed, has an unsupported kind, contains empty required text or IDs,
+/// has an empty todo list, or reports progress outside `0.0..=1.0`.
 pub fn normalize_plugin_tool_result(
     plugin_id: &str,
     tool_name: &str,
@@ -143,6 +208,9 @@ pub fn normalize_plugin_tool_result(
     normalized_value(plugin_id, tool_name, input.transcript, input.view)
 }
 
+/// Returns transcript text from a normalized result envelope.
+///
+/// Returns `None` for plain JSON, malformed envelopes, or a different kind.
 pub fn transcript_text(result: &Value) -> Option<&str> {
     result
         .get("kind")
@@ -153,6 +221,10 @@ pub fn transcript_text(result: &Value) -> Option<&str> {
         .and_then(Value::as_str)
 }
 
+/// Returns the raw structured view from a normalized result envelope.
+///
+/// Returns `None` when no view is present or the value is not a normalized
+/// `plugin_tool_result` envelope.
 pub fn view(result: &Value) -> Option<&Value> {
     result
         .get("kind")

--- a/src/plugin/status.rs
+++ b/src/plugin/status.rs
@@ -1,3 +1,9 @@
+//! Client-facing plugin health, aggregate status, and per-tool availability.
+//!
+//! Health describes runtime loading independently of session enablement.
+//! [`PluginRuntimeStatus`] combines health with canonical tool availability so
+//! clients can render ready, partial, auth-blocked, and failed states.
+
 use crate::plugin::auth::{AuthAvailability, AuthState};
 use crate::plugin::effective_tools::UnavailableReason;
 use crate::plugin::manifest::ExportedTool;
@@ -194,7 +200,7 @@ impl PluginStatus {
         }
     }
 
-    /// Generate a user-facing status message
+    /// Generates a concise user-facing message for an aggregate runtime status.
     pub fn generate_status_message(
         runtime_status: PluginRuntimeStatus,
         plugin_name: &str,

--- a/src/profile/mod.rs
+++ b/src/profile/mod.rs
@@ -5,6 +5,25 @@
 //! prompt layer. They intentionally do not store credential secret material;
 //! managed provider credentials are resolved from `iron-core`'s credential
 //! state at execution time.
+//!
+//! ```
+//! use iron_core::{AgentApproval, AgentProfile, AgentProfileProvider, SkillFilter, ToolFilter};
+//! use iron_core::provider_credential::ProviderSlug;
+//!
+//! let profile = AgentProfile {
+//!     name: "code-review".into(),
+//!     provider: AgentProfileProvider::Managed {
+//!         provider_slug: ProviderSlug::new("openai"),
+//!         model: "gpt-4.1".into(),
+//!     },
+//!     tools: ToolFilter::Allow(vec!["read".into(), "search".into()]),
+//!     skills: SkillFilter::Allow(vec!["code-review".into()]),
+//!     approval: AgentApproval::PerTool,
+//!     identity_prompt: Some("Review changes for correctness and risk.".into()),
+//! };
+//!
+//! assert_eq!(profile.effective_identity_prompt(), "Review changes for correctness and risk.");
+//! ```
 
 use crate::provider_credential::domain::{ProviderPromptContext, ProviderSlug};
 use iron_providers::Provider;
@@ -19,7 +38,10 @@ pub const PROFILE_SCHEMA_VERSION: i64 = 1;
 /// For durable profiles, the `ConfigStore` profile record ID is the stable
 /// profile ID. The user-facing display name lives inside [`AgentProfile::name`].
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct AgentProfileId(pub String);
+pub struct AgentProfileId(
+    /// Opaque durable identifier stored as the profile row's primary key.
+    pub String,
+);
 
 impl AgentProfileId {
     /// Borrow the underlying ID string.
@@ -266,7 +288,9 @@ pub enum ResolvedProfileProvider {
     /// provider/model reference was unavailable or credential resolution
     /// failed. The diagnostic explains why the fallback occurred.
     Fallback {
+        /// Runtime-default provider used in place of the unavailable selection.
         provider: Arc<dyn Provider>,
+        /// Human-readable reason managed resolution could not be completed.
         diagnostic: String,
     },
 }
@@ -307,7 +331,10 @@ impl ResolvedProfileProvider {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ProfileLoadIssue {
     /// The stored profile schema version is not supported.
-    UnsupportedSchemaVersion { version: i64 },
+    UnsupportedSchemaVersion {
+        /// Unsupported version read from the profile row.
+        version: i64,
+    },
     /// The stored payload could not be decoded as an `AgentProfile`.
     InvalidPayload,
     /// The profile ID is invalid or reserved.
@@ -569,7 +596,9 @@ pub enum DefaultProfileSeedDiagnostic {
     SkippedFirstRunDone(AgentProfileId),
     /// Storage failure for this profile.
     StorageFailure {
+        /// Shipped profile that could not be persisted.
         profile_id: AgentProfileId,
+        /// Human-readable storage failure.
         reason: String,
     },
 }
@@ -614,6 +643,12 @@ impl DefaultProfileSeedReport {
 ///
 /// Returns a structured report describing created, skipped, and diagnostic
 /// outcomes for each shipped default.
+///
+/// # Errors
+///
+/// Returns a configuration-store error if marker reads, profile serialization
+/// or insertion, or durable marker persistence fails. Existing profile rows are
+/// never overwritten.
 pub async fn seed_default_profiles(
     store: &crate::config::ConfigStore,
     policy: DefaultProfileSeedPolicy,

--- a/src/prompt/assembly.rs
+++ b/src/prompt/assembly.rs
@@ -1,8 +1,16 @@
+//! Legacy linear prompt assembly and repository-instruction rendering.
+
 use crate::prompt::config::RepoInstructionPayload;
 
+/// Assembles instruction sources into provider-ready text.
 pub struct PromptAssembler;
 
 impl PromptAssembler {
+    /// Concatenates non-empty instruction sources in argument order.
+    ///
+    /// The order is baseline, repository instructions, additional inline
+    /// blocks, session instructions, skill instructions, and runtime context.
+    /// Adjacent sources are separated by two newlines.
     pub fn assemble(
         baseline: &str,
         repo_payload: &RepoInstructionPayload,
@@ -48,6 +56,10 @@ impl PromptAssembler {
         parts.join("\n\n")
     }
 
+    /// Renders repository and additional instruction files with source paths.
+    ///
+    /// Sources retain their payload order. Returns an empty string when the
+    /// payload contains no files.
     pub fn render_repo_instructions(payload: &RepoInstructionPayload) -> String {
         if payload.sources.is_empty() && payload.additional_files.is_empty() {
             return String::new();

--- a/src/prompt/baseline.rs
+++ b/src/prompt/baseline.rs
@@ -1,3 +1,6 @@
+//! Core-owned baseline instructions included in composed system prompts.
+
+/// Default behavioral instructions supplied to the core-guidelines prompt section.
 pub const BASELINE_PROMPT: &str = r##"<baseline_instructions>
 You are a tool-using agent. Execute tasks by choosing tools and interpreting their results.
 Follow instructions from the user, from repository instruction files, and from session-level instructions.

--- a/src/prompt/config.rs
+++ b/src/prompt/config.rs
@@ -1,15 +1,22 @@
+//! Configuration and data types for composing system prompts.
+
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
+/// Selects repository instruction filenames and their precedence.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum RepoInstructionFamily {
+    /// Prefer `AGENTS.md`, falling back to `CLAUDE.md` in each scope.
     #[default]
     PreferAgentsFallbackClaude,
+    /// Load only `AGENTS.md` files.
     AgentsOnly,
+    /// Load only `CLAUDE.md` files.
     ClaudeOnly,
 }
 
 impl RepoInstructionFamily {
+    /// Returns candidate filenames in lookup precedence order.
     pub fn candidates(&self) -> &[&str] {
         match self {
             Self::PreferAgentsFallbackClaude => &["AGENTS.md", "CLAUDE.md"],
@@ -19,10 +26,14 @@ impl RepoInstructionFamily {
     }
 }
 
+/// Controls discovery of repository instruction files.
 #[derive(Debug, Clone, PartialEq)]
 pub struct RepoInstructionConfig {
+    /// Whether repository instruction discovery is enabled.
     pub enabled: bool,
+    /// Filename family and precedence used within each scope.
     pub family: RepoInstructionFamily,
+    /// Directories searched in order for instruction files.
     pub scopes: Vec<PathBuf>,
 }
 
@@ -37,34 +48,46 @@ impl Default for RepoInstructionConfig {
 }
 
 impl RepoInstructionConfig {
+    /// Creates the default enabled repository instruction configuration.
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Sets whether repository instruction discovery is enabled.
     pub fn with_enabled(mut self, enabled: bool) -> Self {
         self.enabled = enabled;
         self
     }
 
+    /// Sets the repository instruction filename family.
     pub fn with_family(mut self, family: RepoInstructionFamily) -> Self {
         self.family = family;
         self
     }
 
+    /// Replaces the ordered directories searched for instructions.
     pub fn with_scopes(mut self, scopes: Vec<PathBuf>) -> Self {
         self.scopes = scopes;
         self
     }
 }
 
+/// Controls all non-conversational text composed into the system prompt.
 #[derive(Debug, Clone, PartialEq)]
 pub struct PromptCompositionConfig {
+    /// Repository instruction discovery settings.
     pub repo_instructions: RepoInstructionConfig,
+    /// Explicit files appended after discovered repository instructions.
     pub additional_files: Vec<PathBuf>,
+    /// Inline instruction blocks rendered in their stored order.
     pub additional_inline: Vec<String>,
+    /// Resource names or paths the rendered prompt marks as protected.
     pub protected_resources: Vec<String>,
+    /// Manual provider guidance used when registry guidance is unavailable.
     pub provider_guidance: Option<String>,
+    /// Client override for the editing-guidelines section.
     pub client_editing_guidance: Option<String>,
+    /// Client-owned fragments rendered in the client-injection section.
     pub client_injections: Vec<ClientPromptFragment>,
 }
 
@@ -88,53 +111,65 @@ impl Default for PromptCompositionConfig {
 }
 
 impl PromptCompositionConfig {
+    /// Creates the default prompt-composition configuration.
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Replaces repository instruction discovery settings.
     pub fn with_repo_instructions(mut self, config: RepoInstructionConfig) -> Self {
         self.repo_instructions = config;
         self
     }
 
+    /// Replaces the explicit additional instruction files.
     pub fn with_additional_files(mut self, files: Vec<PathBuf>) -> Self {
         self.additional_files = files;
         self
     }
 
+    /// Replaces inline instruction blocks, preserving the supplied order.
     pub fn with_additional_inline(mut self, blocks: Vec<String>) -> Self {
         self.additional_inline = blocks;
         self
     }
 
+    /// Replaces the protected-resource labels rendered into runtime context.
     pub fn with_protected_resources(mut self, resources: Vec<String>) -> Self {
         self.protected_resources = resources;
         self
     }
 
+    /// Sets fallback provider-specific guidance.
     pub fn with_provider_guidance<S: Into<String>>(mut self, guidance: S) -> Self {
         self.provider_guidance = Some(guidance.into());
         self
     }
 
+    /// Sets the client-owned editing guidance section.
     pub fn with_client_editing_guidance<S: Into<String>>(mut self, guidance: S) -> Self {
         self.client_editing_guidance = Some(guidance.into());
         self
     }
 
+    /// Replaces client prompt fragments, preserving the supplied order.
     pub fn with_client_injections(mut self, fragments: Vec<ClientPromptFragment>) -> Self {
         self.client_injections = fragments;
         self
     }
 }
 
+/// A client-owned Markdown fragment injected into the system prompt.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ClientPromptFragment {
+    /// Optional heading rendered before the fragment body.
     pub title: Option<String>,
+    /// Markdown body rendered verbatim when non-empty.
     pub markdown: String,
 }
 
 impl ClientPromptFragment {
+    /// Creates an untitled fragment from Markdown text.
     pub fn new<S: Into<String>>(markdown: S) -> Self {
         Self {
             title: None,
@@ -142,6 +177,7 @@ impl ClientPromptFragment {
         }
     }
 
+    /// Creates a fragment with a heading and Markdown body.
     pub fn titled<T: Into<String>, M: Into<String>>(title: T, markdown: M) -> Self {
         Self {
             title: Some(title.into()),
@@ -150,21 +186,31 @@ impl ClientPromptFragment {
     }
 }
 
+/// A discovered repository instruction file and its loaded contents.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RepoInstructionSource {
+    /// Directory in which the instruction file was discovered.
     pub scope: PathBuf,
+    /// Discovered filename, such as `AGENTS.md`.
     pub filename: String,
+    /// UTF-8 file contents.
     pub content: String,
 }
 
+/// An explicitly configured instruction file and its loaded contents.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct AdditionalInstructionFile {
+    /// Configured file path.
     pub path: PathBuf,
+    /// UTF-8 file contents.
     pub content: String,
 }
 
+/// Loaded repository and additional instruction material.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct RepoInstructionPayload {
+    /// Discovered repository files in scope order.
     pub sources: Vec<RepoInstructionSource>,
+    /// Explicitly loaded files in configuration order.
     pub additional_files: Vec<AdditionalInstructionFile>,
 }

--- a/src/prompt/mod.rs
+++ b/src/prompt/mod.rs
@@ -1,3 +1,9 @@
+//! System-prompt composition, repository instruction loading, and runtime-context rendering.
+//!
+//! Prompt material is assembled in the stable order defined by
+//! [`PROMPT_SECTION_ORDER`]. Repository and client-provided text is treated as
+//! prompt content; loading it does not grant additional runtime capabilities.
+
 pub mod assembly;
 pub mod baseline;
 pub mod config;

--- a/src/prompt/repo_loader.rs
+++ b/src/prompt/repo_loader.rs
@@ -1,3 +1,5 @@
+//! Filesystem loading for repository-level prompt instructions.
+
 use std::path::{Path, PathBuf};
 
 use crate::error::RuntimeError;
@@ -6,9 +8,20 @@ use crate::prompt::config::{
     RepoInstructionPayload, RepoInstructionSource,
 };
 
+/// Resolves configured repository instruction files into prompt payloads.
 pub struct RepoInstructionLoader;
 
 impl RepoInstructionLoader {
+    /// Loads at most one preferred instruction file from each configured scope.
+    ///
+    /// Scopes are processed in configuration order. Missing files and unreadable
+    /// preferred files are skipped, and a disabled configuration returns an
+    /// empty payload.
+    ///
+    /// # Errors
+    ///
+    /// The current resolver performs best-effort reads and does not return an
+    /// error, but the result remains fallible for API consistency.
     pub fn resolve(config: &RepoInstructionConfig) -> Result<RepoInstructionPayload, RuntimeError> {
         if !config.enabled {
             return Ok(RepoInstructionPayload::default());
@@ -27,6 +40,14 @@ impl RepoInstructionLoader {
         })
     }
 
+    /// Appends explicitly configured instruction files to an existing payload.
+    ///
+    /// Files are read and appended in slice order. If a read fails, previously
+    /// appended files remain in `payload` and later files are not attempted.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RuntimeError`] when a file cannot be read as UTF-8 text.
     pub fn load_additional_files(
         payload: &mut RepoInstructionPayload,
         files: &[PathBuf],

--- a/src/prompt/runtime_context.rs
+++ b/src/prompt/runtime_context.rs
@@ -1,9 +1,17 @@
+//! Rendering of dynamic, non-conversational runtime context.
+
 use crate::capability::CapabilityRegistry;
 use crate::config::{ApprovalStrategy, Config, EmbeddedPythonConfig};
 
+/// Produces the `<runtime_context>` block supplied to the model.
 pub struct RuntimeContextRenderer;
 
 impl RuntimeContextRenderer {
+    /// Renders platform, workspace, approval, protection, and capability facts.
+    ///
+    /// Workspace roots and capabilities preserve their input iteration order.
+    /// Embedded-Python guidance is included only when both configuration and
+    /// effective tool availability enable it.
     pub fn render(
         config: &Config,
         capabilities: Option<&CapabilityRegistry>,

--- a/src/prompt/system.rs
+++ b/src/prompt/system.rs
@@ -1,40 +1,66 @@
+//! Stable section model, cache, fingerprint, and renderer for system prompts.
+
 use crate::prompt::{ClientPromptFragment, RepoInstructionPayload};
 
+/// A section in the canonical system-prompt layout.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PromptSection {
+    /// Agent identity and role.
     Identity,
+    /// Dynamic runtime and workspace facts.
     StaticContext,
+    /// Core behavioral baseline.
     CoreGuidelines,
+    /// Tool-use and context-management guidance.
     ToolPhilosophy,
+    /// Editing policy supplied by the client or core default.
     EditingGuidelines,
+    /// Safety and protected-resource constraints.
     Safety,
+    /// Guidance specific to the selected provider.
     ProviderSpecificGuidance,
+    /// Response style and formatting guidance.
     CommunicationFormatting,
+    /// Repository, session, skill, and client-owned instructions.
     ClientInjection,
 }
 
+/// Authority responsible for a prompt section's contents.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PromptSectionOwner {
+    /// Content controlled by `iron-core`.
     Core,
+    /// Content selected from provider metadata.
     Provider,
+    /// Content supplied through client configuration or session state.
     Client,
 }
 
+/// Expected change frequency of a prompt section.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PromptSectionTemperature {
+    /// Content expected to remain stable across most requests.
     Cold,
+    /// Content that changes occasionally with configuration or environment.
     Warm,
+    /// Content that may change from turn to turn.
     Hot,
 }
 
+/// Descriptive metadata for one canonical prompt section.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PromptSectionMetadata {
+    /// Section represented by this metadata.
     pub section: PromptSection,
+    /// Human-readable heading rendered for the section.
     pub title: &'static str,
+    /// Authority that controls the section.
     pub owner: PromptSectionOwner,
+    /// Expected change frequency used by diagnostics and caching policy.
     pub temperature: PromptSectionTemperature,
 }
 
+/// Canonical rendering order for all system-prompt sections.
 pub const PROMPT_SECTION_ORDER: [PromptSection; 9] = [
     PromptSection::Identity,
     PromptSection::StaticContext,
@@ -48,6 +74,7 @@ pub const PROMPT_SECTION_ORDER: [PromptSection; 9] = [
 ];
 
 impl PromptSection {
+    /// Returns the title, owner, and temperature assigned to this section.
     pub fn metadata(self) -> PromptSectionMetadata {
         match self {
             PromptSection::Identity => PromptSectionMetadata {
@@ -108,25 +135,46 @@ impl PromptSection {
     }
 }
 
+/// Borrowed inputs required to render a complete system prompt.
+///
+/// Optional empty textual inputs use their section-specific fallback where one
+/// exists. Client injection collections retain their input order.
 pub struct SystemPromptInputs<'a> {
+    /// Core baseline inserted into the core-guidelines section.
     pub baseline: &'a str,
+    /// Pre-rendered `<runtime_context>` block.
     pub runtime_context: &'a str,
+    /// Loaded repository and additional instruction files.
     pub repo_payload: &'a RepoInstructionPayload,
+    /// Additional inline instruction blocks in rendering order.
     pub additional_inline: &'a [String],
+    /// Optional profile-specific replacement for the default identity.
     pub profile_identity: Option<&'a str>,
+    /// Optional session-level instructions.
     pub session_instructions: Option<&'a str>,
+    /// Optional instructions from active skills.
     pub skill_instructions: Option<&'a str>,
+    /// Optional provider-specific guidance.
     pub provider_guidance: Option<&'a str>,
+    /// Optional replacement for the default editing guidance.
     pub client_editing_guidance: Option<&'a str>,
+    /// Client-owned Markdown fragments in rendering order.
     pub client_injections: &'a [ClientPromptFragment],
+    /// Whether `python_exec` is present in the effective tool catalog.
     pub python_exec_available: bool,
+    /// Current context pressure used to select tool-use guidance.
     pub context_pressure: crate::context::ContextPressure,
 }
 
+/// Deterministic, opaque cache key derived from all system-prompt inputs.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SystemPromptFingerprint(String);
 
 impl SystemPromptFingerprint {
+    /// Computes a length-delimited fingerprint from every rendering input.
+    ///
+    /// The fingerprint is intended for equality checks, not cryptographic use
+    /// or stable persistence across crate versions.
     pub fn from_inputs(inputs: &SystemPromptInputs<'_>) -> Self {
         let mut value = String::new();
         push_part(&mut value, inputs.baseline);
@@ -155,6 +203,7 @@ impl SystemPromptFingerprint {
     }
 }
 
+/// Memoizes the most recently rendered system prompt.
 #[derive(Debug, Default, Clone)]
 pub struct SystemPromptCache {
     rendered: Option<String>,
@@ -162,6 +211,8 @@ pub struct SystemPromptCache {
 }
 
 impl SystemPromptCache {
+    /// Returns a prompt rendered from `inputs`, reusing the cached allocation
+    /// when the complete input fingerprint is unchanged.
     pub fn render(&mut self, inputs: &SystemPromptInputs<'_>) -> &str {
         let fingerprint = SystemPromptFingerprint::from_inputs(inputs);
         if self.fingerprint.as_ref() != Some(&fingerprint) {
@@ -172,27 +223,33 @@ impl SystemPromptCache {
         self.rendered.as_deref().unwrap_or_default()
     }
 
+    /// Invalidates the cached prompt after working-directory context changes.
     pub fn invalidate_working_directory(&mut self) {
         self.invalidate();
     }
 
+    /// Invalidates the cached prompt after provider guidance changes.
     pub fn invalidate_provider_guidance(&mut self) {
         self.invalidate();
     }
 
+    /// Invalidates the cached prompt after effective tool availability changes.
     pub fn invalidate_tool_availability(&mut self) {
         self.invalidate();
     }
 
+    /// Clears the cached rendering and fingerprint unconditionally.
     pub fn invalidate(&mut self) {
         self.rendered = None;
         self.fingerprint = None;
     }
 }
 
+/// Stateless renderer for the canonical, numbered system-prompt layout.
 pub struct SystemPromptRenderer;
 
 impl SystemPromptRenderer {
+    /// Renders every section in [`PROMPT_SECTION_ORDER`], separated by blank lines.
     pub fn render(inputs: &SystemPromptInputs<'_>) -> String {
         PROMPT_SECTION_ORDER
             .iter()
@@ -239,6 +296,7 @@ impl SystemPromptRenderer {
     }
 }
 
+/// Core identity text used when no non-empty profile identity is supplied.
 pub(crate) const DEFAULT_RENDERED_IDENTITY: &str = "You are an AI coding agent powered by iron-core. Follow the core-owned instructions in this prompt and preserve the authority boundaries between core, provider, and client sections.";
 
 fn render_identity() -> String {

--- a/src/prompt_lifecycle.rs
+++ b/src/prompt_lifecycle.rs
@@ -1,68 +1,117 @@
+//! Provider- and tool-runner lifecycle events delivered to prompt frontends.
+
 use crate::connection::{notification, SharedClientChannel};
 use agent_client_protocol::schema::v1 as acp;
 use std::pin::Pin;
 
+/// A semantic event emitted while a prompt is running.
+///
+/// Output and tool events are emitted in execution order. A proposed tool call
+/// precedes its updates, and compaction starts before it finishes or fails.
 pub enum PromptLifecycleEvent {
+    /// Incremental model or transcript-safe tool output.
     Output {
+        /// Text chunk to append to client-visible output.
         text: String,
     },
+    /// A provider proposed a tool call that has not yet completed.
     ToolCallProposed {
+        /// Provider-assigned tool call identifier.
         call_id: String,
+        /// Requested tool name.
         tool_name: String,
+        /// Requested JSON arguments.
         arguments: serde_json::Value,
     },
+    /// A tool call changed execution state.
     ToolCallUpdate {
+        /// Provider-assigned tool call identifier.
         call_id: String,
+        /// Tool name, or an empty string when unavailable.
         tool_name: String,
+        /// New execution status.
         status: ToolUpdateStatus,
+        /// Optional result or structured error payload.
         output: Option<serde_json::Value>,
     },
+    /// An embedded script or one of its child calls changed state.
     ScriptActivity {
+        /// Runtime-assigned script identifier.
         script_id: String,
+        /// Tool call that launched the script.
         parent_call_id: String,
+        /// Machine-readable activity type.
         activity_type: String,
+        /// Machine-readable activity status.
         status: String,
+        /// Optional activity-specific data.
         detail: Option<serde_json::Value>,
     },
+    /// Context compaction began.
     CompactionStarted {
+        /// Correlation identifier for the compaction operation.
         compaction_id: String,
+        /// Compaction strategy name.
         method: String,
     },
+    /// Context compaction completed successfully.
     CompactionFinished {
+        /// Correlation identifier from the start event.
         compaction_id: String,
+        /// Estimated token count before compaction, when known.
         tokens_before: Option<u32>,
+        /// Estimated token count after compaction, when known.
         tokens_after: Option<u32>,
+        /// Compaction strategy used.
         method: String,
     },
+    /// Context compaction failed.
     CompactionFailed {
+        /// Correlation identifier from the start event.
         compaction_id: String,
+        /// Human-readable failure reason.
         reason: String,
     },
 }
 
+/// Client-visible execution state for a tool call.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ToolUpdateStatus {
+    /// Execution has started but is not terminal.
     InProgress,
+    /// Execution completed successfully.
     Completed,
+    /// Execution failed, was denied, or was cancelled.
     Failed,
 }
 
+/// Information presented to a prompt sink for a tool-approval decision.
 pub struct ApprovalRequest {
+    /// Provider-assigned tool call identifier.
     pub call_id: String,
+    /// Requested tool name.
     pub tool_name: String,
+    /// Requested JSON arguments.
     pub arguments: serde_json::Value,
 }
 
+/// Decision returned by a prompt sink for one permission request.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ApprovalVerdict {
+    /// Permit this invocation once.
     AllowOnce,
+    /// Deny this invocation while allowing the prompt loop to continue.
     Denied,
+    /// Cancel the prompt and remaining tool calls.
     Cancelled,
 }
 
+/// Receives ordered prompt events and resolves tool-approval requests.
 pub trait PromptSink {
+    /// Emits one lifecycle event and resolves after the sink processes it.
     fn emit(&self, event: PromptLifecycleEvent) -> Pin<Box<dyn std::future::Future<Output = ()>>>;
 
+    /// Requests an approval verdict for a proposed tool call.
     fn request_approval(
         &self,
         request: ApprovalRequest,
@@ -81,12 +130,14 @@ pub trait PromptSink {
     }
 }
 
+/// Adapts prompt lifecycle events to ACP notifications and permission requests.
 pub(crate) struct AcpPromptSink {
     session_id: acp::SessionId,
     client: SharedClientChannel,
 }
 
 impl AcpPromptSink {
+    /// Creates a sink routing events to `client` under `session_id`.
     pub(crate) fn new(session_id: acp::SessionId, client: SharedClientChannel) -> Self {
         Self { session_id, client }
     }

--- a/src/prompt_runner.rs
+++ b/src/prompt_runner.rs
@@ -1,3 +1,5 @@
+//! Prompt inference loop, permission flow, tool execution, and turn cleanup.
+
 use crate::config::Config;
 use crate::connection::SharedClientChannel;
 use crate::delegation::{
@@ -68,6 +70,7 @@ fn tie_off_cancelled(durable: &Arc<Mutex<DurableSession>>) {
     }
 }
 
+/// Executes provider iterations and tool calls for one admitted prompt.
 pub(crate) struct PromptRunner {
     runtime: IronRuntime,
     managed_provider: Option<Box<dyn Provider>>,
@@ -78,6 +81,7 @@ pub(crate) struct PromptRunner {
 }
 
 impl PromptRunner {
+    /// Creates a runner that uses the runtime's default provider.
     pub(crate) fn new(runtime: IronRuntime) -> Self {
         Self {
             runtime,
@@ -88,6 +92,10 @@ impl PromptRunner {
         }
     }
 
+    /// Creates a runner bound to an explicitly resolved managed provider.
+    ///
+    /// `context` is retained so an OAuth-backed authentication failure can
+    /// force one credential refresh and retry.
     pub(crate) fn new_managed(
         runtime: IronRuntime,
         provider: Box<dyn Provider>,
@@ -103,6 +111,7 @@ impl PromptRunner {
     }
 
     #[cfg(test)]
+    /// Creates a managed runner with a deterministic retry provider for tests.
     pub(crate) fn new_managed_with_retry_provider_for_test(
         runtime: IronRuntime,
         provider: Box<dyn Provider>,
@@ -146,6 +155,14 @@ impl PromptRunner {
         self.runtime.force_refresh_managed_provider(context).await
     }
 
+    /// Runs provider and tool iterations until a terminal ACP stop reason.
+    ///
+    /// Each iteration builds a request from a durable snapshot, streams output
+    /// before executing proposed tools, resolves approvals in proposal order,
+    /// and executes approved calls sequentially. Cancellation ties off every
+    /// running tool record before returning. Request and provider failures are
+    /// persisted as agent text and terminate with `EndTurn`; exceeding
+    /// `max_iterations` returns `MaxTurnRequests`.
     pub(crate) async fn run(
         &self,
         durable: &Arc<Mutex<DurableSession>>,
@@ -2475,6 +2492,10 @@ impl PromptRunner {
         .await;
     }
 
+    /// Emits a durable and client-visible warning when post-turn pressure is critical.
+    ///
+    /// This check runs only when context management is enabled. Notification
+    /// delivery is best effort and occurs after the warning is persisted.
     pub(crate) async fn maybe_compact_post_turn(
         &self,
         durable: &Arc<Mutex<DurableSession>>,

--- a/src/prompt_turn.rs
+++ b/src/prompt_turn.rs
@@ -1,3 +1,5 @@
+//! Standalone handle for observing and cancelling ephemeral prompt-turn state.
+
 use crate::{
     durable::SessionId,
     ephemeral::{EphemeralTurn, SharedEphemeralTurn, TurnPhase},
@@ -6,13 +8,20 @@ use crate::{
 };
 use std::sync::Arc;
 
+/// A locally observable prompt turn associated with one durable session.
+///
+/// This type owns ephemeral phase and cancellation state. Constructing it does
+/// not register the turn as the runtime's active prompt; runtime-managed prompt
+/// admission is performed by [`IronRuntime::try_start_prompt`].
 pub struct PromptTurn {
+    /// Durable session associated with the turn.
     pub session_id: SessionId,
     ephemeral: SharedEphemeralTurn,
     _runtime: IronRuntime,
 }
 
 impl PromptTurn {
+    /// Creates a pending turn for `session_id` backed by `runtime`.
     pub fn new(session_id: SessionId, runtime: IronRuntime) -> Self {
         let ephemeral = Arc::new(tokio::sync::Mutex::new(EphemeralTurn::new(
             session_id, None,
@@ -24,22 +33,34 @@ impl PromptTurn {
         }
     }
 
+    /// Returns the durable session associated with this turn.
     pub fn session_id(&self) -> SessionId {
         self.session_id
     }
 
+    /// Returns a snapshot of the turn's current phase.
     pub async fn phase(&self) -> TurnPhase {
         self.ephemeral.lock().await.phase
     }
 
+    /// Returns whether the turn has reached a terminal phase.
     pub async fn is_terminal(&self) -> bool {
         self.ephemeral.lock().await.is_terminal()
     }
 
+    /// Returns a shared handle to the turn's ephemeral state.
     pub fn ephemeral(&self) -> SharedEphemeralTurn {
         self.ephemeral.clone()
     }
 
+    /// Requests cancellation unless the turn is already terminal.
+    ///
+    /// Repeated cancellation and cancellation after termination are no-ops.
+    ///
+    /// # Errors
+    ///
+    /// The current implementation is infallible; the result preserves the
+    /// cancellation API's fallible contract.
     pub async fn cancel(&self) -> Result<(), RuntimeError> {
         let mut turn = self.ephemeral.lock().await;
         if turn.is_terminal() {

--- a/src/provider_credential/domain.rs
+++ b/src/provider_credential/domain.rs
@@ -11,7 +11,10 @@ use std::time::SystemTime;
 ///
 /// Examples: `"kimi-code"`, `"codex"`, `"openai"`.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct ProviderSlug(pub String);
+pub struct ProviderSlug(
+    /// Canonical provider identifier used by profiles, stores, and registries.
+    pub String,
+);
 
 impl ProviderSlug {
     /// Create a new provider slug.
@@ -94,13 +97,19 @@ pub enum ProviderAuthStatus {
     /// An API key is configured.
     ConfiguredApiKey,
     /// OAuth is connected with a known expiry.
-    ConnectedOAuth { expires_at: Option<SystemTime> },
-    /// OAuth refresh is in progress.
+    ConnectedOAuth {
+        /// Known access-token expiry, or `None` when the provider omitted it.
+        expires_at: Option<SystemTime>,
+    },
+    /// OAuth refresh is due because the token is expired or nearing expiry.
     Refreshing,
     /// OAuth access token has expired.
     Expired,
     /// OAuth refresh failed with a reason.
-    RefreshFailed { reason: String },
+    RefreshFailed {
+        /// Sanitized reason the most recent refresh attempt failed.
+        reason: String,
+    },
     /// OAuth credential was revoked.
     Revoked,
     /// The configured credential mode is not supported by the provider.
@@ -117,7 +126,9 @@ pub enum ProviderAuthError {
     /// The provider does not support the configured credential mode.
     #[error("Provider '{provider}' does not support credential mode {mode:?}")]
     UnsupportedCredential {
+        /// Provider whose capability does not include the stored mode.
         provider: String,
+        /// Credential mode rejected by the provider profile.
         mode: CredentialMode,
     },
 
@@ -127,7 +138,12 @@ pub enum ProviderAuthError {
 
     /// OAuth token refresh failed.
     #[error("OAuth refresh failed for provider '{provider}': {reason}")]
-    RefreshFailed { provider: String, reason: String },
+    RefreshFailed {
+        /// Provider whose OAuth token could not be refreshed.
+        provider: String,
+        /// Network, protocol, or response-validation failure.
+        reason: String,
+    },
 
     /// The OAuth credential was revoked.
     #[error("OAuth credential revoked for provider '{0}'")]
@@ -135,7 +151,12 @@ pub enum ProviderAuthError {
 
     /// A durable credential store operation failed.
     #[error("Credential store error for provider '{provider}': {reason}")]
-    StoreError { provider: String, reason: String },
+    StoreError {
+        /// Provider whose credential operation failed.
+        provider: String,
+        /// Durable storage, key-source, serialization, or encryption failure.
+        reason: String,
+    },
 }
 
 /// Result type for provider credential operations.

--- a/src/provider_credential/durable_store.rs
+++ b/src/provider_credential/durable_store.rs
@@ -1,10 +1,21 @@
+//! Durable provider credential persistence over [`crate::config::ConfigStore`].
+//!
+//! Credential bodies are serialized and delegated to the configuration store,
+//! which encrypts them at rest. [`FallibleCredentialStore`] preserves storage,
+//! key-source, serialization, and decryption failures for callers that need to
+//! distinguish them from an absent credential.
+
 use crate::config::{ConfigError, ConfigStore};
 use crate::provider_credential::domain::{ProviderSlug, StoredCredential};
 use crate::provider_credential::store::ProviderCredentialStore;
 use async_trait::async_trait;
 use tracing::warn;
 
-/// A durable provider credential store backed by ConfigStore.
+/// A durable provider credential store backed by [`ConfigStore`].
+///
+/// Its [`ProviderCredentialStore`] implementation logs and suppresses durable
+/// errors for compatibility. Use [`FallibleCredentialStore`] when errors must
+/// be surfaced to the caller.
 pub struct DurableCredentialStore {
     store: ConfigStore,
 }
@@ -107,9 +118,13 @@ pub trait FallibleCredentialStore: Send + Sync {
 /// Credential metadata without secret material.
 #[derive(Debug, Clone)]
 pub struct CredentialMetadata {
+    /// Provider slug that owns the credential row.
     pub provider_slug: String,
+    /// Persisted credential-mode discriminator; secret material is omitted.
     pub credential_mode: String,
+    /// Time at which a credential was first stored for this provider.
     pub created_at: chrono::DateTime<chrono::Utc>,
+    /// Time at which the credential was last replaced or refreshed.
     pub updated_at: chrono::DateTime<chrono::Utc>,
 }
 

--- a/src/provider_credential/mod.rs
+++ b/src/provider_credential/mod.rs
@@ -36,6 +36,20 @@
 //!
 //! The module is additive: existing injected-provider paths in `IronAgent` and
 //! `IronRuntime` continue to work without using any of these types.
+//!
+//! ```
+//! use iron_core::provider_credential::{
+//!     CredentialMode, InMemoryCredentialStore, StoredCredential,
+//! };
+//! use std::collections::HashMap;
+//!
+//! let credentials = HashMap::from([
+//!     ("openai".into(), StoredCredential::ApiKey("sk-example".into())),
+//! ]);
+//! let store = InMemoryCredentialStore::from_map(credentials);
+//! let snapshot = store.snapshot();
+//! assert_eq!(snapshot["openai"].mode(), CredentialMode::ApiKey);
+//! ```
 
 pub mod domain;
 pub mod durable_store;

--- a/src/provider_credential/oauth.rs
+++ b/src/provider_credential/oauth.rs
@@ -108,10 +108,6 @@ pub struct DeviceCodeInteraction {
     pub interval_secs: u64,
 }
 
-/// Start a device-code authorization flow.
-///
-/// Calls the provider's device authorization endpoint and returns the
-/// interaction data the client should present to the user.
 fn encode_form(params: &[(&str, &str)]) -> String {
     let mut encoded = url::form_urlencoded::Serializer::new(String::new());
     for (k, v) in params {
@@ -139,6 +135,16 @@ fn refresh_response_error(
     }
 }
 
+/// Start the provider-specific device authorization flow.
+///
+/// Calls the configured device authorization endpoint and returns opaque
+/// polling state plus interaction data that is safe to present to the user.
+///
+/// # Errors
+///
+/// Returns [`ProviderAuthError::RefreshFailed`] for request failures,
+/// unsuccessful responses, malformed response bodies, or missing required
+/// device-auth fields.
 pub async fn start_device_code_flow(
     metadata: &OAuthProviderMetadata,
     client: &reqwest::Client,
@@ -299,6 +305,12 @@ pub struct DeviceCodeStartResult {
 ///
 /// This should be called repeatedly (respecting `interval_secs`) until it
 /// returns either tokens or a terminal error.
+///
+/// # Errors
+///
+/// Pending authorization and polling throttles are represented as
+/// [`ProviderAuthError::RefreshFailed`] with an actionable reason, as are
+/// network, protocol, decoding, denial, and expiry failures.
 pub async fn poll_token_exchange(
     metadata: &OAuthProviderMetadata,
     device_code: &str,
@@ -513,6 +525,12 @@ async fn exchange_codex_authorization_code(
 }
 
 /// Refresh an OAuth access token using a refresh token.
+///
+/// # Errors
+///
+/// Returns [`ProviderAuthError::Revoked`] for revoked or invalid grants and
+/// [`ProviderAuthError::RefreshFailed`] for transport, response-status,
+/// decoding, or missing-token failures.
 pub async fn refresh_access_token(
     metadata: &OAuthProviderMetadata,
     refresh_token: &str,

--- a/src/provider_credential/resolver.rs
+++ b/src/provider_credential/resolver.rs
@@ -25,7 +25,9 @@ pub const REFRESH_MARGIN: Duration = Duration::from_secs(5 * 60);
 /// Supported credential modes for a provider.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct CredentialSupport {
+    /// Whether the provider accepts API-key credentials.
     pub api_key: bool,
+    /// Whether the provider accepts OAuth bearer credentials.
     pub oauth_bearer: bool,
 }
 
@@ -179,6 +181,12 @@ impl CredentialResolver {
     /// Otherwise, the credential store is queried for an OAuth credential.
     /// If found and the provider supports OAuth, the token is refreshed if
     /// expired or within `REFRESH_MARGIN` of expiry.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProviderAuthError::NotConfigured`] when no credential exists,
+    /// [`ProviderAuthError::UnsupportedCredential`] when the selected mode is
+    /// not supported, or refresh/store errors from the OAuth lifecycle.
     pub async fn resolve(
         &self,
         context: &ProviderPromptContext,
@@ -398,6 +406,12 @@ impl CredentialResolver {
     ///
     /// This is used after a provider auth failure to obtain a fresh token
     /// before retrying the request.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when no credential is configured, an API key is not
+    /// supported, OAuth refresh fails, or the durable store cannot be read or
+    /// updated. API keys are returned without a network request.
     pub async fn force_refresh(
         &self,
         slug: &ProviderSlug,

--- a/src/provider_profile/mod.rs
+++ b/src/provider_profile/mod.rs
@@ -4,6 +4,21 @@
 //! effective registry construction for provider profiles. Built-in provider
 //! profiles remain compiled into `iron-providers`; persisted rows in the config
 //! store represent only custom profiles and explicit overrides.
+//!
+//! ```
+//! use iron_core::provider_profile::validate_provider_profile;
+//! use iron_providers::{ApiFamily, ProviderProfile};
+//!
+//! let profile = ProviderProfile::new(
+//!     "internal-openai",
+//!     ApiFamily::Responses,
+//!     "https://models.example.com/v1",
+//! );
+//! let json = serde_json::to_string(&profile)?;
+//! let validated = validate_provider_profile(&json)?;
+//! assert_eq!(validated.slug, "internal-openai");
+//! # Ok::<(), Box<dyn std::error::Error>>(())
+//! ```
 
 pub mod registry;
 pub mod store;

--- a/src/provider_profile/registry.rs
+++ b/src/provider_profile/registry.rs
@@ -9,13 +9,17 @@ use iron_providers::{ProviderProfile, ProviderRegistry};
 
 /// Build an effective provider registry from built-ins plus persisted profiles.
 ///
-/// Starts with [`ProviderRegistry::default()` (which loads all built-in
-/// profiles) and applies each persisted provider profile. Persisted profiles
+/// Starts with [`ProviderRegistry::default`] (which loads all built-in profiles)
+/// and applies each persisted provider profile. Persisted profiles
 /// with built-in slugs override the built-in; persisted profiles with new slugs
 /// are added alongside built-ins.
 ///
 /// Invalid stored profiles are skipped with a warning rather than failing the
 /// entire operation.
+///
+/// # Errors
+///
+/// Returns [`ConfigError`] if persisted provider-profile rows cannot be listed.
 pub async fn build_effective_registry(
     store: &ConfigStore,
 ) -> Result<ProviderRegistry, ConfigError> {

--- a/src/provider_profile/store.rs
+++ b/src/provider_profile/store.rs
@@ -89,6 +89,11 @@ impl ProfileStore for DurableProfileStore {
 /// deserializes it to extract the slug, and persists the validated JSON.
 ///
 /// Returns the slug of the imported profile on success.
+///
+/// # Errors
+///
+/// Returns [`ConfigError`] when validation rejects malformed or secret-bearing
+/// JSON, canonical serialization fails, or the durable write fails.
 pub async fn import_provider_profile(
     store: &ConfigStore,
     json: &str,
@@ -110,6 +115,10 @@ pub async fn import_provider_profile(
 ///
 /// Returns `None` if no profile is stored for the slug. The exported JSON
 /// contains only non-secret provider profile metadata.
+///
+/// # Errors
+///
+/// Returns [`ConfigError`] if the durable lookup fails.
 pub async fn export_provider_profile(
     store: &ConfigStore,
     slug: &str,

--- a/src/request_builder.rs
+++ b/src/request_builder.rs
@@ -1,3 +1,5 @@
+//! Construction of provider inference requests and composed system instructions.
+
 use crate::{
     config::{Config, ContextWindowPolicy},
     context::models::CompressedBlock,
@@ -6,12 +8,19 @@ use crate::{
 };
 use iron_providers::{InferenceRequest, Message, ProviderRegistry, ToolPolicy};
 
+/// Per-request context used to build instructions and effective tool exposure.
 pub struct EffectiveToolRequestContext<'a> {
+    /// Durable summaries prepended to the provider transcript as assistant messages.
     pub compressed_blocks: &'a [CompressedBlock],
+    /// Optional session instructions rendered in the client-injection section.
     pub instructions: Option<&'a str>,
+    /// Optional preloaded repository instruction payload.
     pub repo_instruction_payload: Option<&'a crate::prompt::config::RepoInstructionPayload>,
+    /// Whether `python_exec` is available in the effective session catalog.
     pub python_exec_available: bool,
+    /// Optional concatenated instructions from active skills.
     pub skill_instructions: Option<&'a str>,
+    /// Current context pressure used to render tool-use guidance.
     pub context_pressure: crate::context::ContextPressure,
     /// Optional session workspace root snapshot. When provided, this overrides
     /// Config.workspace_roots for runtime context rendering.
@@ -39,8 +48,16 @@ struct ComposedInstructionInputs<'a> {
     effective_provider_guidance: Option<&'a str>,
 }
 
-/// Build an inference request using an effective tool view.
-/// This allows MCP tools to be included based on session state.
+/// Builds an inference request using an already resolved effective tool view.
+///
+/// Compressed blocks precede retained messages. Context-window pruning applies
+/// only to `messages`, and tools are emitted in `effective_tools` order. An
+/// empty tool view forces [`ToolPolicy::None`].
+///
+/// # Errors
+///
+/// Returns [`RuntimeError`] if the configured context-window policy cannot be
+/// applied.
 pub fn build_inference_request_with_effective_tools(
     config: &Config,
     messages: &[Message],
@@ -101,6 +118,11 @@ pub fn build_inference_request_with_effective_tools(
     Ok(request)
 }
 
+/// Builds an inference request from the runtime's local tool registry.
+///
+/// # Errors
+///
+/// Returns [`RuntimeError`] if request context preparation fails.
 pub fn build_inference_request(
     config: &Config,
     messages: &[Message],
@@ -126,6 +148,11 @@ pub fn build_inference_request(
     )
 }
 
+/// Builds an inference request with compressed context prepended to messages.
+///
+/// # Errors
+///
+/// Returns [`RuntimeError`] if request context preparation fails.
 pub fn build_inference_request_with_context(
     config: &Config,
     messages: &[Message],
@@ -152,6 +179,11 @@ pub fn build_inference_request_with_context(
     )
 }
 
+/// Builds an inference request with optional preloaded repository instructions.
+///
+/// # Errors
+///
+/// Returns [`RuntimeError`] if request context preparation fails.
 pub fn build_inference_request_with_repo(
     config: &Config,
     messages: &[Message],
@@ -178,6 +210,16 @@ pub fn build_inference_request_with_repo(
     )
 }
 
+/// Builds an inference request from the local registry and complete prompt context.
+///
+/// Compressed blocks are prepended before retained messages. The request uses
+/// the effective model when supplied, otherwise `config.model`; `python_exec`
+/// guidance is enabled if either the context or local registry exposes it.
+///
+/// # Errors
+///
+/// Returns [`RuntimeError`] if the configured context-window policy cannot be
+/// applied.
 pub fn build_inference_request_with_context_and_repo(
     config: &Config,
     messages: &[Message],

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -132,7 +132,10 @@ struct RuntimeConnection {
 
 /// Stable identifier for a client connection registered with the runtime.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct ConnectionId(pub u64);
+pub struct ConnectionId(
+    /// Process-local numeric connection identifier.
+    pub u64,
+);
 
 static CONNECTION_ID_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
 
@@ -945,6 +948,7 @@ impl IronRuntime {
         }
     }
 
+    /// Returns the shared manager responsible for MCP server connections.
     pub fn mcp_connection_manager(&self) -> Arc<McpConnectionManager> {
         self.inner.mcp_connection_manager.clone()
     }
@@ -1079,6 +1083,7 @@ impl IronRuntime {
         diagnostics
     }
 
+    /// Clones the runtime skill catalog into a session-initialization snapshot.
     pub(crate) fn available_skill_snapshot(&self) -> Vec<LoadedSkill> {
         self.skill_catalog()
             .list_all()
@@ -1232,6 +1237,9 @@ impl IronRuntime {
         true
     }
 
+    /// Registers an active client connection under a preallocated identifier.
+    ///
+    /// Registering an existing identifier replaces its prior runtime record.
     pub fn register_connection(&self, id: ConnectionId) {
         let conn = Arc::new(RuntimeConnection {
             active: AtomicBool::new(true),
@@ -1239,6 +1247,7 @@ impl IronRuntime {
         self.inner.connections.write().insert(id, conn);
     }
 
+    /// Removes a connection and recursively closes every session it owns.
     pub fn close_connection(&self, id: ConnectionId) {
         if let Some(conn) = self.inner.connections.write().get(&id) {
             conn.active.store(false, Ordering::SeqCst);
@@ -1247,10 +1256,19 @@ impl IronRuntime {
         self.close_sessions_for_connection(id);
     }
 
+    /// Returns the number of currently registered connections.
     pub fn connection_count(&self) -> usize {
         self.inner.connections.read().len()
     }
 
+    /// Creates a visible session owned by `connection_id`.
+    ///
+    /// Session initialization snapshots runtime workspace roots, repository
+    /// instructions, plugin and MCP defaults, and available skills.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RuntimeError`] when the runtime has shut down.
     pub fn create_session(
         &self,
         connection_id: ConnectionId,
@@ -1258,6 +1276,14 @@ impl IronRuntime {
         self.create_session_with_options(connection_id, CreateSessionOptions::default())
     }
 
+    /// Creates a session with explicit visibility options.
+    ///
+    /// Initialization is identical to [`Self::create_session`], with hidden
+    /// sessions omitted from normal connection listings.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RuntimeError`] when the runtime has shut down.
     pub fn create_session_with_options(
         &self,
         connection_id: ConnectionId,
@@ -1366,6 +1392,15 @@ impl IronRuntime {
             .unwrap_or(false)
     }
 
+    /// Inserts a preexisting durable session under a connection.
+    ///
+    /// Destination-runtime plugin and MCP defaults fill only missing choices;
+    /// existing session choices are preserved. Missing workspace roots are
+    /// backfilled before session skills are refreshed.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RuntimeError`] when the runtime has shut down.
     pub fn insert_session(
         &self,
         session_id: SessionId,
@@ -1404,6 +1439,7 @@ impl IronRuntime {
         Ok(())
     }
 
+    /// Returns shared durable state for a session, or `None` if it is absent.
     pub fn get_session(&self, id: SessionId) -> Option<Arc<Mutex<DurableSession>>> {
         self.inner
             .sessions
@@ -1412,6 +1448,7 @@ impl IronRuntime {
             .map(|rs| rs.session.clone())
     }
 
+    /// Returns the connection that owns a session, or `None` if it is absent.
     pub fn get_session_connection(&self, id: SessionId) -> Option<ConnectionId> {
         self.inner
             .sessions
@@ -1420,10 +1457,15 @@ impl IronRuntime {
             .map(|rs| rs.connection_id)
     }
 
+    /// Cancels and removes a session and all registered descendants.
     pub fn close_session(&self, id: SessionId) {
         self.cancel_and_remove_session_subtree(id);
     }
 
+    /// Cancels and removes all sessions owned by `connection_id`.
+    ///
+    /// Descendants are removed recursively even when their direct connection
+    /// ownership differs.
     pub fn close_sessions_for_connection(&self, connection_id: ConnectionId) {
         let to_remove: Vec<SessionId> = {
             let sessions = self.inner.sessions.read();
@@ -1610,6 +1652,15 @@ impl IronRuntime {
         false
     }
 
+    /// Atomically admits a new active prompt for a session.
+    ///
+    /// The returned ephemeral turn is already running and has a monotonically
+    /// increasing session-local turn identifier.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RuntimeError`] if the session does not exist or already has an
+    /// active prompt.
     pub fn try_start_prompt(
         &self,
         session_id: SessionId,
@@ -1639,6 +1690,9 @@ impl IronRuntime {
         Ok(ephemeral)
     }
 
+    /// Clears a session's active-prompt slot at a turn boundary.
+    ///
+    /// This is a no-op when the session is absent or no prompt is active.
     pub fn finish_prompt(&self, session_id: SessionId) {
         let sessions = self.inner.sessions.read();
         if let Some(rs) = sessions.get(&session_id) {
@@ -2156,6 +2210,9 @@ impl IronRuntime {
         self.inner.model_capability_registry.read()
     }
 
+    /// Requests cancellation for a session's active prompt and all descendants.
+    ///
+    /// Returns `true` if at least one active prompt received cancellation.
     pub fn cancel_active_prompt(&self, session_id: SessionId) -> bool {
         let sessions = self.inner.sessions.read();
         let children_by_parent = self.inner.children_by_parent.read();
@@ -2182,6 +2239,7 @@ impl IronRuntime {
         false
     }
 
+    /// Returns whether a session currently occupies its active-prompt slot.
     pub fn has_active_prompt(&self, session_id: SessionId) -> bool {
         let sessions = self.inner.sessions.read();
         sessions
@@ -2254,6 +2312,7 @@ impl IronRuntime {
         let _ = self.refresh_session_skills(session_id, &roots);
     }
 
+    /// Returns shared ephemeral state for a session's active prompt.
     pub fn get_active_prompt_ephemeral(
         &self,
         session_id: SessionId,
@@ -2267,10 +2326,15 @@ impl IronRuntime {
         })
     }
 
+    /// Returns the total number of visible and hidden runtime sessions.
     pub fn session_count(&self) -> usize {
         self.inner.sessions.read().len()
     }
 
+    /// Lists sessions directly owned by a connection.
+    ///
+    /// Hidden sessions are included only when `include_hidden` is `true`; the
+    /// returned order follows the runtime map and is not stable.
     pub fn sessions_for_connection(
         &self,
         connection_id: ConnectionId,
@@ -2327,6 +2391,10 @@ impl IronRuntime {
         result
     }
 
+    /// Begins runtime shutdown, aborting tracked tasks and removing all state.
+    ///
+    /// MCP shutdown is scheduled first. Repeated calls are safe, and subsequent
+    /// task spawning or session creation is rejected.
     pub fn shutdown(&self) {
         let manager = self.inner.mcp_connection_manager.clone();
         let _shutdown_handle = self.inner.tokio_handle.spawn(async move {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -2018,7 +2018,7 @@ impl IronRuntime {
         // Update current model and capability restrictions
         session.current_model = Some(to_model.clone());
         session.current_provider_slug = to_provider_slug;
-        session.current_provider_api_key = to_api_key;
+        session.current_provider_api_key = to_api_key.map(crate::secret::SecretString::new);
         session.hidden_tools = plan.capability_diff.hidden_tools.clone();
 
         // Emit model switch applied debug event

--- a/src/scheduled_task/host.rs
+++ b/src/scheduled_task/host.rs
@@ -141,7 +141,9 @@ pub enum HostSchedulerError {
     /// The platform does not support the requested schedule.
     #[error("unsupported schedule for {platform}: {reason}")]
     UnsupportedSchedule {
+        /// Stable name of the rejecting platform adapter.
         platform: &'static str,
+        /// Explanation of the platform representation limit.
         reason: String,
     },
 
@@ -334,17 +336,24 @@ pub trait CommandRunner: Send + Sync {
 /// Output from a command runner invocation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CommandOutput {
+    /// Process exit code, or `-1` when the process ended without one.
     pub exit_code: i32,
+    /// Standard output decoded lossily as UTF-8.
     pub stdout: String,
+    /// Standard error decoded lossily as UTF-8.
     pub stderr: String,
 }
 
 /// Injectable filesystem boundary.
 #[async_trait]
 pub trait SchedulerFilesystem: Send + Sync {
+    /// Read an entire scheduler-owned file as UTF-8 text.
     async fn read_to_string(&self, path: &std::path::Path) -> Result<String, std::io::Error>;
+    /// Replace a scheduler-owned file with the supplied text.
     async fn write(&self, path: &std::path::Path, content: &str) -> Result<(), std::io::Error>;
+    /// Report whether a scheduler-owned path currently exists.
     async fn exists(&self, path: &std::path::Path) -> bool;
+    /// Remove a scheduler-owned file.
     async fn remove_file(&self, path: &std::path::Path) -> Result<(), std::io::Error>;
 }
 
@@ -363,6 +372,7 @@ pub struct FakeHostScheduler {
 }
 
 impl FakeHostScheduler {
+    /// Create an empty scheduler with no forced error.
     pub fn new() -> Self {
         Self::default()
     }

--- a/src/scheduled_task/mod.rs
+++ b/src/scheduled_task/mod.rs
@@ -4,6 +4,19 @@
 //! a five-field cron expression and enabled state. Schedules never contain
 //! executable paths, shell commands, prompt text, or environment variables —
 //! the installed host entry is always a core-generated `agent-iron run` call.
+//!
+//! ```
+//! use iron_core::scheduled_task::{validate_schedule_input, ScheduledTaskInput};
+//!
+//! let schedule = validate_schedule_input(&ScheduledTaskInput {
+//!     id: "weekday-review".into(),
+//!     automation_task_id: "daily-review".into(),
+//!     cron_expression: "0 9 * * 1-5".into(),
+//!     enabled: true,
+//! })?;
+//! assert_eq!(schedule.cron_expression, "0 9 * * 1-5");
+//! # Ok::<(), String>(())
+//! ```
 
 pub mod cron;
 pub mod host;

--- a/src/scheduled_task/platform/crontab.rs
+++ b/src/scheduled_task/platform/crontab.rs
@@ -37,7 +37,9 @@ pub const MARKER_PREFIX: &str = "# iron-core-task:";
 /// A parsed owned crontab block.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CronOwnedBlock {
+    /// Stable schedule identifier encoded in the ownership markers.
     pub schedule_id: String,
+    /// Whether the cron line is active rather than commented out.
     pub enabled: bool,
     /// The cron schedule fields (e.g. `"0 9 * * *"`).
     pub cron_schedule: String,
@@ -102,7 +104,12 @@ pub enum CrontabSegment {
     /// Non-owned lines, preserved as-is.
     Other(String),
     /// A malformed owned block (unbalanced or duplicate markers).
-    Malformed { schedule_id: String, raw: String },
+    Malformed {
+        /// Schedule identifier recovered from the opening marker.
+        schedule_id: String,
+        /// Original block text preserved to avoid destructive rewriting.
+        raw: String,
+    },
 }
 
 impl ParsedCrontab {

--- a/src/scheduled_task/platform/launchd.rs
+++ b/src/scheduled_task/platform/launchd.rs
@@ -2,7 +2,11 @@
 //!
 //! Manages user-level LaunchAgent plists with `com.agentiron.task.` labels.
 //! Cron expressions are expanded into launchd `StartCalendarInterval`
-//! entries. plist files live in `~/Library/LaunchAgents/`.
+//! entries, capped at [`MAX_INTERVALS`]. When both day-of-month and weekday
+//! are restricted, expansion emits their union to preserve cron OR semantics.
+//! Plist files live in `~/Library/LaunchAgents/`; `launchctl` controls loaded
+//! and enabled state. launchd inspection can recover command and enabled state,
+//! but not the original cron text.
 //!
 //! The plist rendering and cron expansion logic is platform-independent
 //! and tested here. The actual `launchctl` command execution is Linux
@@ -44,12 +48,21 @@ pub const MAX_INTERVALS: usize = 64;
 // ============================================================================
 
 /// A single launchd calendar interval.
+///
+/// `None` omits the corresponding `StartCalendarInterval` key and therefore
+/// leaves that calendar component unrestricted. Cron Sunday (`0`) is converted
+/// to launchd Sunday (`7`) during expansion.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CalendarInterval {
+    /// Minute in `0..=59`, or any minute when omitted.
     pub minute: Option<u32>,
+    /// Hour in `0..=23`, or any hour when omitted.
     pub hour: Option<u32>,
+    /// Day of month in `1..=31`, or any day when omitted.
     pub day_of_month: Option<u32>,
+    /// Month in `1..=12`, or any month when omitted.
     pub month: Option<u32>,
+    /// launchd weekday in `1..=7`, or any weekday when omitted.
     pub day_of_week: Option<u32>,
 }
 
@@ -330,6 +343,10 @@ pub struct LaunchdHostScheduler {
 }
 
 impl LaunchdHostScheduler {
+    /// Create a launchd adapter for a user LaunchAgents directory.
+    ///
+    /// Commands run through `runner`; the adapter derives service labels and
+    /// plist paths from validated schedule IDs.
     pub fn new(runner: Box<dyn CommandRunner>, launchagents_dir: PathBuf) -> Self {
         let uid = extern_uid();
         Self {
@@ -521,6 +538,8 @@ fn extern_uid() -> u32 {
     extern "C" {
         fn getuid() -> u32;
     }
+    // SAFETY: POSIX `getuid` takes no arguments, has no preconditions, and
+    // returns the real user ID without exposing borrowed memory.
     unsafe { getuid() }
 }
 

--- a/src/scheduled_task/platform/task_scheduler.rs
+++ b/src/scheduled_task/platform/task_scheduler.rs
@@ -2,7 +2,11 @@
 //!
 //! Manages tasks under `\AgentIron\Tasks\<id>` using generated Task Scheduler
 //! XML. Uses `schtasks.exe` for lifecycle operations. Cron expressions are
-//! compiled into Task Scheduler triggers.
+//! compiled into calendar triggers, with separate monthly and weekly triggers
+//! preserving cron's day-of-month OR weekday semantics. Expansion rejects
+//! definitions whose represented field values exceed [`MAX_TRIGGERS`].
+//! Inspection recovers enabled and command state from XML but does not
+//! reconstruct the original cron expression.
 //!
 //! The XML rendering and cron expansion logic is platform-independent and
 //! tested here. The actual `schtasks.exe` execution requires Windows.
@@ -25,12 +29,21 @@ pub const MAX_TRIGGERS: usize = 64;
 // ============================================================================
 
 /// A Task Scheduler calendar trigger specification.
+///
+/// Values are expanded numeric cron matches. Rendering emits one Windows
+/// calendar trigger per minute/hour pair and preserves cron's day-of-month OR
+/// day-of-week behavior by emitting separate monthly and weekly triggers.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TaskTrigger {
+    /// Matching minutes in `0..=59`.
     pub minutes: Vec<u32>,
+    /// Matching hours in `0..=23`.
     pub hours: Vec<u32>,
+    /// Matching days of month in `1..=31`.
     pub days_of_month: Vec<u32>,
+    /// Matching months in `1..=12`.
     pub months: Vec<u32>,
+    /// Matching cron weekdays, where `0` is Sunday and `6` is Saturday.
     pub days_of_week: Vec<u32>,
 }
 
@@ -324,6 +337,7 @@ pub struct TaskSchedulerHostScheduler {
 }
 
 impl TaskSchedulerHostScheduler {
+    /// Create a Windows Task Scheduler adapter using the supplied command runner.
     pub fn new(runner: Box<dyn CommandRunner>) -> Self {
         Self { runner }
     }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,19 +1,35 @@
+//! JSON Schema validation for tool arguments.
+
 use serde_json::Value;
 
 #[derive(Debug)]
+/// Result of compiling a JSON Schema and validating an argument value.
 pub enum SchemaValidationOutcome {
+    /// The arguments satisfy the schema.
     Valid,
-    Invalid { errors: Vec<String> },
-    BadSchema { error: String },
+    /// The schema compiled, but the arguments violate one or more constraints.
+    Invalid {
+        /// All validation errors reported by the schema validator.
+        errors: Vec<String>,
+    },
+    /// The supplied schema could not be compiled.
+    BadSchema {
+        /// Description of the schema compilation failure.
+        error: String,
+    },
 }
 
+/// Validate `arguments` against `schema` and collect every violation.
+///
+/// Schema compilation failures are distinguished from argument validation
+/// failures through [`SchemaValidationOutcome::BadSchema`].
 pub fn validate_arguments(schema: &Value, arguments: &Value) -> SchemaValidationOutcome {
     let validator = match jsonschema::validator_for(schema) {
         Ok(v) => v,
         Err(e) => {
             return SchemaValidationOutcome::BadSchema {
                 error: e.to_string(),
-            }
+            };
         }
     };
 

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -1,0 +1,68 @@
+//! Redacting wrappers for secret-bearing strings.
+//!
+//! Types in this module keep their value reachable for serialization and
+//! runtime use while preventing accidental disclosure through
+//! [`Debug`](std::fmt::Debug) formatting. They are used for durable and
+//! handoff fields that carry provider credentials.
+//!
+//! # Serialization
+//!
+//! [`SecretString`] serializes transparently as a plain JSON string, so
+//! existing serialized sessions and handoff bundles remain compatible and
+//! credential portability is preserved. The redaction only affects debug
+//! output, not persistence.
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+/// A string wrapper that serializes transparently but redacts its value in
+/// [`Debug`](fmt::Debug) output.
+///
+/// Use this for fields that must round-trip through serialized payloads (for
+/// example durable sessions and handoff bundles) but should never appear in
+/// logs or debug-rendered state. The wrapped value is still serialized as a
+/// plain string, preserving compatibility with previously persisted data.
+///
+/// # Examples
+///
+/// ```
+/// use iron_core::SecretString;
+///
+/// let key = SecretString::new("sk-example".to_string());
+/// assert_eq!(key.reveal(), "sk-example");
+/// assert_eq!(format!("{key:?}"), "SecretString(<redacted>)");
+/// ```
+#[derive(Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct SecretString(String);
+
+impl SecretString {
+    /// Wraps a secret string.
+    pub fn new(value: String) -> Self {
+        Self(value)
+    }
+
+    /// Returns the secret value.
+    pub fn reveal(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Debug for SecretString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("SecretString(<redacted>)")
+    }
+}
+
+impl From<String> for SecretString {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+
+impl From<&str> for SecretString {
+    fn from(value: &str) -> Self {
+        Self(value.to_string())
+    }
+}

--- a/src/skill/catalog.rs
+++ b/src/skill/catalog.rs
@@ -1,3 +1,9 @@
+//! Unified skill catalog and source-precedence resolution.
+//!
+//! Discovery fully loads source entries into owned snapshots. Name collisions
+//! resolve deterministically by [`crate::skill::origin_precedence`], while
+//! shadowing and load failures remain available as diagnostics.
+
 use crate::skill::source::SkillSource;
 use crate::skill::{
     origin_precedence, DiagnosticLevel, LoadedSkill, SkillDiagnostic, SkillMetadata,
@@ -108,7 +114,7 @@ impl SkillCatalog {
         self.diagnostics.extend(diagnostics);
     }
 
-    /// Register a skill directly into the catalog.
+    /// Register a skill directly, applying the same origin precedence used by discovery.
     pub fn register(&mut self, skill: LoadedSkill) {
         self.insert(skill.metadata.id.clone(), skill);
     }

--- a/src/skill/mod.rs
+++ b/src/skill/mod.rs
@@ -6,11 +6,35 @@
 //!
 //! ## Architecture
 //!
-//! - [`SkillSource`] trait abstracts discovery (filesystem, client-provided, etc.)
-//! - [`SkillCatalog`] unifies discovered skills from all sources
-//! - [`Skill`] represents a loaded skill with metadata and body content
-//! - [`SkillRegistry`] is runtime-owned and manages the lifecycle
-//! - Session-scoped activation is tracked in [`DurableSession`]
+//! - [`SkillSource`] separates discovery from loading owned skill snapshots.
+//! - [`LoadedSkill`] carries metadata, instructions, location, and resources.
+//! - [`SkillCatalog`] merges sources and resolves collisions by origin precedence.
+//! - [`SessionSkillState`] activates snapshots idempotently and injects their
+//!   instructions until deactivation.
+//! - Session state is persisted as part of [`crate::durable::DurableSession`].
+//!
+//! ```
+//! use iron_core::skill::{LoadedSkill, SkillCatalog, SkillMetadata, SkillOrigin};
+//!
+//! let mut catalog = SkillCatalog::new();
+//! catalog.register(LoadedSkill {
+//!     metadata: SkillMetadata {
+//!         id: "review".into(),
+//!         display_name: "Code Review".into(),
+//!         description: "Review changes for correctness.".into(),
+//!         origin: SkillOrigin::ClientProvided,
+//!         auto_activate: false,
+//!         tags: vec!["engineering".into()],
+//!         requires_tools: vec!["read".into()],
+//!         requires_capabilities: vec![],
+//!         requires_trust: false,
+//!     },
+//!     location: None,
+//!     body: "Inspect the diff and report actionable findings.".into(),
+//!     resources: vec![],
+//! });
+//! assert!(catalog.contains("review"));
+//! ```
 
 pub mod catalog;
 pub mod source;
@@ -105,16 +129,22 @@ pub struct LoadedSkill {
 /// Severity level for a skill diagnostic.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum DiagnosticLevel {
+    /// Informational discovery or precedence detail.
     Info,
+    /// Recoverable problem that may reduce the available skill set.
     Warning,
+    /// Skill discovery or loading failure requiring attention.
     Error,
 }
 
 /// A diagnostic message about skill discovery.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SkillDiagnostic {
+    /// Severity of the reported condition.
     pub level: DiagnosticLevel,
+    /// Human-readable discovery or loading detail.
     pub message: String,
+    /// Affected skill identifier, when the condition is skill-specific.
     pub skill_name: Option<String>,
 }
 
@@ -153,14 +183,17 @@ impl SessionSkillState {
         self.active.iter().any(|r| r.name == name)
     }
 
-    /// Activate a skill (idempotent).
+    /// Activate a loaded skill snapshot if its name is not already active.
+    ///
+    /// Re-activation is idempotent and does not refresh an existing snapshot;
+    /// callers must deactivate first to pick up changed instructions/resources.
     pub fn activate(&mut self, record: ActivatedSkillRecord) {
         if !self.is_active(&record.name) {
             self.active.push(record);
         }
     }
 
-    /// Deactivate a skill by name.
+    /// Deactivate a skill by name, leaving other activation order unchanged.
     pub fn deactivate(&mut self, name: &str) {
         self.active.retain(|r| r.name != name);
     }
@@ -170,7 +203,9 @@ impl SessionSkillState {
         self.active.iter().map(|r| r.name.as_str()).collect()
     }
 
-    /// Get the full instruction text for all active skills.
+    /// Render active skill snapshots as model-visible instruction blocks.
+    ///
+    /// Blocks preserve activation order and are separated by a blank line.
     pub fn active_skill_instructions(&self) -> String {
         let mut output = String::new();
         for skill in &self.active {
@@ -183,6 +218,7 @@ impl SessionSkillState {
     }
 }
 
+/// Wrap a snapshotted skill body for injection into session instructions.
 pub(crate) fn render_skill_content(name: &str, body: &str) -> String {
     format!(
         "<skill_content name=\"{}\">\n{}\n</skill_content>",

--- a/src/skill/source.rs
+++ b/src/skill/source.rs
@@ -1,3 +1,10 @@
+//! Skill discovery backends for filesystem and in-memory sources.
+//!
+//! Sources separate lightweight discovery from full loading. Filesystem
+//! sources parse `SKILL.md`, snapshot its instruction body and resources, and
+//! retain diagnostics; static sources provide the same lifecycle for skills
+//! supplied by an embedding client.
+
 use crate::skill::{
     LoadedSkill, SkillDiagnostic, SkillLocation, SkillMetadata, SkillOrigin, SkillResourceEntry,
 };
@@ -15,7 +22,8 @@ pub trait SkillSource: Send + Sync {
 
     /// Load a full skill by name.
     ///
-    /// Returns `None` if the skill is not found or cannot be loaded.
+    /// Returns `None` if the skill is not found or cannot be loaded. A loaded
+    /// value is an owned snapshot suitable for session-scoped activation.
     fn load(&self, name: &str) -> Option<LoadedSkill>;
 
     /// Return any diagnostics accumulated during discovery/load.
@@ -241,12 +249,15 @@ impl StaticSkillSource {
         }
     }
 
-    /// Register a skill with this source.
+    /// Register or replace a skill with this source by metadata ID.
     pub fn register(&mut self, skill: LoadedSkill) {
         self.skills.insert(skill.metadata.id.clone(), skill);
     }
 
-    /// Register a skill from raw components.
+    /// Register or replace a client-provided skill from raw components.
+    ///
+    /// The created skill has no filesystem location, resources, trust
+    /// requirement, or automatic activation.
     pub fn register_raw(
         &mut self,
         name: impl Into<String>,

--- a/src/stored_prompt/mod.rs
+++ b/src/stored_prompt/mod.rs
@@ -2,6 +2,22 @@
 //!
 //! Stored prompts are named reusable task definitions persisted in the core
 //! config store. They are invoked through delegated child-session execution.
+//!
+//! ```
+//! use iron_core::{StoredPrompt, StoredPromptRegistry};
+//!
+//! let prompt = StoredPrompt {
+//!     display_name: "Review Changes".into(),
+//!     normalized_name: "review-changes".into(),
+//!     instructions: "Review the current changes and report risks.".into(),
+//!     skills: vec!["code-review".into()],
+//!     profile: None,
+//! };
+//! let mut registry = StoredPromptRegistry::new();
+//! registry.register("review".into(), prompt)?;
+//! assert_eq!(registry.get("review").unwrap().normalized_name, "review-changes");
+//! # Ok::<(), String>(())
+//! ```
 
 use crate::config::{ConfigError, ConfigStore};
 use crate::profile::AgentProfileId;
@@ -44,7 +60,13 @@ pub struct StoredPrompt {
 }
 
 impl StoredPrompt {
-    /// Validate invariants for v2 records.
+    /// Validate invariants for current-schema records.
+    ///
+    /// # Errors
+    ///
+    /// Returns a diagnostic string when instructions or display identity are
+    /// empty, the normalized handle is stale, a skill identifier is invalid,
+    /// or skill identifiers repeat case-insensitively.
     pub fn validate(&self) -> Result<(), String> {
         if self.instructions.trim().is_empty() {
             return Err("stored prompt instructions must not be empty".to_string());
@@ -84,33 +106,55 @@ impl StoredPrompt {
 /// A stored prompt paired with its stable ID and identity state.
 #[derive(Debug, Clone, PartialEq)]
 pub struct StoredPromptEntry {
+    /// Immutable record ID used by automation-task references.
     pub id: String,
+    /// Decoded reusable prompt definition.
     pub prompt: StoredPrompt,
+    /// Whether the prompt is usable by handle or quarantined pending a rename.
     pub identity_state: IdentityState,
 }
 
 /// Issue category reported for a skipped prompt during `load_prompts`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PromptLoadIssue {
-    UnsupportedSchemaVersion { version: i64 },
+    /// The row uses a schema version this binary cannot decode.
+    UnsupportedSchemaVersion {
+        /// Unsupported version read from the prompt row.
+        version: i64,
+    },
+    /// The row ID or serialized prompt failed decoding or validation.
     InvalidPayload,
+    /// The ID appeared in a listing but disappeared before it could be read.
     MissingRecord,
-    UnavailableProfile { profile_id: String },
-    UnavailableSkill { skill: String },
+    /// The prompt refers to a profile unavailable to the loading context.
+    UnavailableProfile {
+        /// Profile ID that could not be resolved.
+        profile_id: String,
+    },
+    /// The prompt requests a skill unavailable to the loading context.
+    UnavailableSkill {
+        /// Requested skill identifier that was unavailable.
+        skill: String,
+    },
+    /// Migration quarantined the prompt after a normalized-name collision.
     NeedsRename,
 }
 
 /// Per-prompt diagnostic returned by best-effort prompt loading.
 #[derive(Debug, Clone, PartialEq)]
 pub struct PromptLoadDiagnostic {
+    /// Stable ID of the skipped or degraded prompt.
     pub prompt_id: String,
+    /// Machine-readable reason the prompt was not loaded normally.
     pub issue: PromptLoadIssue,
 }
 
 /// Result of loading typed stored prompts from ConfigStore.
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct PromptLoadReport {
+    /// Successfully decoded prompt entries, including their identity state.
     pub loaded: Vec<StoredPromptEntry>,
+    /// Record-local problems that did not abort the best-effort load.
     pub diagnostics: Vec<PromptLoadDiagnostic>,
 }
 
@@ -121,12 +165,21 @@ pub struct StoredPromptRegistry {
 }
 
 impl StoredPromptRegistry {
+    /// Create an empty in-memory prompt registry.
     pub fn new() -> Self {
         Self {
             prompts: HashMap::new(),
         }
     }
 
+    /// Validate and register a prompt under a trimmed stable ID.
+    ///
+    /// Replaces an existing prompt with the same ID.
+    ///
+    /// # Errors
+    ///
+    /// Returns a diagnostic string if the ID is empty or contains control
+    /// characters, or if [`StoredPrompt::validate`] rejects the prompt.
     pub fn register(&mut self, id: String, prompt: StoredPrompt) -> Result<(), String> {
         let trimmed = id.trim();
         if trimmed.is_empty() {
@@ -140,14 +193,22 @@ impl StoredPromptRegistry {
         Ok(())
     }
 
+    /// Remove the prompt identified by the trimmed ID.
+    ///
+    /// Returns whether an entry was present.
     pub fn unregister(&mut self, id: &str) -> bool {
         self.prompts.remove(id.trim()).is_some()
     }
 
+    /// Look up a prompt by its trimmed stable ID.
     pub fn get(&self, id: &str) -> Option<&StoredPrompt> {
         self.prompts.get(id.trim())
     }
 
+    /// Return cloned entries sorted by stable ID.
+    ///
+    /// Registry entries are always returned with [`IdentityState::Ready`]
+    /// because quarantined durable rows are not registered.
     pub fn list(&self) -> Vec<StoredPromptEntry> {
         let mut ids: Vec<&String> = self.prompts.keys().collect();
         ids.sort();
@@ -160,10 +221,12 @@ impl StoredPromptRegistry {
             .collect()
     }
 
+    /// Return whether the registry contains no prompts.
     pub fn is_empty(&self) -> bool {
         self.prompts.is_empty()
     }
 
+    /// Return the number of registered prompts.
     pub fn len(&self) -> usize {
         self.prompts.len()
     }

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -1,4 +1,4 @@
-//! Tool registry and definitions
+//! Tool registry and definitions.
 //!
 //! Tool registration, execution, and approval management.
 
@@ -10,7 +10,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 
-/// Type alias for a tool execution future.
+/// Owned, sendable future returned by asynchronous tool execution.
 pub type ToolFuture = Pin<Box<dyn Future<Output = RuntimeResult<Value>> + Send>>;
 
 /// Executable tool trait.
@@ -27,17 +27,17 @@ pub type ToolFuture = Pin<Box<dyn Future<Output = RuntimeResult<Value>> + Send>>
 /// `spawn_blocking`. Custom async `Tool` implementations that need to call
 /// blocking APIs should do the same.
 pub trait Tool: Send + Sync {
-    /// Get the tool definition (metadata for the model)
+    /// Return the tool definition exposed to the model.
     fn definition(&self) -> ToolDefinition;
 
-    /// Execute the tool with the given arguments.
+    /// Execute one tool call with its identifier and structured arguments.
     ///
     /// The returned future runs on the orchestration runtime.
     /// See the [trait-level contract](Tool#contract-do-not-block-the-orchestration-runtime)
     /// for blocking requirements.
     fn execute(&self, call_id: &str, arguments: Value) -> ToolFuture;
 
-    /// Check if this tool requires human approval
+    /// Return whether calls require human approval before execution.
     fn requires_approval(&self) -> bool;
 }
 
@@ -65,7 +65,7 @@ pub struct ToolDefinition {
 }
 
 impl ToolDefinition {
-    /// Create a new tool definition.
+    /// Create a tool definition that does not require approval by default.
     pub fn new<S1: Into<String>, S2: Into<String>>(
         name: S1,
         description: S2,
@@ -127,6 +127,9 @@ impl ToolRegistry {
     }
 
     /// Register or replace a tool by its definition name.
+    ///
+    /// Registration increments the mutation [`Self::version`], including when
+    /// an existing name is replaced.
     pub fn register<T: Tool + 'static>(&mut self, tool: T) {
         let definition = tool.definition();
         self.tools.insert(definition.name, Arc::new(tool));
@@ -144,6 +147,8 @@ impl ToolRegistry {
     }
 
     /// Return all tool definitions registered in this registry.
+    ///
+    /// Definition order is unspecified because the registry is hash-based.
     pub fn definitions(&self) -> Vec<ToolDefinition> {
         self.tools.values().map(|t| t.definition()).collect()
     }
@@ -166,7 +171,7 @@ impl ToolRegistry {
         self.tools.is_empty()
     }
 
-    /// Remove all registered tools.
+    /// Remove all registered tools and increment the mutation version.
     pub fn clear(&mut self) {
         self.tools.clear();
         self.version += 1;
@@ -196,7 +201,10 @@ impl std::fmt::Debug for FunctionTool {
 }
 
 impl FunctionTool {
-    /// Create a new function-backed tool.
+    /// Create a tool backed by a synchronous function.
+    ///
+    /// The handler is dispatched through [`tokio::task::spawn_blocking`] by
+    /// [`Tool::execute`].
     pub fn new<F>(definition: ToolDefinition, handler: F) -> Self
     where
         F: Fn(Value) -> RuntimeResult<Value> + Send + Sync + 'static,

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -1,4 +1,19 @@
 //! ACP transport adapters for `iron-core`.
+//!
+//! Every transport enters the same ACP RPC layer, so transport selection only
+//! changes how messages move between client and agent. Session ownership,
+//! durable history, permission mediation, and cancellation semantics remain
+//! transport-independent. The in-process adapter is operational; the stdio and
+//! TCP entry points currently return ACP compatibility errors.
+//!
+//! ```
+//! use iron_core::transport::{TransportKind, TransportMetadata, ACP_SUPPORT};
+//!
+//! let transport = TransportMetadata::new(TransportKind::InProcess);
+//! assert_eq!(transport.kind, TransportKind::InProcess);
+//! assert!(ACP_SUPPORT.stable_methods.contains(&"prompt"));
+//! assert!(ACP_SUPPORT.stable_methods.contains(&"cancel"));
+//! ```
 
 use crate::connection::{ClientChannel, IronConnection};
 use agent_client_protocol as acp;
@@ -86,12 +101,26 @@ semantics. The transport only affects how bytes move between the agent and \
 client sides - it does not change runtime/session ownership, durable history \
 behavior, permission mediation, or cancellation outcomes.";
 
+/// Handles agent-to-client ACP callbacks for an in-process transport.
+///
+/// Implementations receive session notifications and permission requests on
+/// the same local executor as the agent. Returned futures therefore need not
+/// be [`Send`], but handlers must remain valid for the lifetime of the
+/// transport.
 pub trait InProcessClientHandler: 'static {
+    /// Delivers an ACP session notification to the embedded client.
+    ///
+    /// The returned future completes when the client has accepted the
+    /// notification or returns an ACP error.
     fn session_notification(
         &self,
         notification: acp_schema::SessionNotification,
     ) -> Pin<Box<dyn Future<Output = agent_client_protocol::Result<()>>>>;
 
+    /// Asks the embedded client to decide an ACP tool permission request.
+    ///
+    /// The response is returned to the waiting agent operation; an ACP error
+    /// aborts that permission exchange.
     fn request_permission(
         &self,
         request: acp_schema::RequestPermissionRequest,
@@ -164,6 +193,7 @@ impl InProcessClient {
         op().await
     }
 
+    /// Initializes the ACP connection and negotiates protocol capabilities.
     pub async fn initialize(
         &self,
         request: acp_schema::InitializeRequest,
@@ -171,6 +201,7 @@ impl InProcessClient {
         self.connection.handle_initialize(request).await
     }
 
+    /// Creates a new ACP session owned by this connection.
     pub async fn new_session(
         &self,
         request: acp_schema::NewSessionRequest,
@@ -178,6 +209,10 @@ impl InProcessClient {
         self.connection.handle_new_session(request).await
     }
 
+    /// Runs a prompt request in an existing session.
+    ///
+    /// Agent notifications and permission requests are delivered through the
+    /// [`InProcessClientHandler`] installed when the transport was created.
     pub async fn prompt(
         &self,
         request: acp_schema::PromptRequest,
@@ -186,6 +221,7 @@ impl InProcessClient {
             .await
     }
 
+    /// Requests cancellation of the session operation named by the notification.
     pub async fn cancel(
         &self,
         notification: acp_schema::CancelNotification,
@@ -193,6 +229,7 @@ impl InProcessClient {
         self.connection.handle_cancel(notification).await
     }
 
+    /// Closes a session through the unstable ACP `closeSession` method.
     pub async fn close_session(
         &self,
         request: acp_schema::CloseSessionRequest,
@@ -201,7 +238,12 @@ impl InProcessClient {
     }
 }
 
-/// Create an in-process ACP transport and its IO driver future.
+/// Creates an in-process ACP transport and its IO driver future.
+///
+/// The handler mediates agent-to-client notifications and permission
+/// requests. The returned driver currently performs no work and completes
+/// immediately; callers may still spawn or await it to use the same ownership
+/// pattern as stream-backed transports.
 pub fn create_in_process_transport<C>(
     runtime: crate::runtime::IronRuntime,
     client_handler: C,
@@ -229,7 +271,11 @@ impl std::fmt::Debug for InProcessTransport {
     }
 }
 
-/// Create an ACP agent bound to stdio.
+/// Creates an ACP agent intended to be bound to standard input and output.
+///
+/// The connection is created immediately. The returned driver currently
+/// resolves to an ACP internal error because ACP 0.11 requires a `Send`
+/// handler that this adapter does not yet provide.
 pub fn create_stdio_agent(
     runtime: crate::runtime::IronRuntime,
 ) -> (
@@ -245,7 +291,12 @@ pub fn create_stdio_agent(
     (iron_conn, future)
 }
 
-/// Serve ACP connections over TCP at the provided socket address.
+/// Serves ACP connections over TCP at the provided socket address.
+///
+/// # Errors
+///
+/// Currently always returns an ACP internal error because the TCP adapter has
+/// not yet been updated for the ACP 0.11 `Send` handler requirement.
 pub async fn serve_tcp_agent(
     _runtime: crate::runtime::IronRuntime,
     _addr: std::net::SocketAddr,
@@ -254,6 +305,12 @@ pub async fn serve_tcp_agent(
         .data("serve_tcp_agent is not yet adapted to the ACP 0.11 Send handler requirements"))
 }
 
+/// Connects an ACP client to a TCP agent at the provided socket address.
+///
+/// # Errors
+///
+/// Currently always returns an ACP internal error because the client adapter
+/// has not yet been updated for the ACP 0.11 client builder API.
 pub async fn connect_tcp_client(_addr: std::net::SocketAddr) -> acp::Result<()> {
     Err(acp::Error::internal_error()
         .data("connect_tcp_client is not yet adapted to the ACP 0.11 client builder API"))

--- a/tasks.py
+++ b/tasks.py
@@ -120,7 +120,7 @@ def docs(ctx):
             ),
             (
                 "cargo test --doc",
-                f"cargo test --manifest-path {MANIFEST_PATH} --doc",
+                f"cargo test --manifest-path {MANIFEST_PATH} --doc --all-features",
             ),
         ],
     )

--- a/tasks.py
+++ b/tasks.py
@@ -108,6 +108,25 @@ def test(ctx):
 
 
 @task
+def docs(ctx):
+    """Run strict documentation checks with a terse summary."""
+    _run_group(
+        ctx,
+        "Docs",
+        [
+            (
+                "cargo doc",
+                f'RUSTDOCFLAGS="-D warnings -D missing-docs" cargo doc --manifest-path {MANIFEST_PATH} --no-deps --all-features',
+            ),
+            (
+                "cargo test --doc",
+                f"cargo test --manifest-path {MANIFEST_PATH} --doc",
+            ),
+        ],
+    )
+
+
+@task
 def security(ctx):
     """Run security checks with a terse summary."""
     results = []
@@ -132,4 +151,5 @@ def security(ctx):
 ns = Collection()
 ns.add_task(build)
 ns.add_task(test)
+ns.add_task(docs)
 ns.add_task(security)

--- a/tests/config_store_tests.rs
+++ b/tests/config_store_tests.rs
@@ -1520,7 +1520,7 @@ fn create_test_handoff_bundle(id: &str) -> iron_core::context::handoff::HandoffB
         model_switch_history: vec![],
         current_model: Some("gpt-4o".to_string()),
         current_provider_slug: Some("openai".to_string()),
-        current_provider_api_key: Some("sk-test-key".to_string()),
+        current_provider_api_key: Some(iron_core::SecretString::new("sk-test-key".to_string())),
         profile_identity: None,
         hidden_tools: vec![],
         profile_id: None,
@@ -1553,8 +1553,12 @@ async fn test_saved_handoff_roundtrip() {
     assert_eq!(loaded.metadata.name, "Test Handoff 1");
     assert_eq!(loaded.bundle, bundle);
     assert_eq!(
-        loaded.bundle.current_provider_api_key,
-        Some("sk-test-key".to_string())
+        loaded
+            .bundle
+            .current_provider_api_key
+            .as_ref()
+            .map(|k| k.reveal()),
+        Some("sk-test-key")
     );
 }
 


### PR DESCRIPTION
## Summary

- document every currently public Rust API item and add 28 compiling doctests
- audit and update README installation, API, release, and documentation guidance
- add `inv docs`, pull request validation, and least-privilege GitHub Pages deployment
- add the `add-automated-documentation` OpenSpec change and track post-merge Pages verification

## Issue

Closes #84

## Testing

- [x] `cargo build --manifest-path Cargo.toml --all-targets`
- [x] `cargo fmt --manifest-path Cargo.toml -- --check`
- [x] `cargo clippy --manifest-path Cargo.toml --all-targets --all-features -- -D warnings`
- [x] `cargo test --manifest-path Cargo.toml`
- [x] `cargo audit --file Cargo.lock`
- [x] `inv docs`
- [x] `bash .github/scripts/check-package-consumer.sh`
- [x] `openspec validate add-automated-documentation --strict`

## Follow-up

After merge, verify the Pages workflow and `core.agentiron.ai`, then complete OpenSpec task 6.6.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rust API documentation is now automatically published to GitHub Pages (with strict rustdoc validation).
  * Added public helpers/types such as `SecretString` and improved durable/session and tooling/reporting fields (e.g., additional token and pressure/diagnostics data).

* **Documentation**
  * Refreshed README structure (install, quick start, capabilities, development, and documentation links).
  * Expanded API docs across tools, prompts, context, configuration, runtime, and embedded-Python.

* **Quality Improvements**
  * Pull requests now run an `inv docs` check that fails on warnings/missing docs and executes README Rust doctests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->