### PR TITLE
fix: emit valid Task Scheduler schedule bodies for daily crons

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -101,7 +101,14 @@ jobs:
       - name: Build and link all targets
         run: cargo build --locked --manifest-path Cargo.toml --all-targets --all-features
 
-      - name: Test native scheduler adapter
+      - name: Test native scheduler adapter (Windows)
+        if: matrix.os == 'windows-latest'
+        run: cargo test --locked --manifest-path Cargo.toml --lib scheduled_task::platform
+        env:
+          AGENTIRON_RUN_NATIVE_SCHEDULER_TESTS: "1"
+
+      - name: Test native scheduler adapter (macOS)
+        if: matrix.os == 'macos-latest'
         run: cargo test --locked --manifest-path Cargo.toml --lib scheduled_task::platform
 
   package-consumer:

--- a/openspec/changes/fix-task-scheduler-daily-trigger/.openspec.yaml
+++ b/openspec/changes/fix-task-scheduler-daily-trigger/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-17

--- a/openspec/changes/fix-task-scheduler-daily-trigger/design.md
+++ b/openspec/changes/fix-task-scheduler-daily-trigger/design.md
@@ -1,0 +1,59 @@
+## Context
+
+`render_task_xml` maps each expanded `(hour, minute)` pair to a Task Scheduler `CalendarTrigger`. Day-of-month restrictions use `ScheduleByMonth`, day-of-week restrictions use `ScheduleByWeek`, and combined restrictions use both triggers to preserve cron OR semantics. When neither day field is restricted, the renderer currently supplies no schedule body, but the Task Scheduler schema requires every `CalendarTrigger` to contain one schedule element.
+
+The unrestricted-day path has two forms. A cron with unrestricted months is a true daily schedule. A cron with restricted months must still run every valid day in only those months. `ScheduleByDay` represents the former but cannot carry a month filter; `ScheduleByMonth` represents the latter when populated with every day-of-month and the selected months.
+
+The renderer has a separate pre-existing problem for month-qualified weekday expressions: `ScheduleByWeek` does not permit a `Months` child in the Task Scheduler schema. Correctly representing that case requires `ScheduleByMonthDayOfWeek` or a typed unsupported-schedule result. That case is related to native XML validity but is not required to resolve issue #104's unrestricted-day failure.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Emit a schema-valid schedule body for every `CalendarTrigger` generated when both cron day fields are unrestricted.
+- Preserve the occurrence set for unrestricted daily and month-restricted daily crons.
+- Catch both semantic rendering regressions and XML rejected by the native Windows parser.
+
+**Non-Goals:**
+
+- Change the supported cron grammar or trigger expansion limit.
+- Change day-of-month/day-of-week OR semantics.
+- Change task ownership, invocation, persistence, or reconciliation behavior.
+- Introduce an XML schema dependency on non-Windows platforms.
+- Repair or redesign month-qualified weekday schedules.
+- Clean up temporary XML files created by the production installation path.
+
+## Decisions
+
+### Use `ScheduleByDay` for unrestricted daily schedules
+
+When day-of-month, day-of-week, and month are all unrestricted, render `ScheduleByDay` with `DaysInterval` set to `1`. This is the direct Task Scheduler representation of a daily cron and supplies the schedule element required by the schema.
+
+The alternative of enumerating all days and months in `ScheduleByMonth` is more verbose and obscures the schedule's daily intent.
+
+### Use `ScheduleByMonth` for month-restricted daily schedules
+
+When both day fields are unrestricted but months are restricted, render `ScheduleByMonth` with days `1` through `31` and the selected months. Task Scheduler naturally skips nonexistent calendar dates, so this produces every real day in each selected month without occurrences in other months.
+
+Using `ScheduleByDay` would drop the cron month constraint. Splitting the cron into many triggers would increase XML size without improving fidelity.
+
+### Test structure and native acceptance separately
+
+Unit tests will parse and expand the exact cron expressions `0 3 * * *` and `0 3 * 6 *` before rendering, then assert the resulting schedule-body shape. Starting from `CronExpression` avoids relying on manually constructed empty vectors that do not match production wildcard expansion.
+
+A Windows-only native integration test will be inert unless `AGENTIRON_RUN_NATIVE_SCHEDULER_TESTS=1` enables scheduler mutation. The Windows CI job will set that variable and run the test. The test will write the same UTF-16LE representation used by production, register a disabled task with a collision-resistant name in the Task Scheduler root, and delete both the registered task and temporary XML before reporting success. Using the root isolates XML acceptance from the separate question of whether the AgentIron task folder exists on a fresh machine.
+
+Native registration is preferred over adding an XML schema validator because `schtasks.exe` is the actual compatibility boundary and is already available in the Windows CI job. Registration proves that Windows accepts the XML and its encoding; deterministic structural tests remain responsible for schedule fidelity. Cleanup failure is a test failure, while cleanup is still attempted after registration or assertion failure.
+
+## Risks / Trade-offs
+
+- [Task cleanup can be interrupted by runner termination] -> Use a collision-resistant test prefix, register the task disabled, use a cleanup guard during normal return and unwinding, and make cleanup failure visible when it can be reported.
+- [Native tests mutate the host scheduler] -> Gate the test behind an explicit environment variable set only by the Windows CI job or an intentional developer invocation.
+- [Native tests can expose Windows environment variance] -> Register in the Task Scheduler root, keep deterministic unit tests as the semantic coverage, and limit native verification to XML registration and deletion.
+- [Enumerating day 31 for short months appears broader than real dates] -> Task Scheduler cannot fire on nonexistent dates, so the resulting occurrence set remains faithful to cron wildcard day semantics.
+
+## Migration Plan
+
+No stored data migration is required. Desired schedules that previously failed installation remain in ConfigStore. After upgrading, callers must explicitly reconcile those schedules to install the corrected native task; read-only inspection will continue to report them as degraded until reconciliation succeeds.
+
+Rollback requires no data conversion. A rollback can leave a reconciled daily task installed, but a later reconciliation through the older renderer may fail to replace it with invalid XML.

--- a/openspec/changes/fix-task-scheduler-daily-trigger/design.md
+++ b/openspec/changes/fix-task-scheduler-daily-trigger/design.md
@@ -6,6 +6,8 @@ The unrestricted-day path has two forms. A cron with unrestricted months is a tr
 
 The renderer has a separate pre-existing problem for month-qualified weekday expressions: `ScheduleByWeek` does not permit a `Months` child in the Task Scheduler schema. Correctly representing that case requires `ScheduleByMonthDayOfWeek` or a typed unsupported-schedule result. That case is related to native XML validity but is not required to resolve issue #104's unrestricted-day failure.
 
+The first native probe run also exposed invalid `Settings` children: `AllowStartIfOnBatteries` and `DontStopIfGoingOnBatteries` are not `settingsType` elements, so every generated document was rejected even after the trigger fix. The schema-valid equivalents are `DisallowStartIfOnBatteries` and `StopIfGoingOnBatteries` (both emitted as `false` to preserve the intended battery behavior), in documented schema order. This correction is in scope because the modified requirement states that Task Scheduler accepts the generated XML.
+
 ## Goals / Non-Goals
 
 **Goals:**

--- a/openspec/changes/fix-task-scheduler-daily-trigger/proposal.md
+++ b/openspec/changes/fix-task-scheduler-daily-trigger/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+The Windows Task Scheduler adapter emits a `CalendarTrigger` without a required schedule element for unrestricted daily crons such as `0 3 * * *`, causing `schtasks.exe` to reject the task. Issue [#104](https://github.com/AgentIron/iron-core/issues/104) also identifies the same invalid path for month-restricted schedules whose day fields are unrestricted.
+
+## What Changes
+
+- Generate schema-valid Task Scheduler calendar triggers for unrestricted daily schedules.
+- Preserve month restrictions when both day-of-month and day-of-week are unrestricted, without adding or omitting cron occurrences.
+- Add parse-to-render regression tests for plain daily and month-restricted daily cron expressions.
+- Add explicitly gated Windows-native verification that temporarily registers disabled generated XML with `schtasks.exe` and strictly cleans up the disposable task and XML file.
+- Leave month-qualified weekday schedules and production temporary-file cleanup to follow-up changes.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `scheduled-automation-tasks`: Clarify the valid Task Scheduler schedule elements and faithful month handling required when both cron day fields are unrestricted.
+
+## Impact
+
+- Affected code: `src/scheduled_task/platform/task_scheduler.rs` and its tests.
+- Affected system: Windows Task Scheduler registration through `schtasks.exe`.
+- CI: Windows coverage for native Task Scheduler XML acceptance.
+- APIs and persisted data: no public API, schema, or desired-state changes.
+- Operations: previously degraded desired schedules require explicit reconciliation after upgrading; inspection remains read-only.

--- a/openspec/changes/fix-task-scheduler-daily-trigger/specs/scheduled-automation-tasks/spec.md
+++ b/openspec/changes/fix-task-scheduler-daily-trigger/specs/scheduled-automation-tasks/spec.md
@@ -1,0 +1,33 @@
+## MODIFIED Requirements
+
+### Requirement: Windows scheduling SHALL use owned Task Scheduler XML definitions
+The Windows adapter SHALL manage tasks under `\AgentIron\Tasks\<id>`, generate Task Scheduler XML with one or more triggers as needed, and use `schtasks.exe` for lifecycle operations. When both cron day fields are unrestricted, every generated `CalendarTrigger` SHALL contain exactly one valid Task Scheduler schedule element and SHALL preserve any cron month restriction without adding or omitting occurrences. The adapter SHALL NOT mutate tasks outside the AgentIron task folder during application lifecycle operations.
+
+#### Scenario: Windows task is installed
+- **WHEN** a schedule can be compiled faithfully for Task Scheduler
+- **THEN** reconciliation registers generated XML under the owned task path
+- **AND** the action contains only the core-generated task invocation
+
+#### Scenario: Unrestricted daily schedule is installed
+- **WHEN** the Windows adapter compiles `0 3 * * *`
+- **THEN** each generated calendar trigger contains a daily schedule element with a one-day interval
+- **AND** Task Scheduler accepts the generated XML
+
+#### Scenario: Month-restricted daily schedule is installed
+- **WHEN** the Windows adapter compiles `0 3 * 6 *`
+- **THEN** each generated calendar trigger contains a monthly schedule element covering every possible day in only the selected months
+- **AND** Task Scheduler accepts the generated XML without introducing occurrences outside the selected months
+
+#### Scenario: Failed daily installation is retried after upgrade
+- **WHEN** a desired daily schedule remains degraded after an earlier installation failure
+- **AND** a caller explicitly reconciles it using the corrected Windows adapter
+- **THEN** the adapter retries registration using valid generated XML
+- **AND** read-only inspection alone does not install or replace the task
+
+#### Scenario: Windows task is disabled
+- **WHEN** desired state is disabled
+- **THEN** the owned task remains registered in disabled state
+
+#### Scenario: Unowned Windows task exists
+- **WHEN** another task exists outside `\AgentIron\Tasks\`
+- **THEN** AgentIron listing, reconciliation, and removal leave it unchanged

--- a/openspec/changes/fix-task-scheduler-daily-trigger/tasks.md
+++ b/openspec/changes/fix-task-scheduler-daily-trigger/tasks.md
@@ -3,6 +3,7 @@
 - [x] 1.1 Add a `ScheduleByDay` renderer and use a one-day interval for triggers whose day and month fields are unrestricted
 - [x] 1.2 Render month-restricted daily triggers as `ScheduleByMonth` with days 1 through 31 and only the selected months
 - [x] 1.3 Ensure both unrestricted-day construction paths supply exactly one non-empty schedule body without changing weekday-restricted rendering
+- [x] 1.4 Replace non-schema `Settings` elements (`AllowStartIfOnBatteries`, `DontStopIfGoingOnBatteries`) with schema-valid equivalents (`DisallowStartIfOnBatteries`, `StopIfGoingOnBatteries`) in documented order
 
 ## 2. Regression Coverage
 

--- a/openspec/changes/fix-task-scheduler-daily-trigger/tasks.md
+++ b/openspec/changes/fix-task-scheduler-daily-trigger/tasks.md
@@ -1,0 +1,19 @@
+## 1. Task Scheduler Rendering
+
+- [x] 1.1 Add a `ScheduleByDay` renderer and use a one-day interval for triggers whose day and month fields are unrestricted
+- [x] 1.2 Render month-restricted daily triggers as `ScheduleByMonth` with days 1 through 31 and only the selected months
+- [x] 1.3 Ensure both unrestricted-day construction paths supply exactly one non-empty schedule body without changing weekday-restricted rendering
+
+## 2. Regression Coverage
+
+- [x] 2.1 Add a parse-to-render test for `0 3 * * *` that requires `ScheduleByDay` with `DaysInterval` 1
+- [x] 2.2 Add a parse-to-render test for `0 3 * 6 *` that verifies days 1 through 31 and only June are represented by `ScheduleByMonth`
+- [x] 2.3 Add a Windows-native test gated by `AGENTIRON_RUN_NATIVE_SCHEDULER_TESTS=1` that registers generated XML as a uniquely named disabled root task and uses a cleanup guard for the task and temporary XML
+- [x] 2.4 Make native-test registration or cleanup failures fail with enough command output to diagnose the failed phase
+
+## 3. Verification
+
+- [x] 3.1 Run formatting and the Task Scheduler adapter unit tests
+- [x] 3.2 Run clippy with all targets and features, treating warnings as errors
+- [x] 3.3 Update the Windows CI scheduler-adapter job to set `AGENTIRON_RUN_NATIVE_SCHEDULER_TESTS=1` and execute the native registration test while ordinary local test runs remain inert
+- [ ] 3.4 Confirm Windows CI passes both exact-cron structural tests and native XML registration with no disposable task or XML left behind

--- a/openspec/changes/fix-task-scheduler-daily-trigger/tasks.md
+++ b/openspec/changes/fix-task-scheduler-daily-trigger/tasks.md
@@ -17,4 +17,4 @@
 - [x] 3.1 Run formatting and the Task Scheduler adapter unit tests
 - [x] 3.2 Run clippy with all targets and features, treating warnings as errors
 - [x] 3.3 Update the Windows CI scheduler-adapter job to set `AGENTIRON_RUN_NATIVE_SCHEDULER_TESTS=1` and execute the native registration test while ordinary local test runs remain inert
-- [ ] 3.4 Confirm Windows CI passes both exact-cron structural tests and native XML registration with no disposable task or XML left behind
+- [x] 3.4 Confirm Windows CI passes both exact-cron structural tests and native XML registration with no disposable task or XML left behind

--- a/src/scheduled_task/platform/task_scheduler.rs
+++ b/src/scheduled_task/platform/task_scheduler.rs
@@ -89,7 +89,10 @@ pub fn expand_cron(cron: &CronExpression) -> Result<TaskTrigger, String> {
 /// a `<StartBoundary>` encoding the time of day. Day-of-week restrictions are
 /// emitted as `<ScheduleByWeek>`, day-of-month restrictions as
 /// `<ScheduleByMonth>`. When cron restricts **both** DOM and DOW (OR
-/// semantics), two independent triggers are emitted.
+/// semantics), two independent triggers are emitted. When neither day field
+/// is restricted, an unrestricted month field renders as `<ScheduleByDay>`
+/// and a month restriction renders as `<ScheduleByMonth>` covering every day
+/// of the selected months.
 pub fn render_task_xml(
     trigger: &TaskTrigger,
     executable: &str,
@@ -129,10 +132,16 @@ pub fn render_task_xml(
                 );
                 xml.push_str(&render_calendar_trigger(&boundary, &body));
             }
-            // No day-of-week or day-of-month restriction: a plain daily
-            // trigger that fires at the given StartBoundary.
+            // No day-of-week or day-of-month restriction: a daily trigger,
+            // optionally constrained to a set of months.
             if !dom_restricted && !dow_restricted {
-                xml.push_str(&render_calendar_trigger(&boundary, ""));
+                let body = if months_restricted {
+                    let all_days: Vec<u32> = (1..=31).collect();
+                    render_schedule_by_month(&all_days, true, &trigger.months)
+                } else {
+                    render_schedule_by_day()
+                };
+                xml.push_str(&render_calendar_trigger(&boundary, &body));
             }
         }
     }
@@ -170,7 +179,7 @@ pub fn render_task_xml(
 }
 
 /// Render a single `<CalendarTrigger>` with the given start boundary and
-/// optional schedule body.
+/// schedule body.
 fn render_calendar_trigger(boundary: &str, schedule_body: &str) -> String {
     let mut s = String::new();
     s.push_str("    <CalendarTrigger>\n");
@@ -178,10 +187,20 @@ fn render_calendar_trigger(boundary: &str, schedule_body: &str) -> String {
         "      <StartBoundary>{}</StartBoundary>\n",
         boundary
     ));
+    debug_assert!(!schedule_body.is_empty());
     if !schedule_body.is_empty() {
         s.push_str(schedule_body);
     }
     s.push_str("    </CalendarTrigger>\n");
+    s
+}
+
+/// Render a `<ScheduleByDay>` body with a one-day interval.
+fn render_schedule_by_day() -> String {
+    let mut s = String::new();
+    s.push_str("      <ScheduleByDay>\n");
+    s.push_str("        <DaysInterval>1</DaysInterval>\n");
+    s.push_str("      </ScheduleByDay>\n");
     s
 }
 
@@ -526,12 +545,43 @@ mod tests {
         assert!(xml.contains("<Task"));
         assert!(xml.contains("<CalendarTrigger>"));
         assert!(xml.contains("<StartBoundary>2024-01-01T09:00:00</StartBoundary>"));
-        // No day restriction: neither schedule element should be emitted.
+        // No day restriction: daily schedule body, not monthly or weekly.
+        assert!(xml.contains("<ScheduleByDay>"));
         assert!(!xml.contains("<ScheduleByMonth>"));
         assert!(!xml.contains("<ScheduleByWeek>"));
         assert!(xml.contains("<Enabled>true</Enabled>"));
         assert!(xml.contains(r"C:\agent-iron.exe"));
         assert!(xml.contains("run task-1"));
+    }
+
+    #[test]
+    fn render_xml_daily_includes_schedule_by_day() {
+        let cron = CronExpression::parse("0 3 * * *").unwrap();
+        let trigger = expand_cron(&cron).unwrap();
+        let xml = render_task_xml(&trigger, "agent-iron.exe", "run t1", true);
+        assert!(xml.contains("<StartBoundary>2024-01-01T03:00:00</StartBoundary>"));
+        assert!(xml.contains("<ScheduleByDay>"));
+        assert!(xml.contains("<DaysInterval>1</DaysInterval>"));
+        assert!(!xml.contains("<ScheduleByMonth>"));
+        assert!(!xml.contains("<ScheduleByWeek>"));
+    }
+
+    #[test]
+    fn render_xml_month_restricted_daily_uses_schedule_by_month() {
+        let cron = CronExpression::parse("0 3 * 6 *").unwrap();
+        let trigger = expand_cron(&cron).unwrap();
+        let xml = render_task_xml(&trigger, "agent-iron.exe", "run t1", true);
+        assert!(xml.contains("<ScheduleByMonth>"));
+        for day in 1..=31 {
+            assert!(
+                xml.contains(&format!("<Day>{day}</Day>")),
+                "missing day {day}"
+            );
+        }
+        assert!(xml.contains("<June/>"));
+        assert!(!xml.contains("<July/>"));
+        assert!(!xml.contains("<ScheduleByDay>"));
+        assert!(!xml.contains("<ScheduleByWeek>"));
     }
 
     #[test]
@@ -639,5 +689,101 @@ mod tests {
     #[test]
     fn task_path_format() {
         assert_eq!(task_path("s1"), r"\AgentIron\Tasks\s1");
+    }
+
+    /// Deletes a disposable root task and its temporary XML file. Cleanup
+    /// failures are fatal unless the test is already unwinding, in which case
+    /// they are reported on stderr.
+    struct NativeProbeCleanup {
+        task_name: String,
+        xml_path: std::path::PathBuf,
+        registered: bool,
+    }
+
+    impl Drop for NativeProbeCleanup {
+        fn drop(&mut self) {
+            let mut failures = Vec::new();
+            if self.registered {
+                match std::process::Command::new("schtasks.exe")
+                    .args(["/Delete", "/TN", &self.task_name, "/F"])
+                    .output()
+                {
+                    Ok(out) if out.status.success() => {}
+                    Ok(out) => failures.push(format!(
+                        "schtasks /Delete exited with {}: {}",
+                        out.status,
+                        String::from_utf8_lossy(&out.stderr)
+                    )),
+                    Err(e) => failures.push(format!("failed to run schtasks /Delete: {e}")),
+                }
+            }
+            if let Err(e) = std::fs::remove_file(&self.xml_path) {
+                if e.kind() != std::io::ErrorKind::NotFound {
+                    failures.push(format!("failed to remove {}: {e}", self.xml_path.display()));
+                }
+            }
+            if !failures.is_empty() {
+                let msg = format!("native probe cleanup failed: {}", failures.join("; "));
+                if std::thread::panicking() {
+                    eprintln!("{msg}");
+                } else {
+                    panic!("{msg}");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn native_schtasks_accepts_generated_daily_xml() {
+        if std::env::var("AGENTIRON_RUN_NATIVE_SCHEDULER_TESTS").as_deref() != Ok("1") {
+            eprintln!(
+                "skipping native schtasks probe; set AGENTIRON_RUN_NATIVE_SCHEDULER_TESTS=1 to enable"
+            );
+            return;
+        }
+
+        for cron_text in ["0 3 * * *", "0 3 * 6 *"] {
+            let cron = CronExpression::parse(cron_text).unwrap();
+            let trigger = expand_cron(&cron).unwrap();
+            let xml = render_task_xml(&trigger, "cmd.exe", "/c exit 0", false);
+
+            let unique = format!(
+                "AgentIronXmlProbe-{}-{}",
+                std::process::id(),
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_nanos()
+            );
+            let task_name = format!("\\{unique}");
+            let xml_path = std::env::temp_dir().join(format!("{unique}.xml"));
+
+            // Same UTF-16LE-with-BOM encoding the adapter uses for schtasks.
+            let mut bytes = Vec::with_capacity(xml.len() * 2 + 2);
+            bytes.extend_from_slice(&[0xFF, 0xFE]);
+            for unit in xml.encode_utf16() {
+                bytes.extend_from_slice(&unit.to_le_bytes());
+            }
+            std::fs::write(&xml_path, &bytes).expect("write native probe XML");
+
+            let mut cleanup = NativeProbeCleanup {
+                task_name: task_name.clone(),
+                xml_path: xml_path.clone(),
+                registered: false,
+            };
+
+            let output = std::process::Command::new("schtasks.exe")
+                .args(["/Create", "/TN", &task_name, "/XML"])
+                .arg(&xml_path)
+                .arg("/F")
+                .output()
+                .expect("run schtasks /Create");
+            assert!(
+                output.status.success(),
+                "schtasks /Create rejected generated XML for `{cron_text}`: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            cleanup.registered = true;
+        }
     }
 }

--- a/src/scheduled_task/platform/task_scheduler.rs
+++ b/src/scheduled_task/platform/task_scheduler.rs
@@ -579,8 +579,27 @@ mod tests {
                 "missing day {day}"
             );
         }
-        assert!(xml.contains("<June/>"));
-        assert!(!xml.contains("<July/>"));
+        for month in [
+            "January",
+            "February",
+            "March",
+            "April",
+            "May",
+            "June",
+            "July",
+            "August",
+            "September",
+            "October",
+            "November",
+            "December",
+        ] {
+            let expected = if month == "June" { 1 } else { 0 };
+            assert_eq!(
+                xml.matches(&format!("<{month}/>")).count(),
+                expected,
+                "unexpected rendered month: {month}"
+            );
+        }
         assert!(!xml.contains("<ScheduleByDay>"));
         assert!(!xml.contains("<ScheduleByWeek>"));
     }

--- a/src/scheduled_task/platform/task_scheduler.rs
+++ b/src/scheduled_task/platform/task_scheduler.rs
@@ -148,16 +148,17 @@ pub fn render_task_xml(
 
     xml.push_str("  </Triggers>\n");
 
-    // Settings
+    // Settings (element names and order per the Task Scheduler schema;
+    // defaults are overridden so tasks run on battery power).
     xml.push_str("  <Settings>\n");
+    xml.push_str("    <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>\n");
     if enabled {
         xml.push_str("    <Enabled>true</Enabled>\n");
     } else {
         xml.push_str("    <Enabled>false</Enabled>\n");
     }
-    xml.push_str("    <AllowStartIfOnBatteries>true</AllowStartIfOnBatteries>\n");
-    xml.push_str("    <DontStopIfGoingOnBatteries>true</DontStopIfGoingOnBatteries>\n");
     xml.push_str("    <ExecutionTimeLimit>PT24H</ExecutionTimeLimit>\n");
+    xml.push_str("    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>\n");
     xml.push_str("  </Settings>\n");
 
     // Actions


### PR DESCRIPTION
## Summary

Fixes #104. The Windows Task Scheduler adapter emitted a `CalendarTrigger` containing only a `StartBoundary` for unrestricted daily crons (`0 3 * * *`), which `schtasks.exe` rejects because every calendar trigger must contain exactly one schedule element.

- Unrestricted daily crons now render `ScheduleByDay` with `DaysInterval` = 1
- Month-restricted daily crons (`0 3 * 6 *`) render `ScheduleByMonth` over days 1–31 in only the selected months
- Weekday-restricted rendering is unchanged

## Tests

- Parse-to-render regression tests for `0 3 * * *` and `0 3 * 6 *`
- Windows-native `schtasks /Create` acceptance probe, gated behind `AGENTIRON_RUN_NATIVE_SCHEDULER_TESTS=1` and enabled in the `Link (windows-latest)` CI job; ordinary local test runs remain inert. The probe registers a uniquely named **disabled** root task and cleans up task + temp XML via a guard.

## Out of scope (follow-ups)

- Month-qualified weekday crons (invalid `Months` child inside `ScheduleByWeek`; needs `ScheduleByMonthDayOfWeek` or typed unsupported-schedule error)
- Temp XML cleanup in the production install path

## Notes

Existing degraded daily schedules remain in ConfigStore and install on the next explicit reconcile; no data migration.

OpenSpec change: `openspec/changes/fix-task-scheduler-daily-trigger/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Windows daily schedule XML generation so unrestricted day-of-month/day-of-week cases produce an accepted trigger.
  * Preserved month restrictions correctly for daily schedules and updated battery-related scheduler settings to schema-valid values.
* **Tests**
  * Expanded unit tests for unrestricted vs month-restricted daily cron renderings.
  * Strengthened the gated Windows native XML validation with safer automatic cleanup.
  * Updated CI to run native scheduler adapter tests with OS-specific steps and an environment gate.
* **Documentation**
  * Added/updated spec, design, and proposal materials describing the required scheduling and settings behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->